### PR TITLE
Display the error line on HTMLParser parse errors.

### DIFF
--- a/compressor/parser/default_htmlparser.py
+++ b/compressor/parser/default_htmlparser.py
@@ -15,7 +15,9 @@ class DefaultHtmlParser(ParserBase, HTMLParser):
             self.feed(self.content)
             self.close()
         except Exception, err:
-            raise ParserError("Error while initializing HtmlParser: %s" % err)
+            lineno = err.lineno
+            line = self.content.splitlines()[lineno]
+            raise ParserError("Error while initializing HtmlParser: %s (line: %s)" % (err, repr(line)))
 
     def handle_starttag(self, tag, attrs):
         tag = tag.lower()


### PR DESCRIPTION
Parse error with the HTMLParser is hard to track. It's helps to see a part of the error content...
