### PR TITLE
Remove some old variables. Overwriting the settings module causes the fol

### DIFF
--- a/compressor/utils/staticfiles.py
+++ b/compressor/utils/staticfiles.py
@@ -7,9 +7,6 @@ from compressor.conf import settings
 INSTALLED = ("staticfiles" in settings.INSTALLED_APPS or
     "django.contrib.staticfiles" in settings.INSTALLED_APPS)
 
-finders = None
-settings = None
-
 if INSTALLED:
     if "django.contrib.staticfiles" in settings.INSTALLED_APPS:
         from django.contrib.staticfiles import finders


### PR DESCRIPTION
Remove some old variables. Overwriting the settings module causes the following lines to break (the None object has no INSTALLED_APPS property).
