### PR TITLE
Support for modern webdev practices/technologies

### DIFF
--- a/compressor/base.py
+++ b/compressor/base.py
@@ -31,7 +31,7 @@ class Compressor(object):
     """
     type = None
 
-    def __init__(self, content=None, output_prefix=None, context=None, *args, **kwargs):
+    def __init__(self, content=None, output_prefix=None, context=None, opts=None, *args, **kwargs):
         self.content = content or ""
         self.output_prefix = output_prefix or "compressed"
         self.output_dir = settings.COMPRESS_OUTPUT_DIR.strip('/')
@@ -42,6 +42,7 @@ class Compressor(object):
         self.extra_context = {}
         self.all_mimetypes = dict(settings.COMPRESS_PRECOMPILERS)
         self.finders = staticfiles.finders
+        self.opts = opts or {}
 
     def split_contents(self):
         """
@@ -49,6 +50,32 @@ class Compressor(object):
         iterable with four values: kind, value, basename, element
         """
         raise NotImplementedError
+
+    def group_contents(self):
+        contents = []
+        groups = {}
+        for kind, value, basename, elems in self.split_contents():
+            attrs = self.parser.elem_attribs(elems[0])
+            charset = attrs.get("charset", self.charset)
+            mimetype = attrs.get("type", None)
+            if mimetype:
+                idx = groups.get(mimetype, -1)
+                if idx >= 0:
+                    # get the content of this elem if it's a file
+                    if kind == SOURCE_FILE:
+                        value = self.get_filecontent(value, charset)
+                    # if there is only 1 existing and it's a file, convert it too
+                    if len(contents[idx][3]) == 1 and contents[idx][0] == SOURCE_FILE:
+                        contents[idx][1] = self.get_filecontent(contents[idx][1], charset)
+                    contents[idx][0] = SOURCE_HUNK
+                    contents[idx][1] += value
+                    contents[idx][3].extend(elems)
+                else:
+                    groups[mimetype] = len(contents)
+                    contents.append([kind, value, smart_unicode(basename), elems])
+            else:
+                contents.append([kind, value, basename, elems])
+        return contents
 
     def get_template_name(self, mode):
         """
@@ -147,17 +174,21 @@ class Compressor(object):
         bunch of precompiled and/or rendered hunks.
         """
         enabled = settings.COMPRESS_ENABLED or forced
+        group_first = self.opts.get('group_first', 'false').lower() == 'true'
+        contents = group_first and self.group_contents() or self.split_contents()
 
-        for kind, value, basename, elem in self.split_contents():
+        for kind, value, basename, elems in contents:
             precompiled = False
-            attribs = self.parser.elem_attribs(elem)
+            # If it's a grouped set, they should all have the same charset and type
+            attribs = self.parser.elem_attribs(elems[0])
             charset = attribs.get("charset", self.charset)
             options = {
                 'method': METHOD_INPUT,
-                'elem': elem,
+                'elems': elems,
                 'kind': kind,
                 'basename': basename,
             }
+            options.update(self.opts)
 
             if kind == SOURCE_FILE:
                 options = dict(options, filename=value)
@@ -174,7 +205,7 @@ class Compressor(object):
                     value = self.handle_output(kind, value, forced=True, basename=basename)
                     yield smart_unicode(value, charset.lower())
                 else:
-                    yield self.parser.elem_str(elem)
+                    yield "\n".join([self.parser.elem_str(e) for e in elems])
 
     def filter_output(self, content):
         """
@@ -193,10 +224,10 @@ class Compressor(object):
             content.append(hunk)
         return content
 
-    def precompile(self, content, kind=None, elem=None, filename=None, **kwargs):
+    def precompile(self, content, kind=None, elems=None, filename=None, **kwargs):
         if not kind:
             return False, content
-        attrs = self.parser.elem_attribs(elem)
+        attrs = self.parser.elem_attribs(elems[0])
         mimetype = attrs.get("type", None)
         if mimetype:
             command = self.all_mimetypes.get(mimetype)

--- a/compressor/css.py
+++ b/compressor/css.py
@@ -4,9 +4,9 @@ from compressor.conf import settings
 
 class CssCompressor(Compressor):
 
-    def __init__(self, content=None, output_prefix="css", context=None):
+    def __init__(self, content=None, output_prefix="css", context=None, opts=None):
         super(CssCompressor, self).__init__(content=content,
-            output_prefix=output_prefix, context=context)
+            output_prefix=output_prefix, context=context, opts=opts)
         self.filters = list(settings.COMPRESS_CSS_FILTERS)
         self.type = output_prefix
 
