### PR TITLE
Replaced the (seemingly) obsolete COMPRESS setting with COMPRESS_ENABLED 

### DIFF
--- a/compressor/conf.py
+++ b/compressor/conf.py
@@ -61,7 +61,7 @@ class CompressorSettings(AppSettings):
     OFFLINE_CONTEXT = {}
 
     def configure_enabled(self, value):
-        return value or getattr(global_settings, 'COMPRESS', value)
+        return value or getattr(global_settings, 'COMPRESS_ENABLED', value)
 
     def configure_root(self, value):
         if value is None:

--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -33,8 +33,8 @@ class Command(NoArgsCommand):
                 'separate multiple extensions with commas, or use -e '
                 'multiple times)'),
         make_option('-f', '--force', default=False, action='store_true',
-            help="Force generation of compressor content even if "
-                "COMPRESS setting is not True.", dest='force'),
+            help="Force the generation of compressed content even if the "
+                "COMPRESS_ENABLED setting is not True.", dest='force'),
         make_option('--follow-links', default=False, action='store_true',
             help="Follow symlinks when traversing the COMPRESS_ROOT "
                 "(which defaults to MEDIA_ROOT). Be aware that using this "
@@ -58,7 +58,7 @@ class Command(NoArgsCommand):
             from django.template.loader import template_source_loaders
         loaders = []
         # If template loader is CachedTemplateLoader, return the loaders
-        # that it wraps around. So if we have 
+        # that it wraps around. So if we have
         # TEMPLATE_LOADERS = (
         #    ('django.template.loaders.cached.Loader', (
         #        'django.template.loaders.filesystem.Loader',
@@ -211,7 +211,7 @@ class Command(NoArgsCommand):
     def handle_noargs(self, **options):
         if not settings.COMPRESS_ENABLED and not options.get("force"):
             raise CommandError(
-                "Compressor is disabled. Set COMPRESS "
+                "Compressor is disabled. Set the COMPRESS_ENABLED "
                 "settting or use --force to override.")
         if not settings.COMPRESS_OFFLINE:
             if not options.get("force"):

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -6,15 +6,16 @@ Settings
 Django Compressor has a number of settings that control its behavior.
 They've been given sensible defaults.
 
-.. _compress:
+.. _compress_enabled:
 
-COMPRESS
-^^^^^^^^
+COMPRESS_ENABLED
+^^^^^^^^^^^^^^^^
 
 :Default: the opposite of ``DEBUG``
 
 Boolean that decides if compression will happen. In order to test compression
-when ``DEBUG`` is enabled COMPRESS needs to explicitly be set to ``True``.
+when ``DEBUG`` is enabled COMPRESS_ENABLED needs to explicitly be set to
+``True``.
 
 .. _compress_url:
 

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -48,13 +48,13 @@ Which would be rendered something like:
 
 Linked files **must** be accessible via :ref:`COMPRESS_URL <compress_url>`.
 
-If the :ref:`COMPRESS <compress>` setting is ``False`` (defaults to the
-opposite of DEBUG) the ``compress`` template tag does nothing and simply returns
-exactly what it was given.
+If the :ref:`COMPRESS_ENABLED <compress_enabled>` setting is ``False``
+(defaults to the opposite of DEBUG) the ``compress`` template tag does nothing
+and simply returns exactly what it was given.
 
-If both DEBUG and :ref:`COMPRESS <compress>` are set to ``True``, incompressible
-files (off-site or non existent) will throw an exception. If DEBUG is ``False``
-these files will be silently stripped.
+If both DEBUG and :ref:`COMPRESS_ENABLED <compress_enabled>` are set to
+``True``, incompressible files (off-site or non existent) will throw an
+exception. If DEBUG is ``False`` these files will be silently stripped.
 
 .. warning::
 


### PR DESCRIPTION
This is a suggested fix for #96. It might be backwards incompatible for people relying on AppSettings, so maybe it's worth mentioning the change in the release notes. I let you decide if this is all worth it ;-)
