### PR TITLE
Adds SlimIt JS Filter

### DIFF
--- a/compressor/filters/slimit_filter.py
+++ b/compressor/filters/slimit_filter.py
@@ -1,0 +1,8 @@
+from slimit import minify
+
+from compressor.filters import FilterBase
+
+
+class SlimItFilter(FilterBase):
+    def output(self, **kwargs):
+        return minify(self.content, mangle=True)


### PR DESCRIPTION
Adds a new filter for the JS minifiter [SlimIt](http://www.slimit.org/).

As SlimIt is purely written in Python and can easily be installed via `pip install slimit` it is a nice alternative to all the non-python minifiers. Additionally no further configuration like with the other tools (path to binary file etc) is needed...

According to their own benchmarks Slimit is supposed to perform [quite nice](http://www.slimit.org/#benchmarks).
