### PR TITLE
use django's unittest2

### DIFF
--- a/compressor/tests/filters.py
+++ b/compressor/tests/filters.py
@@ -1,8 +1,8 @@
 from __future__ import with_statement
 import os
 import sys
-from unittest2 import skipIf
 
+from django.utils.unittest import skipIf
 from django.test import TestCase
 
 from compressor.cache import get_hashed_mtime, get_hashed_content

--- a/compressor/tests/parsers.py
+++ b/compressor/tests/parsers.py
@@ -1,6 +1,6 @@
 from __future__ import with_statement
 import os
-from unittest2 import skipIf
+from django.utils.unittest import skipIf
 
 try:
     import lxml


### PR DESCRIPTION
Surprising that in Python 2.7 running tests on django compressor failed with ImportError unittest2.
There is a better way, use django.utils.unittest which is exactly what unittest2 is - but it has the grace to use Python 2.7 when available.
