### PR TITLE
Add a dedicated method in CompressorNode to check if offline compression is enabled

### DIFF
--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -243,7 +243,7 @@ class Command(NoArgsCommand):
         for node in self.get_nodelist(node):
             if isinstance(node, BlockNode):
                 block_name = node.name
-            if isinstance(node, CompressorNode):
+            if isinstance(node, CompressorNode) and node.is_offline_compression_enabled(forced=True):
                 node._block_name = block_name
                 yield node
             else:

--- a/compressor/templatetags/compress.py
+++ b/compressor/templatetags/compress.py
@@ -41,13 +41,23 @@ class CompressorNode(template.Node):
             if request is not None:
                 return settings.COMPRESS_DEBUG_TOGGLE in request.GET
 
+    def is_offline_compression_enabled(self, forced):
+        """
+        Check if offline compression is enabled or forced
+
+        Defaults to just checking the settings and forced argument,
+        but can be overriden to completely disable compression for
+        a subclass, for instance.
+        """
+        rval = (settings.COMPRESS_ENABLED and settings.COMPRESS_OFFLINE) or forced
+        return rval
+
     def render_offline(self, context, forced):
         """
-        If enabled and in offline mode, and not forced or in debug mode
-        check the offline cache and return the result if given
+        If enabled and in offline mode, and not forced check the offline cache
+        and return the result if given
         """
-        if (settings.COMPRESS_ENABLED and
-                settings.COMPRESS_OFFLINE) and not forced:
+        if self.is_offline_compression_enabled(forced) and not forced:
             key = get_offline_hexdigest(self.nodelist.render(context))
             offline_manifest = get_offline_manifest()
             if key in offline_manifest:


### PR DESCRIPTION
This allows more flexibility in CompressorNode subclasses, making sure developers can opt out of offline compression in specific subclasses if necessary.

Doing this without modifying django-compressor means copy/pasting some code to avoid inheriting from CompressorNode, which is what I was trying to avoid. This passes all current tests, an additional test using a subclass could be added if necessary.
