### PR TITLE
Fixed "compress" command for cached template loaders

### DIFF
--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -10,6 +10,7 @@ except ImportError:
 
 from django.core.management.base import  NoArgsCommand, CommandError
 from django.template import Context, Template, TemplateDoesNotExist, TemplateSyntaxError
+from django.template.loaders.cached import Loader as CachedLoader
 from django.utils.datastructures import SortedDict
 from django.utils.importlib import import_module
 
@@ -51,7 +52,23 @@ class Command(NoArgsCommand):
             except TemplateDoesNotExist:
                 pass
             from django.template.loader import template_source_loaders
-        return template_source_loaders or []
+        loaders = []
+        # If template loader is CachedTemplateLoader, return the loaders
+        # that it wraps around. So if we have 
+        # TEMPLATE_LOADERS = (
+        #    ('django.template.loaders.cached.Loader', (
+        #        'django.template.loaders.filesystem.Loader',
+        #        'django.template.loaders.app_directories.Loader',
+        #    )),
+        # )
+        # The loaders will return django.template.loaders.filesystem.Loader
+        # and django.template.loaders.app_directories.Loader
+        for loader in template_source_loaders:
+            if isinstance(loader, CachedLoader):
+                loaders.extend(loader.loaders)
+            else:
+                loaders.append(loader)
+        return loaders
 
     def compress(self, log=None, **options):
         """

--- a/compressor/tests/runtests.py
+++ b/compressor/tests/runtests.py
@@ -22,6 +22,12 @@ if not settings.configured:
             os.path.join(TEST_DIR, 'templates'),
         ),
         TEST_DIR = TEST_DIR,
+        TEMPLATE_LOADERS = (
+            ('django.template.loaders.cached.Loader', (
+                'django.template.loaders.filesystem.Loader',
+                'django.template.loaders.app_directories.Loader',
+            )),
+        )
     )
 
 from django.test.simple import run_tests

--- a/compressor/tests/tests.py
+++ b/compressor/tests/tests.py
@@ -24,6 +24,8 @@ except ImportError:
 from django.core.cache.backends import dummy
 from django.core.files.storage import get_storage_class
 from django.template import Template, Context, TemplateSyntaxError
+from django.template.loaders.filesystem import Loader as FileSystemLoader
+from django.template.loaders.app_directories import Loader as AppDirectoriesLoader
 from django.test import TestCase
 
 from compressor import base
@@ -471,6 +473,18 @@ class OfflineGenerationTestCase(TestCase):
             u'<script type="text/javascript" src="/media/CACHE/js/0a2bb9a287c0.js" charset="utf-8"></script>',
         ], result)
         settings.COMPRESS_OFFLINE_CONTEXT = self._old_offline_context
+    
+    def test_get_loaders(self):
+        template_loaders = (
+            ('django.template.loaders.cached.Loader', (
+                'django.template.loaders.filesystem.Loader',
+                'django.template.loaders.app_directories.Loader',
+            )),
+        )
+        self.assertEqual(template_loaders, settings.TEMPLATE_LOADERS)
+        loaders = CompressCommand().get_loaders()
+        self.assertIsInstance(loaders[0], FileSystemLoader)
+        self.assertIsInstance(loaders[1], AppDirectoriesLoader)
 
 
 class CssTidyTestCase(TestCase):


### PR DESCRIPTION
Hi Jannis,

Previously the "compress" management command would fail when using cached template loaders as described in django docs:

TEMPLATE_LOADERS = (
        ('django.template.loaders.cached.Loader', (
            'django.template.loaders.filesystem.Loader',
            'django.template.loaders.app_directories.Loader',
        )),
    )

I fixed the issue, but am not sure how to write tests for it. I tried changing settings.TEMPLATE_LOADERS in setUp but that doesn't seem to do it so I wrote put the setting in runtests.py instead. 

Please have a look at it and let me know if anything needs changing.

Thanks,
Selwin
