### PR TITLE
Avoid network I/O for remote storages in get_filename

### DIFF
--- a/compressor/base.py
+++ b/compressor/base.py
@@ -74,14 +74,18 @@ class Compressor(object):
     def get_filename(self, basename):
         filename = None
         # first try finding the file in the root
-        if self.storage.exists(basename):
-            try:
-                filename = self.storage.path(basename)
-            except NotImplementedError:
-                # remote storages don't implement path, access the file locally
+        try:
+            # call path first so remote storages don't make it to exists,
+            # which would cause network I/O
+            filename = self.storage.path(basename)
+            if not self.storage.exists(basename):
+                filename = None
+        except NotImplementedError:
+            # remote storages don't implement path, access the file locally
+            if compressor_file_storage.exists(basename):
                 filename = compressor_file_storage.path(basename)
         # secondly try to find it with staticfiles (in debug mode)
-        elif self.finders:
+        if not filename and self.finders:
             filename = self.finders.find(urllib.url2pathname(basename))
         if filename:
             return filename


### PR DESCRIPTION
I haven't run the tests on this because I'm not sure how to at a glance. We're running an equivalent monkey patch in production that avoids the occasional timeouts we were getting when `exists` was called for every file to S3.
