### PR TITLE
Store the offline manifest entries in the cache.

### DIFF
--- a/compressor/templatetags/compress.py
+++ b/compressor/templatetags/compress.py
@@ -2,9 +2,8 @@ from django import template
 from django.core.exceptions import ImproperlyConfigured
 
 from compressor.cache import (cache_get, cache_set, get_offline_hexdigest,
-                              get_offline_manifest, get_templatetag_cachekey)
+                              get_offline_value, get_templatetag_cachekey)
 from compressor.conf import settings
-from compressor.exceptions import OfflineGenerationError
 from compressor.utils import get_class
 
 register = template.Library()
@@ -63,13 +62,7 @@ class CompressorMixin(object):
         """
         if self.is_offline_compression_enabled(forced) and not forced:
             key = get_offline_hexdigest(self.nodelist.render(context))
-            offline_manifest = get_offline_manifest()
-            if key in offline_manifest:
-                return offline_manifest[key]
-            else:
-                raise OfflineGenerationError('You have offline compression '
-                    'enabled but key "%s" is missing from offline manifest. '
-                    'You may need to run "python manage.py compress".' % key)
+            return get_offline_value(key)
 
     def render_cached(self, compressor, kind, mode, forced=False):
         """

--- a/docs/behind-the-scenes.txt
+++ b/docs/behind-the-scenes.txt
@@ -10,13 +10,14 @@ Offline cache
 -------------
 
 If offline cache is activated, the first thing {% compress %} tries to do is
-retrieve the compressed version for its nodelist from the offline manifest
-cache. It doesn't parse, doesn't check the modified times of the files, doesn't
+retrieve the compressed version for its nodelist from the cache and, in case it
+is not found there, from the offline manifest cache.
+It doesn't parse, doesn't check the modified times of the files, doesn't
 even know which files are concerned actually, since it doesn't look inside the
 nodelist of the template block enclosed by the ``compress`` template tag.
 The offline cache manifest is just a json file, stored on disk inside the
 directory that holds the compressed files. The format of the manifest is simply
-a key <=> value dictionnary, with the hash of the nodelist being the key,
+a key <=> value dictionary, with the hash of the nodelist being the key,
 and the HTML containing the element code for the combined file or piece of code
 being the value. Generating the offline manifest, using the ``compress``
 management command, also generates the combined files referenced in the manifest.

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -148,10 +148,14 @@ If not specified, the ``COMPRESS_OFFLINE_CONTEXT`` will by default contain
 the commonly used setting to refer to saved files ``MEDIA_URL`` and
 ``STATIC_URL`` (if specified in the settings).
 
-The result of running the ``compress`` management command will be cached
-in a file called ``manifest.json`` using the :attr:`configured storage
-<django.conf.settings.COMPRESS_STORAGE>` to be able to be transfered from your developement
-computer to the server easily.
+The result of running the ``compress`` management command will be saved
+in the cache as well as stored in a file called ``manifest.json``
+using the :attr:`configured storage <django.conf.settings.COMPRESS_STORAGE>`.
+The cache is used to avoid any delays from fetching and reading the file the first time it is accessed
+(especially, if it is not stored locally).
+The manifest file, on the other hand, is used as a fallback, in case a key in the cache has expired.
+Generating the manifest file has the added benefit of making it possible to compress the static files
+in a development computer and later transfer just the manifest file to the production servers.
 
 .. _TEMPLATE_LOADERS: http://docs.djangoproject.com/en/dev/ref/settings/#template-loaders
 


### PR DESCRIPTION
We make the `compress` command store the entries of the manifest.json file in cache and the `compress` templatetag try to read the correct value from the cache instead of the `manifest.json` file.