### PR TITLE
Enhanced compress template tag

### DIFF
--- a/compressor/base.py
+++ b/compressor/base.py
@@ -31,7 +31,7 @@ class Compressor(object):
     """
     type = None
 
-    def __init__(self, content=None, output_prefix=None, context=None, *args, **kwargs):
+    def __init__(self, content=None, output_prefix=None, context=None, opts=None, *args, **kwargs):
         self.content = content or ""
         self.output_prefix = output_prefix or "compressed"
         self.output_dir = settings.COMPRESS_OUTPUT_DIR.strip('/')
@@ -42,6 +42,7 @@ class Compressor(object):
         self.extra_context = {}
         self.all_mimetypes = dict(settings.COMPRESS_PRECOMPILERS)
         self.finders = staticfiles.finders
+        self.opts = opts or {}
 
     def split_contents(self):
         """
@@ -158,6 +159,7 @@ class Compressor(object):
                 'kind': kind,
                 'basename': basename,
             }
+            options.update(self.opts)
 
             if kind == SOURCE_FILE:
                 options = dict(options, filename=value)

--- a/compressor/css.py
+++ b/compressor/css.py
@@ -4,9 +4,9 @@ from compressor.conf import settings
 
 class CssCompressor(Compressor):
 
-    def __init__(self, content=None, output_prefix="css", context=None):
+    def __init__(self, content=None, output_prefix="css", context=None, opts=None):
         super(CssCompressor, self).__init__(content=content,
-            output_prefix=output_prefix, context=context)
+            output_prefix=output_prefix, context=context, opts=opts)
         self.filters = list(settings.COMPRESS_CSS_FILTERS)
         self.type = output_prefix
 

--- a/compressor/js.py
+++ b/compressor/js.py
@@ -4,8 +4,8 @@ from compressor.base import Compressor, SOURCE_HUNK, SOURCE_FILE
 
 class JsCompressor(Compressor):
 
-    def __init__(self, content=None, output_prefix="js", context=None):
-        super(JsCompressor, self).__init__(content, output_prefix, context)
+    def __init__(self, content=None, output_prefix="js", context=None, opts=None):
+        super(JsCompressor, self).__init__(content, output_prefix, context, opts)
         self.filters = list(settings.COMPRESS_JS_FILTERS)
         self.type = output_prefix
 

--- a/compressor/templatetags/compress.py
+++ b/compressor/templatetags/compress.py
@@ -33,9 +33,9 @@ class CompressorMixin(object):
         return get_class(self.compressors.get(kind),
                          exception=ImproperlyConfigured)(*args, **kwargs)
 
-    def get_compressor(self, context, kind):
+    def get_compressor(self, context, kind, tag_opts):
         return self.compressor_cls(kind,
-            content=self.get_original_content(context), context=context)
+            content=self.get_original_content(context), context=context, opts=tag_opts)
 
     def debug_mode(self, context):
         if settings.COMPRESS_DEBUG_TOGGLE:
@@ -82,7 +82,7 @@ class CompressorMixin(object):
             return cache_key, cache_content
         return None, None
 
-    def render_compressed(self, context, kind, mode, forced=False):
+    def render_compressed(self, context, kind, mode, tag_opts=None, forced=False):
 
         # See if it has been rendered offline
         cached_offline = self.render_offline(context, forced=forced)
@@ -96,7 +96,7 @@ class CompressorMixin(object):
             return self.get_original_content(context)
 
         context['compressed'] = {'name': getattr(self, 'name', None)}
-        compressor = self.get_compressor(context, kind)
+        compressor = self.get_compressor(context, kind, tag_opts)
 
         # Prepare the actual compressor and check cache
         cache_key, cache_content = self.render_cached(compressor, kind, mode, forced=forced)
@@ -122,11 +122,12 @@ class CompressorMixin(object):
 
 class CompressorNode(CompressorMixin, template.Node):
 
-    def __init__(self, nodelist, kind=None, mode=OUTPUT_FILE, name=None):
+    def __init__(self, nodelist, kind=None, mode=OUTPUT_FILE, name=None, tag_opts={}):
         self.nodelist = nodelist
         self.kind = kind
         self.mode = mode
         self.name = name
+        self.tag_opts = tag_opts
 
     def get_original_content(self, context):
         return self.nodelist.render(context)
