### PR TITLE
Flaking required due to flake8 1.4 release moving to pep8 1.2

### DIFF
--- a/compressor/base.py
+++ b/compressor/base.py
@@ -113,7 +113,7 @@ class Compressor(object):
                 return fd.read()
             except IOError, e:
                 raise UncompressableFileError("IOError while processing "
-                                               "'%s': %s" % (filename, e))
+                                              "'%s': %s" % (filename, e))
             except UnicodeDecodeError, e:
                 raise UncompressableFileError("UnicodeDecodeError while "
                                               "processing '%s' with "
@@ -207,7 +207,7 @@ class Compressor(object):
                                           "mimetype '%s'." % mimetype)
             else:
                 return True, CompilerFilter(content, filter_type=self.type,
-                    command=command, filename=filename).input(**kwargs)
+                                            command=command, filename=filename).input(**kwargs)
         return False, content
 
     def filter(self, content, method, **kwargs):

--- a/compressor/cache.py
+++ b/compressor/cache.py
@@ -135,7 +135,7 @@ def cache_get(key):
         # Store the stale value while the cache
         # revalidates for another MINT_DELAY seconds.
         cache_set(key, val, refreshed=True,
-            timeout=settings.COMPRESS_MINT_DELAY)
+                  timeout=settings.COMPRESS_MINT_DELAY)
         return None
     return val
 

--- a/compressor/contrib/jinja2ext.py
+++ b/compressor/contrib/jinja2ext.py
@@ -19,7 +19,7 @@ class CompressorExtension(CompressorMixin, Extension):
         if args[0].value not in self.compressors:
             raise TemplateSyntaxError('compress kind may be one of: %s' %
                                       (', '.join(self.compressors.keys())),
-                                       lineno)
+                                      lineno)
         if parser.stream.skip_if('comma'):
             modearg = parser.parse_expression()
             # Allow mode to be defined as jinja2 name node
@@ -30,7 +30,7 @@ class CompressorExtension(CompressorMixin, Extension):
             args.append(nodes.Const('file'))
         body = parser.parse_statements(['name:endcompress'], drop_needle=True)
         return nodes.CallBlock(self.call_method('_compress', args), [], [],
-            body).set_lineno(lineno)
+                               body).set_lineno(lineno)
 
     def _compress(self, kind, mode, caller):
         # This extension assumes that we won't force compression

--- a/compressor/css.py
+++ b/compressor/css.py
@@ -6,7 +6,7 @@ class CssCompressor(Compressor):
 
     def __init__(self, content=None, output_prefix="css", context=None):
         super(CssCompressor, self).__init__(content=content,
-            output_prefix=output_prefix, context=context)
+                                            output_prefix=output_prefix, context=context)
         self.filters = list(settings.COMPRESS_CSS_FILTERS)
         self.type = output_prefix
 

--- a/compressor/filters/base.py
+++ b/compressor/filters/base.py
@@ -115,7 +115,7 @@ class CompilerFilter(FilterBase):
         try:
             command = fstr(self.command).format(**options)
             proc = subprocess.Popen(command, shell=True, cwd=self.cwd,
-                stdout=self.stdout, stdin=self.stdin, stderr=self.stderr)
+                                    stdout=self.stdout, stdin=self.stdin, stderr=self.stderr)
             if self.infile is None:
                 filtered, err = proc.communicate(self.content.encode('utf8'))
             else:

--- a/compressor/filters/css_default.py
+++ b/compressor/filters/css_default.py
@@ -38,7 +38,7 @@ class CssAbsoluteFilter(FilterBase):
             self.host = parts[2]
         self.directory_name = '/'.join((self.url, os.path.dirname(self.path)))
         return SRC_PATTERN.sub(self.src_converter,
-            URL_PATTERN.sub(self.url_converter, self.content))
+                               URL_PATTERN.sub(self.url_converter, self.content))
 
     def find(self, basename):
         if settings.DEBUG and basename and staticfiles.finders:

