### PR TITLE
Adding option to concatenate files before processing

### DIFF
--- a/compressor/css.py
+++ b/compressor/css.py
@@ -21,9 +21,9 @@ class CssCompressor(Compressor):
             if elem_name == 'link' and elem_attribs['rel'].lower() == 'stylesheet':
                 basename = self.get_basename(elem_attribs['href'])
                 filename = self.get_filename(basename)
-                data = (SOURCE_FILE, filename, basename, elem)
+                data = (SOURCE_FILE, filename, basename, [elem])
             elif elem_name == 'style':
-                data = (SOURCE_HUNK, self.parser.elem_content(elem), None, elem)
+                data = (SOURCE_HUNK, self.parser.elem_content(elem), None, [elem])
             if data:
                 self.split_content.append(data)
                 media = elem_attribs.get('media', None)

--- a/compressor/js.py
+++ b/compressor/js.py
@@ -17,9 +17,9 @@ class JsCompressor(Compressor):
             if 'src' in attribs:
                 basename = self.get_basename(attribs['src'])
                 filename = self.get_filename(basename)
-                content = (SOURCE_FILE, filename, basename, elem)
+                content = (SOURCE_FILE, filename, basename, [elem])
                 self.split_content.append(content)
             else:
                 content = self.parser.elem_content(elem)
-                self.split_content.append((SOURCE_HUNK, content, None, elem))
+                self.split_content.append((SOURCE_HUNK, content, None, [elem]))
         return self.split_content

--- a/compressor/tests/media/css/one.less
+++ b/compressor/tests/media/css/one.less
@@ -1,0 +1,1 @@
+body { background:#990; }

--- a/compressor/tests/media/css/two.less
+++ b/compressor/tests/media/css/two.less
@@ -1,0 +1,1 @@
+body { color:#fff; }

--- a/compressor/tests/media/js/two.coffee
+++ b/compressor/tests/media/js/two.coffee
@@ -1,0 +1,1 @@
+# this is a comment.

--- a/compressor/tests/test_parsers.py
+++ b/compressor/tests/test_parsers.py
@@ -59,7 +59,7 @@ class Html5LibParserTests(ParserTestCase, CompressorTestCase):
             (SOURCE_FILE, os.path.join(settings.COMPRESS_ROOT, u'css', u'two.css'), u'css/two.css', u'<link href="/media/css/two.css" rel="stylesheet" type="text/css">'),
         ]
         split = self.css_node.split_contents()
-        split = [(x[0], x[1], x[2], self.css_node.parser.elem_str(x[3])) for x in split]
+        split = [(x[0], x[1], x[2], self.css_node.parser.elem_str(x[3][0])) for x in split]
         self.assertEqual(out, split)
 
     def test_js_split(self):
@@ -68,7 +68,7 @@ class Html5LibParserTests(ParserTestCase, CompressorTestCase):
             (SOURCE_HUNK, u'obj.value = "value";', None, u'<script type="text/javascript">obj.value = "value";</script>'),
         ]
         split = self.js_node.split_contents()
-        split = [(x[0], x[1], x[2], self.js_node.parser.elem_str(x[3])) for x in split]
+        split = [(x[0], x[1], x[2], self.js_node.parser.elem_str(x[3][0])) for x in split]
         self.assertEqual(out, split)
 
 Html5LibParserTests = skipIf(


### PR DESCRIPTION
Setting the option `group_first=true` in the `compress` template tag (requires #285) will cause files of the same type to be concatenated before being handed to precompilers/filters.  This will allow people to do standard code decomposition with things like .less files (having a mixins file separate from page-specific files)

For example:

```
{% compress css group_first=true %}
    <link rel="stylesheet" href="/media/css/mixins.less" type="text/less" />
    <link rel="stylesheet" href="/media/css/home.less" type="text/less" />
    <link rel="stylesheet" href="/media/css/foo.css" type="text/css" />
{% endcompress %}
```

Will concatenate the .less files so the less precompiler will properly process all the files
This provides a fix for #30
