### PR TITLE
Add install note about setting a view for handler500

### DIFF
--- a/docs/quickstart.txt
+++ b/docs/quickstart.txt
@@ -32,8 +32,21 @@ Installation
          'compressor.finders.CompressorFinder',
      )
 
+* Finally, if you use Django Compressor and ``STATIC_URL`` in your
+  ``500.html`` error template, you should add a ``handler500`` in
+  your urlconf. For example, in Django 1.3:
+
+  .. code-block:: python
+
+     handler500 = TemplateView.as_view(template_name="500.html")
+
+  This ensures that RequestContext_ is used to render the template, which
+  is `not the case by default`_ but is needed to populate `STATIC _URL``.
+
 .. _staticfiles: http://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/
 .. _django-staticfiles: http://pypi.python.org/pypi/django-staticfiles
+.. _RequestContext: https://docs.djangoproject.com/en/dev/ref/templates/api/#django.template.RequestContext
+.. _not the case by default: https://docs.djangoproject.com/en/dev/topics/http/views/#the-500-server-error-view
 
 .. _dependencies:
 


### PR DESCRIPTION
This is needed to avoid "TemplateSyntaxError: Caught UncompressableFileError ..."
when rendering the 500.html error page: if STATIC_URL outputs nothing, then
compressor complains that the file isn't accessible via COMPRESS_URL.
