### PR TITLE
Re-added import statement that allows offline compression again. Refs #131

### DIFF
--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -13,6 +13,7 @@ from django.core.management.base import  NoArgsCommand, CommandError
 from django.template import Context, Template, TemplateDoesNotExist, TemplateSyntaxError
 from django.utils.datastructures import SortedDict
 from django.utils.importlib import import_module
+from django.template.loader import get_template
 from django.template.loader_tags import ExtendsNode, BlockNode, BLOCK_CONTEXT_KEY
 
 try:


### PR DESCRIPTION
I've added back in the import that was removed and is the source of issue #131. This makes version 1.1 of compressor work for me. I'd like to dig into the actual underlying problem, but can't at the moment. In the meantime, this temporarily fixes the issue.