@@ -145,7 +146,16 @@ class CompressorNode(CompressorMixin, template.Node):
         if self.debug_mode(context):
             return self.get_original_content(context)
 
-        return self.render_compressed(context, self.kind, self.mode, forced=forced)
+        self.resolve_variables(context)
+        return self.render_compressed(context, self.kind, self.mode, self.tag_opts, forced=forced)
+
+    def resolve_variables(self, context):
+        for option, value in self.tag_opts.items():
+            try:
+                value = value.resolve(context)
+            except template.VariableDoesNotExist:
+                value = unicode(value)
+            self.tag_opts[option] = value
 
 
 @register.tag
@@ -155,7 +165,7 @@ def compress(parser, token):
 
     Syntax::
 
-        {% compress <js/css> %}
+        {% compress js|css [file|inline] [<option>=<value>[ <option>=<value>...]] [as <variable_name>] %}
         <html of inline or linked JS/CSS>
         {% endcompress %}
 
@@ -192,22 +202,30 @@ def compress(parser, token):
 
     args = token.split_contents()
 
-    if not len(args) in (2, 3, 4):
+    if not len(args) >= 2:
         raise template.TemplateSyntaxError(
-            "%r tag requires either one, two or three arguments." % args[0])
+            "%r tag requires at least one argument." % args[0])
 
     kind = args[1]
-
+    name = None
+    mode = OUTPUT_FILE
+    tag_opts = {}
     if len(args) >= 3:
-        mode = args[2]
-        if not mode in OUTPUT_MODES:
-            raise template.TemplateSyntaxError(
-                "%r's second argument must be '%s' or '%s'." %
-                (args[0], OUTPUT_FILE, OUTPUT_INLINE))
-    else:
-        mode = OUTPUT_FILE
-    if len(args) == 4:
-        name = args[3]
-    else:
-        name = None
-    return CompressorNode(nodelist, kind, mode, name)
+        looking_for_name = False
+        for i in range(2, len(args)):
+            if looking_for_name:
+                name = args[i]
+                looking_for_name = False
+            elif args[i] == "as":
+                looking_for_name = True
+            elif '=' in args[i]:
+                option, value = args[i].split("=")
+                tag_opts[option] = template.Variable(value)
+            elif args[i] in OUTPUT_MODES:
+                mode = args[i]
+            else:
+                raise template.TemplateSyntaxError(
+                    "%r's third argument on must either be (file|input) or <option>=<value> or 'as <name>'" %
+                    args[0])
+
+    return CompressorNode(nodelist, kind, mode, name, tag_opts)

--- a/compressor/tests/test_templatetags.py
+++ b/compressor/tests/test_templatetags.py
@@ -3,13 +3,14 @@ from __future__ import with_statement
 import os
 import sys
 
-from mock import Mock
+from mock import Mock, patch
 
 from django.template import Template, Context, TemplateSyntaxError
 from django.test import TestCase
 
 from compressor.conf import settings
 from compressor.signals import post_compress
+from compressor.templatetags.compress import CompressorNode
 from compressor.tests.test_base import css_tag, test_dir
 
 
@@ -116,7 +117,7 @@ class TemplatetagTestCase(TestCase):
         self.assertEqual(out, render(template, context))
 
     def test_named_compress_tag(self):
