### PR TITLE
Make it abundantly clear that in order to debug compression COMPRESS needs to be enabled

### DIFF
--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -13,7 +13,8 @@ COMPRESS
 
 :Default: the opposite of ``DEBUG``
 
-Boolean that decides if compression will happen.
+Boolean that decides if compression will happen. In order to test compression
+when ``DEBUG`` is enabled COMPRESS needs to explicitly be set to ``True``.
 
 .. _compress_url:
 

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -47,12 +47,14 @@ Which would be rendered something like:
     <script type="text/javascript" src="/static/CACHE/js/3f33b9146e12.js" charset="utf-8"></script>
 
 Linked files **must** be accesible via :ref:`COMPRESS_URL <compress_url>`.
-If DEBUG is ``True``, off-site files will throw exceptions. If DEBUG is
-``False`` they will be silently stripped.
 
 If the :ref:`COMPRESS <compress>` setting is ``False`` (defaults to the
-opposite of DEBUG) the ``compress`` template tag simply returns exactly
-what it was given, to ease development.
+opposite of DEBUG) the ``compress`` template tag does nothing and simply returns
+exactly what it was given.
+
+If both DEBUG and :ref:`COMPRESS <compress>` are set to ``True``, uncompressable
+files (off-site or non existent) will throw and exception. If DEBUG is ``False``
+these files will be silently stripped.
 
 .. warning::
 


### PR DESCRIPTION
Tweaked documentation about COMPRESS wrt. DEBUG. Made it much clearer that in order to get Exceptions when DEBUG is True, COMPRESS needs to be enabled explicitly.

I was really confused about this for such a long time. Might be my reading comprehension, anyway, this should make it more understandable...
