### PR TITLE
Include stdout in the exception if no stderr.

### DIFF
--- a/compressor/filters/base.py
+++ b/compressor/filters/base.py
@@ -88,6 +88,8 @@ class CompilerFilter(FilterBase):
                 if not err:
                     err = ('Unable to apply %s (%s)' %
                            (self.__class__.__name__, self.command))
+                    if filtered:
+                        err += '\n%s' % filtered
                 raise FilterError(err)
             if self.verbose:
                 self.logger.debug(err)


### PR DESCRIPTION
Compass sends debug info to stdout so the compass traceback is never shown.
This adds the compass output to the exception value, allowing debugging when
using {% compress %} or offline compilation with the compass filter.
