### PR TITLE
Let the COMPRESS setting override DEBUG

### DIFF
--- a/compressor/conf.py
+++ b/compressor/conf.py
@@ -61,7 +61,12 @@ class CompressorSettings(AppSettings):
     OFFLINE_CONTEXT = {}
 
     def configure_enabled(self, value):
-        return value or getattr(global_settings, 'COMPRESS', value)
+        global_enabled = getattr(global_settings, 'COMPRESS', None)
+
+        if global_enabled is None:
+            return value
+
+        return global_enabled
 
     def configure_root(self, value):
         if value is None:


### PR DESCRIPTION
This is clearly a design decision and not a bug. However, I'd like to be able to disable compressing even with DEBUG turned off. I'm using a minimal live server for selenium testing and would like to get meaningful Javascript error messages with line numbers, but not having DEBUG enabled.
