### PR TITLE
As of django 1.4 b1, the default value for `STATIC_ROOT` is `''` which m...

### DIFF
--- a/compressor/conf.py
+++ b/compressor/conf.py
@@ -73,7 +73,7 @@ class CompressorConf(AppConf):
             value = getattr(settings, 'STATIC_ROOT', None)
             if not value:
                 value = settings.MEDIA_ROOT
-        if not value:
+        if value is None:
             raise ImproperlyConfigured("COMPRESS_ROOT setting must be set")
         return os.path.normcase(os.path.abspath(value))
 


### PR DESCRIPTION
...eans `COMPRESS_ROOT` becomes `''` which is false but not None.

I haven't proven this with unit tests but I know that just changing it to "is None" fixed it for my django 1.4b1 project.
