### PR TITLE
Defining requires_model_validation as False on compress command, for offline compression

### DIFF
--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -53,6 +53,8 @@ class Command(NoArgsCommand):
                 "directory of itself.", dest='follow_links'),
     )
 
+    requires_model_validation = False
+
     def get_loaders(self):
         from django.template.loader import template_source_loaders
         if template_source_loaders is None:

--- a/tests/tests/offline.py
+++ b/tests/tests/offline.py
@@ -26,6 +26,9 @@ class OfflineGenerationTestCase(TestCase):
         settings.COMPRESS_OFFLINE = self._old_compress_offline
         self.template_file.close()
 
+    def test_requires_model_validation(self):
+        self.assertFalse(CompressCommand.requires_model_validation)
+
     def test_offline(self):
         count, result = CompressCommand().compress()
         self.assertEqual(5, count)


### PR DESCRIPTION
Defining requires_model_validation as False on compress command, for offline compression (see [#127](https://github.com/jezdez/django_compressor/issues/127))
