### PR TITLE
The yui compressor filter adds the `java -jar` automatically (as seen at...

### DIFF
--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -122,8 +122,7 @@ Backend settings
 
       .. attribute:: COMPRESS_YUI_BINARY
 
-         The YUI compressor filesystem path. Make sure to also prepend this
-         setting with ``java -jar`` if you use that kind of distribution.
+         The YUI compressor filesystem path.
 
       .. attribute:: COMPRESS_YUI_CSS_ARGUMENTS
 


### PR DESCRIPTION
... https://github.com/jezdez/django_compressor/blob/develop/compressor/filters/yui.py), this is not necessary.
