### PR TITLE
Fix for conflict between collectstatic and compress commands

### DIFF
--- a/docs/remote-storages.txt
+++ b/docs/remote-storages.txt
@@ -68,9 +68,6 @@ integrated.
             self.local_storage._save(name, content)
             return name
 
-        def path(self, name):
-            return self.local_storage.path(name)
-
 #. Set your :ref:`COMPRESS_STORAGE <compress_storage>` and STATICFILES_STORAGE_
    settings to the dotted path of your custom cached storage backend, e.g.
    ``'mysite.storage.CachedS3BotoStorage'``.


### PR DESCRIPTION
Per [my comment](https://github.com/jezdez/django_compressor/issues/77#issuecomment-2365760) on issue #77, the docs recommend adding a `path` method to the CachedS3Storage. However, this causes collectstatic to stop functioning properly with the remote storage. I've added a fix that tells the `compress` management command to first try to get `path``, and if that method raises an error, grab the local file storage path instead. Also updated docs to remove the path instructions.
