### PR TITLE
using host names in cache keys

### DIFF
--- a/compressor/base.py
+++ b/compressor/base.py
@@ -1,4 +1,5 @@
 import os
+import socket
 from itertools import chain
 
 from django.template.loader import render_to_string
@@ -57,7 +58,8 @@ class Compressor(object):
     def cachekey(self):
         cachestr = "".join(
             chain([self.content], self.mtimes)).encode(self.charset)
-        return "django_compressor.%s" % get_hexdigest(cachestr)[:12]
+        return "django_compressor.%s.%s" % (socket.gethostname(),
+                                            get_hexdigest(cachestr)[:12])
 
     @cached_property
     def storage(self):

--- a/compressor/cache.py
+++ b/compressor/cache.py
@@ -1,4 +1,5 @@
 import os
+import socket
 
 from django.core.cache import get_cache
 from django.utils.encoding import smart_str
@@ -10,11 +11,13 @@ def get_hexdigest(plaintext):
     return sha_constructor(plaintext).hexdigest()
 
 def get_mtime_cachekey(filename):
-    return "django_compressor.mtime.%s" % get_hexdigest(filename)
+    return "django_compressor.mtime.%s.%s" % (socket.gethostname(),
+                                              get_hexdigest(filename))
 
 def get_offline_cachekey(source):
-    return ("django_compressor.offline.%s" %
-            get_hexdigest("".join(smart_str(s) for s in source)))
+    return ("django_compressor.offline.%s.%s" %
+            (socket.gethostname(),
+             get_hexdigest("".join(smart_str(s) for s in source))))
 
 def get_mtime(filename):
     if settings.COMPRESS_MTIME_DELAY:

--- a/compressor/tests/tests.py
+++ b/compressor/tests/tests.py
@@ -1,5 +1,6 @@
 import os
 import re
+import socket
 from BeautifulSoup import BeautifulSoup
 
 try:
@@ -65,8 +66,9 @@ class CompressorTestCase(TestCase):
         self.assertEqual(self.css, self.css_node.output())
 
     def test_cachekey(self):
-        is_cachekey = re.compile(r'django_compressor\.\w{12}')
-        self.assert_(is_cachekey.match(self.css_node.cachekey), "cachekey is returning something that doesn't look like r'django_compressor\.\w{12}'")
+        host_name = socket.gethostname()
+        is_cachekey = re.compile(r'django_compressor\.%s\.\w{12}' % host_name)
+        self.assert_(is_cachekey.match(self.css_node.cachekey), "cachekey is returning something that doesn't look like r'django_compressor\.%s\.\w{12}'" % host_name)
 
     def test_css_hash(self):
         self.assertEqual('f7c661b7a124', self.css_node.hash)


### PR DESCRIPTION
Hi Jannis,

We had a minor issue with django_compressor when using it on Bitbucket:

If you run multiple frontends that would totally confuse django_compressor as it would think compressed file is on file system although it's only been written to one of them. Adding host names to cache keys will eliminate the problem.

Cheers

Mehmet