--- a/compressor/management/commands/mtime_cache.py
+++ b/compressor/management/commands/mtime_cache.py
@@ -13,22 +13,22 @@ class Command(NoArgsCommand):
     help = "Add or remove all mtime values from the cache"
     option_list = NoArgsCommand.option_list + (
         make_option('-i', '--ignore', action='append', default=[],
-            dest='ignore_patterns', metavar='PATTERN',
-            help="Ignore files or directories matching this glob-style "
-                "pattern. Use multiple times to ignore more."),
+                    dest='ignore_patterns', metavar='PATTERN',
+                    help="Ignore files or directories matching this glob-style "
+                    "pattern. Use multiple times to ignore more."),
         make_option('--no-default-ignore', action='store_false',
-            dest='use_default_ignore_patterns', default=True,
-            help="Don't ignore the common private glob-style patterns 'CVS', "
-                "'.*' and '*~'."),
+                    dest='use_default_ignore_patterns', default=True,
+                    help="Don't ignore the common private glob-style patterns 'CVS', "
+                    "'.*' and '*~'."),
         make_option('--follow-links', dest='follow_links', action='store_true',
-            help="Follow symlinks when traversing the COMPRESS_ROOT "
-                "(which defaults to MEDIA_ROOT). Be aware that using this "
-                "can lead to infinite recursion if a link points to a parent "
-                "directory of itself."),
+                    help="Follow symlinks when traversing the COMPRESS_ROOT "
+                    "(which defaults to MEDIA_ROOT). Be aware that using this "
+                    "can lead to infinite recursion if a link points to a parent "
+                    "directory of itself."),
         make_option('-c', '--clean', dest='clean', action='store_true',
-            help="Remove all items"),
+                    help="Remove all items"),
         make_option('-a', '--add', dest='add', action='store_true',
-            help="Add all items"),
+                    help="Add all items"),
     )
 
     def is_ignored(self, path):
@@ -53,7 +53,7 @@ class Command(NoArgsCommand):
 
         if not settings.COMPRESS_MTIME_DELAY:
             raise CommandError('mtime caching is currently disabled. Please '
-                'set the COMPRESS_MTIME_DELAY setting to a number of seconds.')
+                               'set the COMPRESS_MTIME_DELAY setting to a number of seconds.')
 
         files_to_add = set()
         keys_to_delete = set()

--- a/compressor/parser/html5lib.py
+++ b/compressor/parser/html5lib.py
@@ -18,7 +18,7 @@ class Html5LibParser(ParserBase):
         fragment = self.html5lib.treebuilders.simpletree.DocumentFragment()
         fragment.appendChild(elem)
         return self.html5lib.serialize(fragment,
-            quote_attr_values=True, omit_optional_tags=False)
+                                       quote_attr_values=True, omit_optional_tags=False)
 
     def _find(self, *names):
         for node in self.html.childNodes:

--- a/compressor/parser/lxml.py
+++ b/compressor/parser/lxml.py
@@ -34,7 +34,7 @@ class LxmlParser(ParserBase):
 
     def css_elems(self):
         return self.tree.xpath('//link[re:test(@rel, "^stylesheet$", "i")]|style',
-            namespaces={"re": "http://exslt.org/regular-expressions"})
+                               namespaces={"re": "http://exslt.org/regular-expressions"})
 
     def js_elems(self):
         return self.tree.findall('script')

--- a/compressor/templatetags/compress.py
+++ b/compressor/templatetags/compress.py
@@ -35,7 +35,7 @@ class CompressorMixin(object):
 
     def get_compressor(self, context, kind):
         return self.compressor_cls(kind,
-            content=self.get_original_content(context), context=context)
+                                   content=self.get_original_content(context), context=context)
 
     def debug_mode(self, context):
         if settings.COMPRESS_DEBUG_TOGGLE:
