### PR TITLE
Cached the offline manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ docs/_build/
 .coverage
 htmlcov
 .sass-cache
+.DS_Store

--- a/compressor/cache.py
+++ b/compressor/cache.py
@@ -63,11 +63,19 @@ def get_offline_manifest_filename():
 
 
 def get_offline_manifest():
-    filename = get_offline_manifest_filename()
-    if default_storage.exists(filename):
-        return simplejson.load(default_storage.open(filename))
-    else:
+    manifest = cache.get(simple_cachekey("manifest"))
+    if manifest is None:
+        filename = get_offline_manifest_filename()
+        if default_storage.exists(filename):
+            manifest = simplejson.load(default_storage.open(filename))
+            if manifest is not None:
+                cache.set(simple_cachekey("manifest"), manifest)
+                return manifest
+        
         return {}
+
+    return manifest
+    
 
 
 def write_offline_manifest(manifest):


### PR DESCRIPTION
Hello,

Just added some quick code to cache the offline manifest, to save multiple disk accesses (especially helpful on slow I/O like EBS).  Also tossed on a .DS_Store ignore, in case you have other mac contributors someday.

Let me know if you'd like this to be differently done!

-Steven
