### PR TITLE
UncompressableFileError on Windows even if COMPRESS_ENABLED is False

### DIFF
--- a/compressor/base.py
+++ b/compressor/base.py
@@ -66,13 +66,14 @@ class Compressor(object):
         return os.path.join(self.output_dir, self.output_prefix, filename)
 
     def get_filename(self, basename):
-        # first try to find it with staticfiles (in debug mode)
         filename = None
+        # first try finding the file in the root
         if self.storage.exists(basename):
             filename = self.storage.path(basename)
-        # secondly try finding the file in the root
+        # secondly try to find it with staticfiles (in debug mode)
         elif self.finders:
-            filename = self.finders.find(basename)
+            import urllib
+            filename = self.finders.find(urllib.url2pathname(basename))
         if filename:
             return filename
         # or just raise an exception as the last resort


### PR DESCRIPTION
Hello.
I ran into this issue on a Windows development machine after upgrading from 0.9.2 to 1.0.1 on Django 1.3.

It looks like `django.contrib.staticfiles.finders.find` expects a file path in OS-specific format (at least, file system finders do), so on Windows the resource name should be manipulated before calling the function (see `django.contrib.staticfiles.handlers.StaticFilesHandler.file_path`, for instance).

This proposed fix forces the same transformation StaticFilesHandler uses. Unfortunately, I was only able to test it with file system based finders.

I think this error should not occur if COMPRESS_ENABLED is False, but it looks like some compressor-specific processing occurs anyway, because Compressor.output is always calling self.filtered_input, which ultimately calls self.filtered_input and self.get_filename.

I'm not confident enough to suggest a solution for this, and I'm not even sure that step can be skipped if compression is disabled, so I leave it up to you.

Thank you.
