### PR TITLE
re-implementing default documented behaviour for uncompressable files, fixes #241

### DIFF
--- a/compressor/css.py
+++ b/compressor/css.py
@@ -20,9 +20,13 @@ class CssCompressor(Compressor):
             elem_name = self.parser.elem_name(elem)
             elem_attribs = self.parser.elem_attribs(elem)
             if elem_name == 'link' and elem_attribs['rel'].lower() == 'stylesheet':
-                basename = self.get_basename(elem_attribs['href'])
-                filename = self.get_filename(basename)
-                data = (SOURCE_FILE, filename, basename, elem)
+                try:
+                    basename = self.get_basename(elem_attribs['href'])
+                    filename = self.get_filename(basename)
+                    data = (SOURCE_FILE, filename, basename, elem)
+                except UncompressableFileError:
+                    if settings.DEBUG:
+                        raise
             elif elem_name == 'style':
                 data = (SOURCE_HUNK, self.parser.elem_content(elem), None, elem)
             if data:

--- a/compressor/js.py
+++ b/compressor/js.py
@@ -16,10 +16,14 @@ class JsCompressor(Compressor):
         for elem in self.parser.js_elems():
             attribs = self.parser.elem_attribs(elem)
             if 'src' in attribs:
-                basename = self.get_basename(attribs['src'])
-                filename = self.get_filename(basename)
-                content = (SOURCE_FILE, filename, basename, elem)
-                self.split_content.append(content)
+                try:
+                    basename = self.get_basename(attribs['src'])
+                    filename = self.get_filename(basename)
+                    content = (SOURCE_FILE, filename, basename, elem)
+                    self.split_content.append(content)
+                except UncompressableFileError:
+                    if settings.DEBUG:
+                        raise
             else:
                 content = self.parser.elem_content(elem)
                 self.split_content.append((SOURCE_HUNK, content, None, elem))


### PR DESCRIPTION
Hi, 
this is an attempted fix that works for me in production and that reproduce the documented behaviour of old django-compressor releases.
I think this behaviour is the good one, because in the case of (for example) 500/404/... pages we don't have access to STATIC_URL or other variables, and adding default valued urls that can be uncompressable is mandatory.

Open for discussion as usual, 
Regards, 

Olivier.