@@ -68,8 +68,8 @@ class CompressorMixin(object):
                 return offline_manifest[key]
             else:
                 raise OfflineGenerationError('You have offline compression '
-                    'enabled but key "%s" is missing from offline manifest. '
-                    'You may need to run "python manage.py compress".' % key)
+                                             'enabled but key "%s" is missing from offline manifest. '
+                                             'You may need to run "python manage.py compress".' % key)
 
     def render_cached(self, compressor, kind, mode, forced=False):
         """
@@ -92,7 +92,7 @@ class CompressorMixin(object):
         # Take a shortcut if we really don't have anything to do
         if ((not settings.COMPRESS_ENABLED and
                 not settings.COMPRESS_PRECOMPILERS)
-                    and not forced):
+                and not forced):
             return self.get_original_content(context)
 
         context['compressed'] = {'name': getattr(self, 'name', None)}

--- a/compressor/tests/precompiler.py
+++ b/compressor/tests/precompiler.py
@@ -7,11 +7,11 @@ import sys
 def main():
     p = optparse.OptionParser()
     p.add_option('-f', '--file', action="store",
-                type="string", dest="filename",
-                help="File to read from, defaults to stdin", default=None)
+                 type="string", dest="filename",
+                 help="File to read from, defaults to stdin", default=None)
     p.add_option('-o', '--output', action="store",
-                type="string", dest="outfile",
-                help="File to write to, defaults to stdout", default=None)
+                 type="string", dest="outfile",
+                 help="File to write to, defaults to stdout", default=None)
 
     options, arguments = p.parse_args()
 

--- a/compressor/tests/test_base.py
+++ b/compressor/tests/test_base.py
@@ -62,7 +62,7 @@ class CompressorTestCase(TestCase):
         is_date = re.compile(r'^\d{10}[\.\d]+$')
         for date in self.css_node.mtimes:
             self.assertTrue(is_date.match(str(float(date))),
-                "mtimes is returning something that doesn't look like a date: %s" % date)
+                            "mtimes is returning something that doesn't look like a date: %s" % date)
 
     def test_css_return_if_off(self):
         settings.COMPRESS_ENABLED = False
@@ -71,7 +71,7 @@ class CompressorTestCase(TestCase):
     def test_cachekey(self):
         is_cachekey = re.compile(r'\w{12}')
         self.assertTrue(is_cachekey.match(self.css_node.cachekey),
-            "cachekey is returning something that doesn't look like r'\w{12}'")
+                        "cachekey is returning something that doesn't look like r'\w{12}'")
 
     def test_css_return_if_on(self):
         output = css_tag('/media/CACHE/css/e41ba2cc6982.css')

--- a/compressor/tests/test_filters.py
+++ b/compressor/tests/test_filters.py
@@ -171,7 +171,7 @@ p { background: url('/media/img/python.png?%(hash1)s'); }
 p { background: url('/media/img/python.png?%(hash1)s'); }
 p { filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(src='/media/img/python.png?%(hash1)s'); }
 """ % hash_dict,
-               u"""\
+                         u"""\
 p { background: url('/media/img/add.png?%(hash2)s'); }
 p { background: url('/media/img/add.png?%(hash2)s'); }
 p { background: url('/media/img/add.png?%(hash2)s'); }

