### PR TITLE
Uses templates specified by attributes

### DIFF
--- a/compressor/base.py
+++ b/compressor/base.py
@@ -267,5 +267,12 @@ class Compressor(object):
         final_context = Context(self.context)
         post_compress.send(sender=self.__class__, type=self.type,
                            mode=mode, context=final_context)
-        return render_to_string("compressor/%s_%s.html" %
-                                (self.type, mode), final_context)
+
+        template_attr = 'template_name'
+        if mode != 'file':
+            template_attr += '_%s' % mode
+        try:
+            template = getattr(self, template_attr)
+        except AttributeError:
+            template = "compressor/%s_%s.html" % (self.type, mode)
+        return render_to_string(template, final_context)


### PR DESCRIPTION
With this change, `Compressor`'s `render_content()` will use the templates defined in the the `template_name` and `template_name_*` properties of the compressor class. That way subclasses can define their own template locations without having to override `render_content()`.

I left the old behavior in as a fallback in case any third parties are implementing custom compressors without `template_name*` attributes.
