### PR TITLE
Preserves filename when preprocessing and `COMPRESS_ENABLED = False`

### DIFF
--- a/compressor/base.py
+++ b/compressor/base.py
@@ -63,8 +63,13 @@ class Compressor(object):
         # drop the querystring, which is used for non-compressed cache-busting.
         return basename.split("?", 1)[0]
 
-    def get_filepath(self, content):
+    def get_filepath(self, content, basename=None):
         filename = "%s.%s" % (get_hexdigest(content, 12), self.type)
+        if basename is not None:
+            filename = '.'.join([
+                os.path.splitext(os.path.split(basename)[1])[0],
+                filename
+            ])
         return os.path.join(self.output_dir, self.output_prefix, filename)
 
     def get_filename(self, basename):
@@ -83,7 +88,7 @@ class Compressor(object):
             return filename
         # or just raise an exception as the last resort
         raise UncompressableFileError(
-            "'%s' could not be found in the COMPRESS_ROOT '%s'%s" %
+            "'%s' could not be found in the COMPRESS_ROOT '%s'%s" % 
             (basename, settings.COMPRESS_ROOT,
              self.finders and " or with staticfiles." or "."))
 
@@ -97,7 +102,7 @@ class Compressor(object):
             except UnicodeDecodeError, e:
                 raise UncompressableFileError("UnicodeDecodeError while "
                                               "processing '%s' with "
-                                              "charset %s: %s" %
+                                              "charset %s: %s" % 
                                               (filename, charset, e))
 
     @cached_property
@@ -151,7 +156,7 @@ class Compressor(object):
                 yield mode, smart_unicode(value, charset.lower())
             else:
                 if precompiled:
-                    value = self.handle_output(kind, value, forced=True)
+                    value = self.handle_output(kind, value, forced=True, basename=basename)
                     yield "verbatim", smart_unicode(value, charset.lower())
                 else:
                     yield mode, self.parser.elem_str(elem)
@@ -226,27 +231,27 @@ class Compressor(object):
 
         return self.content
 
-    def handle_output(self, mode, content, forced):
+    def handle_output(self, mode, content, forced, basename=None):
         # Then check for the appropriate output method and call it
         output_func = getattr(self, "output_%s" % mode, None)
         if callable(output_func):
-            return output_func(mode, content, forced)
+            return output_func(mode, content, forced, basename)
         # Total failure, raise a general exception
         raise CompressorError(
             "Couldn't find output method for mode '%s'" % mode)
 
-    def output_file(self, mode, content, forced=False):
+    def output_file(self, mode, content, forced=False, basename=None):
         """
         The output method that saves the content to a file and renders
         the appropriate template with the file's URL.
         """
-        new_filepath = self.get_filepath(content)
+        new_filepath = self.get_filepath(content, basename=basename)
         if not self.storage.exists(new_filepath) or forced:
             self.storage.save(new_filepath, ContentFile(content))
         url = self.storage.url(new_filepath)
         return self.render_output(mode, {"url": url})
 
-    def output_inline(self, mode, content, forced=False):
+    def output_inline(self, mode, content, forced=False, basename=None):
         """
         The output method that directly returns the content for inline
         display.
@@ -266,5 +271,5 @@ class Compressor(object):
         final_context.update(self.extra_context)
         post_compress.send(sender='django-compressor', type=self.type,
                            mode=mode, context=final_context)
-        return render_to_string("compressor/%s_%s.html" %
+        return render_to_string("compressor/%s_%s.html" % 
                                 (self.type, mode), final_context)


### PR DESCRIPTION
Hi. 

I've mentioned this at some point.

We're using `compress` a lot with precompilers for `text/coffee-script` and `text/x-scss`. Really handy. _But_, when you're including more than a single file of any mime type, and want to inspect / debug it in a browser's debugger it's a bit painful to have to click through a dozen or so sha1 hashed filenames to find the correct source.

This is a proposal to add the original filename to the hash when `COMPRESS_ENABLED == False` and a preprocessor is used. 
The resulting filenames are something like the ones below and make for a much easier navigation.

```
static/CACHE/js/map.49e86a7be69e.js
static/CACHE/js/search.21961b1dfa31.js
```

This could be further modified to depend on a setting. Feedback please :)