-        template = u"""{% load compress %}{% compress js inline foo %}
+        template = u"""{% load compress %}{% compress js inline as foo %}
         <script type="text/javascript">obj.value = "value";</script>
         {% endcompress %}
         """
@@ -129,6 +130,26 @@ class TemplatetagTestCase(TestCase):
         args, kwargs = callback.call_args
         context = kwargs['context']
         self.assertEqual('foo', context['compressed']['name'])
+
+    @patch('compressor.templatetags.compress.CompressorNode', wraps=CompressorNode)
+    def test_tag_opts(self, mock_class):
+        template = u"""{% load compress %}{% compress js inline group_first=True %}
+        <script type="text/javascript">obj.value = "value";</script>
+        {% endcompress %}
+        """
+        render(template)
+        self.assertEqual(len(mock_class.mock_calls), 1)
+        self.assertEqual(len(mock_class.mock_calls[0][1]), 5)
+        self.assertDictEqual(mock_class.mock_calls[0][1][4], {'group_first': 'True'})
+
+    @patch('compressor.templatetags.compress.CompressorNode', wraps=CompressorNode)
+    def test_variable_tag_opts(self, mock_class):
+        template = u"""{% load compress %}{% compress js inline group_first=True %}
+        <script type="text/javascript">obj.value = "value";</script>
+        {% endcompress %}
+        """
+        render(template, {'group_first': True})
+        self.assertDictEqual(mock_class.mock_calls[0][1][4], {'group_first': 'True'})
 
 
 class PrecompilerTemplatetagTestCase(TestCase):

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -6,7 +6,7 @@ Usage
 .. code-block:: django
 
     {% load compress %}
-    {% compress <js/css> [<file/inline> [block_name]] %}
+    {% compress js|css [file|inline] [as <block_name>] [<option>=<value>[ <option>=<value>...]] %}
     <html of inline or linked JS/CSS>
     {% endcompress %}
 
@@ -75,10 +75,9 @@ exception. If DEBUG is ``False`` these files will be silently stripped.
     :attr:`~django.conf.settings.COMPRESS_CACHE_BACKEND` and
     Django's `caching documentation`_).
 
-The compress template tag supports a second argument specifying the output
-mode and defaults to saving the result in a file. Alternatively you can
-pass '``inline``' to the template tag to return the content directly to the
-rendered page, e.g.:
+The compress template tag supports specifying the output mode and defaults
+to saving the result in a file. Alternatively, you can pass '``inline``' to
+the template tag to return the content directly to the rendered page, e.g.:
 
 .. code-block:: django
 
@@ -96,9 +95,32 @@ would be rendered something like::
     obj.value = "value";
     </script>
 
-The compress template tag also supports a third argument for naming the output
-of that particular compress tag.  This is then added to the context so you can
-access it in the `post_compress signal <signals>`.
+The compress template tag also supports naming the output of that particular
+compress tag, e.g.:
+
+.. code-block:: django
+
+    {% load compress %}
+
+    {% compress js as main_js %}
+    <script src="/static/js/one.js" type="text/javascript" charset="utf-8"></script>
+    <script type="text/javascript" charset="utf-8">obj.value = "value";</script>
+    {% endcompress %}
+
+This is then added to the context so you can access it in the `post_compress signal <signals>`.
+
+The compress template also supports passing any number of arbitrary keyword arguments.  These are
+passed to all the compressors and, when using the default compressor classes, all of the
+precompilers and filters, e.g.:
+
+.. code-block:: django
+
+    {% load compress %}
+
+    {% compress js foo=bar group_first=true %}
+    <script src="/static/js/one.js" type="text/javascript" charset="utf-8"></script>
+    <script type="text/javascript" charset="utf-8">obj.value = "value";</script>
+    {% endcompress %}
 
 .. _memcached: http://memcached.org/
 .. _caching documentation: http://docs.djangoproject.com/en/1.2/topics/cache/#memcached


### PR DESCRIPTION
### Background

I used and heavily modified django-compress for a while, but needed something else when the project stalled.  Django_compressor offered some continuity (filters/extensibility) and some very welcome differences (parsing blocks from the code).  I would like to see django_compressor be the basis for a full modern web asset handling package, that works well with modern best practises (e.g. asynchronous asset loaders, css sprites, etc).  To that end, my plan is to start with django_compressor's extensibility, enhance it a little bit, then build some useful stuff on top of it (e.g. filters/compilers for images).  The first step, however is just adding a little more flexibility and standardization to the template tag
### What's in this pull request
- Let tag arguments after kind (css|js) be specified in any order 
- Use more standard 'as <name>' syntax to name the code block
- Add ability to specify options in the tag

There are tests and documentation updates as well as the code changes
#### Tag Argument Order

There's not really any need to enforce a certain arrangement of arguments in the tag so let's just let people specify them however they want after the kind parameter.  So now all of these are valid:

```
{% compress js inline as main %}

{% compress js as main file %}

{% compress css group_first=true as base %}
```
#### Using 'as &lt;name>'

Lots of things in python and django use this syntax, so it would be nice to do so as well
#### Specifying options in the tag

Here's the big one.  Just like the `with` tag in django, you can specify an arbitrary number of keyword/value arguments to the tag.  These will get put into a dictionary and passed to the Compressor classes.  Also, the default compressors, add these to the options that they pass the precompilers and filters.  One of the main motivations for this was to prepare for being able to specify that files should be grouped first before, say, lessc precompilation (as discussed in #30)