@@ -21,9 +21,9 @@ class CssCompressor(Compressor):
             if elem_name == 'link' and elem_attribs['rel'].lower() == 'stylesheet':
                 basename = self.get_basename(elem_attribs['href'])
                 filename = self.get_filename(basename)
-                data = (SOURCE_FILE, filename, basename, elem)
+                data = (SOURCE_FILE, filename, basename, [elem])
             elif elem_name == 'style':
-                data = (SOURCE_HUNK, self.parser.elem_content(elem), None, elem)
+                data = (SOURCE_HUNK, self.parser.elem_content(elem), None, [elem])
             if data:
                 self.split_content.append(data)
                 media = elem_attribs.get('media', None)
@@ -34,7 +34,7 @@ class CssCompressor(Compressor):
                     self.media_nodes[-1][1].split_content.append(data)
                 else:
                     node = CssCompressor(content=self.parser.elem_str(elem),
-                                         context=self.context)
+                                         context=self.context, opts=self.opts)
                     node.split_content.append(data)
                     self.media_nodes.append((media, node))
         return self.split_content

--- a/compressor/js.py
+++ b/compressor/js.py
@@ -4,8 +4,8 @@ from compressor.base import Compressor, SOURCE_HUNK, SOURCE_FILE
 
 class JsCompressor(Compressor):
 
-    def __init__(self, content=None, output_prefix="js", context=None):
-        super(JsCompressor, self).__init__(content, output_prefix, context)
+    def __init__(self, content=None, output_prefix="js", context=None, opts=None):
+        super(JsCompressor, self).__init__(content, output_prefix, context, opts)
         self.filters = list(settings.COMPRESS_JS_FILTERS)
         self.type = output_prefix
 
@@ -17,9 +17,9 @@ class JsCompressor(Compressor):
             if 'src' in attribs:
                 basename = self.get_basename(attribs['src'])
                 filename = self.get_filename(basename)
-                content = (SOURCE_FILE, filename, basename, elem)
+                content = (SOURCE_FILE, filename, basename, [elem])
                 self.split_content.append(content)
             else:
                 content = self.parser.elem_content(elem)
-                self.split_content.append((SOURCE_HUNK, content, None, elem))
+                self.split_content.append((SOURCE_HUNK, content, None, [elem]))
         return self.split_content

--- a/compressor/tests/media/css/one.less
+++ b/compressor/tests/media/css/one.less
@@ -1,0 +1,1 @@
+body { background:#990; }

--- a/compressor/tests/media/css/two.less
+++ b/compressor/tests/media/css/two.less
@@ -1,0 +1,1 @@
+body { color:#fff; }

--- a/compressor/tests/media/js/two.coffee
+++ b/compressor/tests/media/js/two.coffee
@@ -1,0 +1,1 @@
+# this is a comment.

--- a/compressor/tests/test_base.py
+++ b/compressor/tests/test_base.py
@@ -46,7 +46,7 @@ class CompressorTestCase(TestCase):
             (SOURCE_FILE, os.path.join(settings.COMPRESS_ROOT, u'css', u'two.css'), u'css/two.css', u'<link rel="stylesheet" href="/media/css/two.css" type="text/css" />'),
         ]
         split = self.css_node.split_contents()
-        split = [(x[0], x[1], x[2], self.css_node.parser.elem_str(x[3])) for x in split]
+        split = [(x[0], x[1], x[2], self.css_node.parser.elem_str(x[3][0])) for x in split]
         self.assertEqual(out, split)
 
     def test_css_hunks(self):
@@ -83,7 +83,7 @@ class CompressorTestCase(TestCase):
             (SOURCE_HUNK, u'obj.value = "value";', None, '<script type="text/javascript">obj.value = "value";</script>'),
         ]
         split = self.js_node.split_contents()
-        split = [(x[0], x[1], x[2], self.js_node.parser.elem_str(x[3])) for x in split]
+        split = [(x[0], x[1], x[2], self.js_node.parser.elem_str(x[3][0])) for x in split]
         self.assertEqual(out, split)
 
     def test_js_hunks(self):
@@ -133,6 +133,73 @@ class CompressorTestCase(TestCase):
             self.assertEqual(output, JsCompressor(self.js).output())
         finally:
             settings.COMPRESS_OUTPUT_DIR = old_output_dir