--- a/compressor/tests/test_jinja2ext.py
+++ b/compressor/tests/test_jinja2ext.py
@@ -29,15 +29,15 @@ class TestJinja2CompressorExtension(TestCase):
 
     def test_error_raised_if_no_arguments_given(self):
         self.assertRaises(jinja2.exceptions.TemplateSyntaxError,
-            self.env.from_string, '{% compress %}Foobar{% endcompress %}')
+                          self.env.from_string, '{% compress %}Foobar{% endcompress %}')
 
     def test_error_raised_if_wrong_kind_given(self):
         self.assertRaises(jinja2.exceptions.TemplateSyntaxError,
-            self.env.from_string, '{% compress foo %}Foobar{% endcompress %}')
+                          self.env.from_string, '{% compress foo %}Foobar{% endcompress %}')
 
     def test_error_raised_if_wrong_mode_given(self):
         self.assertRaises(jinja2.exceptions.TemplateSyntaxError,
-            self.env.from_string, '{% compress css foo %}Foobar{% endcompress %}')
+                          self.env.from_string, '{% compress css foo %}Foobar{% endcompress %}')
 
     def test_compress_is_disabled(self):
         org_COMPRESS_ENABLED = settings.COMPRESS_ENABLED

--- a/compressor/tests/test_templatetags.py
+++ b/compressor/tests/test_templatetags.py
@@ -220,9 +220,9 @@ class PrecompilerTemplatetagTestCase(TestCase):
             {% endcompress %}"""
 
             out = '\n'.join([
-                    script(src="/media/CACHE/js/one.95cfb869eead.js"),
-                    script(scripttype="", src="/media/js/one.js"),
-                    script(src="/media/CACHE/js/one.81a2cd965815.js")])
+                script(src="/media/CACHE/js/one.95cfb869eead.js"),
+                script(scripttype="", src="/media/js/one.js"),
+                script(src="/media/CACHE/js/one.81a2cd965815.js")])
 
             self.assertEqual(out, render(template, self.context))
         finally:
@@ -240,8 +240,8 @@ class PrecompilerTemplatetagTestCase(TestCase):
             {% endcompress %}"""
 
             out = ''.join([
-                    '<link rel="stylesheet" type="text/css" href="/media/css/one.css" />',
-                    '<link rel="stylesheet" type="text/css" href="/media/css/two.css" />'])
+                '<link rel="stylesheet" type="text/css" href="/media/css/one.css" />',
+                '<link rel="stylesheet" type="text/css" href="/media/css/two.css" />'])
 
             self.assertEqual(out, render(template, self.context))
         finally:
@@ -260,9 +260,9 @@ class PrecompilerTemplatetagTestCase(TestCase):
             {% endcompress %}"""
 
             out = ''.join([
-                    '<link rel="stylesheet" type="text/css" href="/media/css/one.css" />',
-                    '<link rel="stylesheet" type="text/css" href="/media/css/two.css" />',
-                    '<link rel="stylesheet" href="/media/CACHE/css/test.c4f8a285c249.css" type="text/css" />'])
+                '<link rel="stylesheet" type="text/css" href="/media/css/one.css" />',
+                '<link rel="stylesheet" type="text/css" href="/media/css/two.css" />',
+                '<link rel="stylesheet" href="/media/CACHE/css/test.c4f8a285c249.css" type="text/css" />'])
             self.assertEqual(out, render(template, self.context))
         finally:
             settings.COMPRESS_ENABLED = self.old_enabled

--- a/compressor/utils/stringformat.py
+++ b/compressor/utils/stringformat.py
@@ -62,7 +62,7 @@ def _strformat(value, format_spec=""):
         pass
     try:
         if ((is_numeric and conversion == 's') or
-            (not is_integer and conversion in set('cdoxX'))):
+                (not is_integer and conversion in set('cdoxX'))):
             raise ValueError
         if conversion == 'c':
             conversion = 's'
@@ -246,7 +246,7 @@ def selftest():
     F = FormattableString
 
     assert F(u"{0:{width}.{precision}s}").format('hello world',
-             width=8, precision=5) == u'hello   '
+                                                 width=8, precision=5) == u'hello   '
 
     d = datetime.date(2010, 9, 7)
     assert F(u"The year is {0.year}").format(d) == u"The year is 2010"


### PR DESCRIPTION
A little annoying that builds started failing with no code changes, but here are updates required to pass the latest flake8 scrutiny.  Maybe freezing the version of flake8 in the requirements might be a good idea
