### PR TITLE
Precompilers Support

### DIFF
--- a/compressor/settings.py
+++ b/compressor/settings.py
@@ -22,6 +22,7 @@ class CompressorSettings(AppSettings):
     URL = None
     ROOT = None
 
+    PRECOMPILERS = {}
     CSS_FILTERS = ['compressor.filters.css_default.CssAbsoluteFilter']
     JS_FILTERS = ['compressor.filters.jsmin.JSMinFilter']
 


### PR DESCRIPTION
Hi.
I like your project very much, but as to me it misses exactly 1 feature implemented in its fork - [django-css] -- flexible precompilers support for different fie/content types.

For example, I like sass, and have main.sass for the whole site. I do also have jquery-ui style file (which of course is pure css). Suporting this setup is impossible (or am I missing something?)

So I did a small change allowing the user specifying the new setting - COMPRESS_PRECOMPILERS, which defines command-line tools to be used on files / hunks prior to filtering.

Here's a sample config:

```
COMPRESS_PRECOMPILERS = [
 {
  'extension': 'coffee',
  'dest_extension': 'js',
  'type': 'coffeescript',
  'command': 'coffee -o {dest_dir} -c {source}',
 },
 {
  'extension': 'sass',
  'dest_extension': 'css',
  'type': 'sass',
  'command': 'sass {source} {dest}',
 },
]
```

it converts any `*.coffee` file or any `script type="text/coffeescript"` / `script type="coffeescript"` to JS before passing it to filters. Same for Sass stylesheets.

Here's a page sample that's working for me

```
{% load compress %}  
{% compress css %}
<link type="text/css" rel="stylesheet" href="{{ STATIC_URL }}sass/main.sass">
{% endcompress %}
{% compress js %}
<script src="{{ STATIC_URL }}js/jquery-1.4.4.min.js"></script>
<script src="{{ STATIC_URL }}coffee/main.coffee"></script>
<script type="text/coffeescript">
  $ ->
    $('body div').append '<span style="color:red">888</span>'
</script>
{% endcompress %}
```
