### PR TITLE
Mark storage URLs as safe.

### DIFF
--- a/compressor/base.py
+++ b/compressor/base.py
@@ -8,6 +8,7 @@ from django.core.files.storage import get_storage_class
 from django.template import Context
 from django.template.loader import render_to_string
 from django.utils.encoding import smart_unicode
+from django.utils.safestring import mark_safe
 
 from compressor.cache import get_hexdigest, get_mtime
 
@@ -256,7 +257,7 @@ class Compressor(object):
         new_filepath = self.get_filepath(content, basename=basename)
         if not self.storage.exists(new_filepath) or forced:
             self.storage.save(new_filepath, ContentFile(content))
-        url = self.storage.url(new_filepath)
+        url = mark_safe(self.storage.url(new_filepath))
         return self.render_output(mode, {"url": url})
 
     def output_inline(self, mode, content, forced=False, basename=None):


### PR DESCRIPTION
When URLs are not marked as safe, they will be escaped again in templates. As a result, some special characters, like '&' would be outputted as '&amp;' and URLs that use GET parameters would not be correct, for instance, URLs to S3 that need to be signed etc.

I guess we can trust the Storage engine used that it correctly escapes the file names itself and rely on that behavior for security.

Apostolis