+
+
+def make_elems_str(parser, elems):
+    return "".join([parser.elem_str(x) for x in elems])
+
+
+class CompressorGroupFirstTestCase(TestCase):
+    def setUp(self):
+        settings.COMPRESS_ENABLED = True
+        settings.COMPRESS_PRECOMPILERS = {}
+        self.css = """\
+<link rel="stylesheet" href="/media/css/one.css" type="text/css" />
+<style type="text/css">p { border:5px solid green;}</style>
+<link rel="stylesheet" href="/media/css/one.less" type="text/less" />
+<link rel="stylesheet" href="/media/css/two.less" type="text/less" />"""
+        self.css_node = CssCompressor(self.css)
+        self.css_node.opts = {'group_first': 'true'}
+
+        self.js = """\
+<script src="/media/js/one.js" type="text/javascript"></script>
+<script type="text/javascript">obj.value = "value";</script>
+<script src="/media/js/one.coffee" type="text/coffeescript"></script>
+<script src="/media/js/two.coffee" type="text/coffeescript"></script>"""
+        self.js_node = JsCompressor(self.js)
+
+    def test_css_group(self):
+        out = [
+            [SOURCE_HUNK,
+             u'body { background:#990; }p { border:5px solid green;}',
+             u'css/one.css',
+             u'<link rel="stylesheet" href="/media/css/one.css" type="text/css" /><style type="text/css">p { border:5px solid green;}</style>'],
+            [SOURCE_HUNK,
+             u'body { background:#990; }body { color:#fff; }',
+             u'css/one.less',
+             u'<link rel="stylesheet" href="/media/css/one.less" type="text/less" /><link rel="stylesheet" href="/media/css/two.less" type="text/less" />'],
+        ]
+        split = self.css_node.group_contents()
+        split = [[x[0], x[1], x[2], make_elems_str(self.css_node.parser, x[3])] for x in split]
+        self.assertEqual(out, split)
+
+    def test_css_single(self):
+        css_node = CssCompressor("""<link rel="stylesheet" href="/media/css/one.css" type="text/css" />""")
+        css_node.opts = {'group_first': 'true'}
+        out = [
+            [SOURCE_FILE,
+             os.path.join(settings.COMPRESS_ROOT, u'css', u'one.css'),
+             u'css/one.css',
+             u'<link rel="stylesheet" href="/media/css/one.css" type="text/css" />'],
+        ]
+        split = css_node.group_contents()
+        split = [[x[0], x[1], x[2], make_elems_str(self.css_node.parser, x[3])] for x in split]
+        self.assertEqual(out, split)
+
+    def test_js_group(self):
+        out = [
+            [SOURCE_HUNK,
+             u'obj = {};obj.value = "value";',
+             u'js/one.js',
+             '<script src="/media/js/one.js" type="text/javascript"></script><script type="text/javascript">obj.value = "value";</script>'],
+            [SOURCE_HUNK,
+             u'# this is a comment.\n# this is a comment.',
+             u'js/one.coffee',
+             '<script src="/media/js/one.coffee" type="text/coffeescript"></script><script src="/media/js/two.coffee" type="text/coffeescript"></script>'],
+        ]
+        split = self.js_node.group_contents()
+        split = [[x[0], x[1], x[2], make_elems_str(self.js_node.parser, x[3])] for x in split]
+        self.assertEqual(out, split)
 
 
 class CssMediaTestCase(TestCase):

--- a/compressor/tests/test_parsers.py
+++ b/compressor/tests/test_parsers.py
@@ -59,7 +59,7 @@ class Html5LibParserTests(ParserTestCase, CompressorTestCase):
             (SOURCE_FILE, os.path.join(settings.COMPRESS_ROOT, u'css', u'two.css'), u'css/two.css', u'<link href="/media/css/two.css" rel="stylesheet" type="text/css">'),
         ]
         split = self.css_node.split_contents()
-        split = [(x[0], x[1], x[2], self.css_node.parser.elem_str(x[3])) for x in split]
+        split = [(x[0], x[1], x[2], self.css_node.parser.elem_str(x[3][0])) for x in split]
         self.assertEqual(out, split)
 
     def test_js_split(self):
@@ -68,7 +68,7 @@ class Html5LibParserTests(ParserTestCase, CompressorTestCase):
             (SOURCE_HUNK, u'obj.value = "value";', None, u'<script type="text/javascript">obj.value = "value";</script>'),
         ]
         split = self.js_node.split_contents()
