### PR TITLE
added java -jar to YUI filter: works with yui-2.4.6

### DIFF
--- a/compressor/filters/yui.py
+++ b/compressor/filters/yui.py
@@ -3,7 +3,7 @@ from compressor.filters import CompilerFilter
 
 
 class YUICompressorFilter(CompilerFilter):
-    command = "{binary} {args}"
+    command = "java -jar {binary} {args}"
 
     def __init__(self, *args, **kwargs):
         super(YUICompressorFilter, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Maybe I'm missing something, but I couldn't get YUI compressor filter to work without changing the command to java -jar yui.... tested with YUI 2.4.6
