### PR TITLE
Offline compression with jinja2ext.py

### DIFF
--- a/compressor/contrib/jinja2ext.py
+++ b/compressor/contrib/jinja2ext.py
@@ -2,20 +2,12 @@ from jinja2 import nodes
 from jinja2.ext import Extension
 from jinja2.exceptions import TemplateSyntaxError
 
-from compressor.conf import settings
 from compressor.templatetags.compress import OUTPUT_FILE, CompressorMixin
 
 
 class CompressorExtension(CompressorMixin, Extension):
 
     tags = set(['compress'])
-
-    @property
-    def compressors(self):
-        return {
-            'js': settings.COMPRESS_JS_COMPRESSOR,
-            'css': settings.COMPRESS_CSS_COMPRESSOR,
-        }
 
     def parse(self, parser):
         lineno = parser.stream.next().lineno


### PR DESCRIPTION
Offline compression wasn't working with CompressorNode in jinja2ext.py. While fixing it I noticed that there was quite a lot of code duplication between CompressorExtension in jinja2ext.py and CompressorNode in compress.py, so I tried to pull out the common parts and create a CompressorMixin that they both inherit from.
