### PR TITLE
If you call `render_to_string` and pass in a `Context` instance you're s...

### DIFF
--- a/compressor/base.py
+++ b/compressor/base.py
@@ -282,4 +282,4 @@ class Compressor(object):
         post_compress.send(sender=self.__class__, type=self.type,
                            mode=mode, context=final_context)
         template_name = self.get_template_name(mode)
-        return render_to_string(template_name, final_context)
+        return render_to_string(template_name, context_instance=final_context)


### PR DESCRIPTION
...upposed to use the `context_instance=` keyword argument. Otherwise it might be mistaken for the `dictionary` parameter.

Docs here: https://docs.djangoproject.com/en/dev/ref/templates/api/#the-render-to-string-shortcut

I need this fix so I can use Jingo together with django_compressor. 
