### PR TITLE
Initialize all apps before the compressor runs (#223)

### DIFF
--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -323,4 +323,10 @@ class Command(NoArgsCommand):
                 raise CommandError(
                     "Offline compression is disabled. Set "
                     "COMPRESS_OFFLINE or use the --force to override.")
+
+        # Initialize all apps before the compressor runs so that they
+        # have an opportunity to register built-in template tags.
+        from django.db.models.loading import cache
+        cache.get_apps()
+
         self.compress(sys.stdout, **options)


### PR DESCRIPTION
Some apps register built-in template tags. The compressor
dies with TemplateSyntaxError if these apps have not been
initialized before the compressor runs. This patch lets
django initialize all apps (but presumably not connect to
the database, which was the issue reported in #127) and
register all built-in template tags before running the
compressor.
