### PR TITLE
to avoid error of not finding settings.py

### DIFF
--- a/compressor/templatetags/compress.py
+++ b/compressor/templatetags/compress.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ImproperlyConfigured
 from compressor.cache import (cache, cache_get, cache_set,
                               get_offline_cachekey, get_templatetag_cachekey)
 from compressor.utils import get_class
+from compressor.models import CompressorConf
 
 register = template.Library()
 


### PR DESCRIPTION
in various cases, where using custom name of settings, in deploy the default conf is not found.
