### PR TITLE
Fix html5lib import error

### DIFF
--- a/compressor/parser/html5lib.py
+++ b/compressor/parser/html5lib.py
@@ -2,12 +2,17 @@ from __future__ import absolute_import
 from django.utils.encoding import smart_unicode
 from django.core.exceptions import ImproperlyConfigured
 
+import html5lib
 from compressor.exceptions import ParserError
 from compressor.parser import ParserBase
 from compressor.utils.decorators import cached_property
 
 
 class Html5LibParser(ParserBase):
+    
+    def __init__(self, content):
+        super(Html5LibParser, self).__init__(content)
+        self.html5lib = html5lib
 
     def _serialize(self, elem):
         fragment = self.html5lib.treebuilders.simpletree.DocumentFragment()
@@ -23,8 +28,6 @@ class Html5LibParser(ParserBase):
     @cached_property
     def html(self):
         try:
-            import html5lib
-            self.html5lib = html5lib
             return html5lib.parseFragment(self.content)
         except ImportError, err:
             raise ImproperlyConfigured("Error while importing html5lib: %s" % err)


### PR DESCRIPTION
Due to property may happen to be cached html5lib are not imported and causes "Caught AttributeError while rendering: 'Html5LibParser' object has no attribute 'html5lib'"

Sorry cannot provide test for that as I don't have the environment set up and am short in time to do this.