-        split = [(x[0], x[1], x[2], self.js_node.parser.elem_str(x[3])) for x in split]
+        split = [(x[0], x[1], x[2], self.js_node.parser.elem_str(x[3][0])) for x in split]
         self.assertEqual(out, split)
 
 Html5LibParserTests = skipIf(

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -6,7 +6,7 @@ Usage
 .. code-block:: django
 
     {% load compress %}
-    {% compress <js/css> [<file/inline> [block_name]] %}
+    {% compress js|css [file|inline] [as <block_name>] [<option>=<value>[ <option>=<value>...]] %}
     <html of inline or linked JS/CSS>
     {% endcompress %}
 
@@ -75,10 +75,9 @@ exception. If DEBUG is ``False`` these files will be silently stripped.
     :attr:`~django.conf.settings.COMPRESS_CACHE_BACKEND` and
     Django's `caching documentation`_).
 
-The compress template tag supports a second argument specifying the output
-mode and defaults to saving the result in a file. Alternatively you can
-pass '``inline``' to the template tag to return the content directly to the
-rendered page, e.g.:
+The compress template tag supports specifying the output mode and defaults
+to saving the result in a file. Alternatively, you can pass '``inline``' to
+the template tag to return the content directly to the rendered page, e.g.:
 
 .. code-block:: django
 
@@ -96,9 +95,46 @@ would be rendered something like::
     obj.value = "value";
     </script>
 
-The compress template tag also supports a third argument for naming the output
-of that particular compress tag.  This is then added to the context so you can
-access it in the `post_compress signal <signals>`.
+The compress template tag also supports naming the output of that particular
+compress tag, e.g.:
+
+.. code-block:: django
+
+    {% load compress %}
+
+    {% compress js as main_js %}
+    <script src="/static/js/one.js" type="text/javascript" charset="utf-8"></script>
+    <script type="text/javascript" charset="utf-8">obj.value = "value";</script>
+    {% endcompress %}
+
+This is then added to the context so you can access it in the `post_compress signal <signals>`.
+
+The compress template also supports passing any number of arbitrary keyword arguments.  These are
+passed to all the compressors and, when using the default compressor classes, all of the
+precompilers and filters, e.g.:
+
+.. code-block:: django
+
+    {% load compress %}
+
+    {% compress js foo=bar group_first=true %}
+    <script src="/static/js/one.js" type="text/javascript" charset="utf-8"></script>
+    <script type="text/javascript" charset="utf-8">obj.value = "value";</script>
+    {% endcompress %}
+
+The following options are currently used by django_compressor:
+
+group_first
+    If true, the django_compressor will concatenate files of like types before passing them to
+    precompilers and filters.  This could be used, for instance, to allow separately maintained
+    files to be processed together, as one might desire if they are maintaining a 'mixins.less'
+    separate from page-specific .less files
+
+deferred
+    If true, instead of rendering the result of the compress tag into the template, the content
+    will be added to the template context under the name specified by the 'as <name>' tag argument.
+    If no name is specified, the content will be rendered normally.  If the tag would have
+    rendered to a file, the url of that file is contained in the template variable.
 
 .. _memcached: http://memcached.org/
 .. _caching documentation: http://docs.djangoproject.com/en/1.2/topics/cache/#memcached


### PR DESCRIPTION
Okay here is a pull request that repackages and cleans up a couple earlier requests
### What's in this pull request
- Let tag arguments after kind (css|js) be specified in any order 
- Use more standard 'as <name>' syntax to name the code block
- Add ability to specify options in the tag
- Ability to group files before processing
- Ability to redirect tag output to template context variable

There are tests and documentation updates as well as the code changes
#### Tag Argument Order

There's not really any need to enforce a certain arrangement of arguments in the tag so let's just let people specify them however they want after the kind parameter.  So now all of these are valid:

```
{% compress js inline as main %}

{% compress js as main file %}

{% compress css group_first=true as base %}
```
#### Using 'as &lt;name>'

Lots of things in python and django use this syntax, so it would be nice to do so as well
#### Specifying options in the tag

Just like the `with` tag in django, you can specify an arbitrary number of keyword/value arguments to the tag.  These will get put into a dictionary and passed to the Compressor classes.  Also, the default compressors add these to the options that they pass the precompilers and filters.  One of the main motivations for this was to prepare for being able to specify that files should be grouped first before, say, lessc precompilation (as discussed in #30)  Currently supported options:
- group_first - if 'group_first=true' is specified, files of like type will be concatenated before being handed to precompilers/filters
- deferred - if 'deferred=true' is specified AND 'as <name>' is specified the results of the template tag are stored in a <name> template context variable
#### Concatenating files before processing (fixes #30)

As mentioned above, using the group_first=true tag options will concatenate files before processing.   This is useful for having django_compressor work for best practices like separate mixins.less and page.less files
#### Template context variable (fixes #249)

As mentioned above, using 'deferred=true' and 'as <name>" in the template tag will cause the output to be placed in a template context variable rather than rendered immediately. This is useful for capturing the results of the compression (the url) for use with asynchronous resource loaders (e.g. yepnope.js, require.js, etc.).  In fact, if the output mode is 'file', the 'deferred' option set the template variable to be just the compressed url (without 'script' tag).  If the mode is 'inline' the template variable just contains whatever the output would have been normally
