### PR TITLE
Jinja2 expects a reference to a class, not a module.

### DIFF
--- a/docs/jinja2.txt
+++ b/docs/jinja2.txt
@@ -32,7 +32,7 @@ only requires to add extension to ``JINJA2_EXTENSIONS`` at main settings
 module::
 
     JINJA2_EXTENSIONS = [
-        'compressor.contrib.jinja2ext',
+        'compressor.contrib.jinja2ext.CompressorExtension',
     ]
 
 And that's it - our extension is loaded and ready to be used.


### PR DESCRIPTION
I noticed this while hooking this up the other night. I followed the docs, but it broke. I switched it to pointing at the class and not the module and everything worked well.
