### PR TITLE
Re-raise original exception

### DIFF
--- a/compressor/templatetags/compress.py
+++ b/compressor/templatetags/compress.py
@@ -111,7 +111,7 @@ class CompressorMixin(object):
             return rendered_output
         except Exception, e:
             if settings.DEBUG or forced:
-                raise e
+                raise
 
         # Or don't do anything in production
         return self.get_original_content(context)


### PR DESCRIPTION
The previous form (`raise e`) clobbers the traceback, making it hard to find the root cause of the exception. The `raise` form simply re-raises the original exception, pointing the developer to the source of the problem.
