### PR TITLE
gargoyle ifswitch support

### DIFF
--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -291,6 +291,7 @@ class Command(NoArgsCommand):
         return count, results
 
     def get_nodelist(self, node):
+        # Check if node is an ```if``` switch with true and false branches
         if hasattr(node, 'nodelist_true') and hasattr(node, 'nodelist_false'):
             return node.nodelist_true + node.nodelist_false
         return getattr(node, "nodelist", [])


### PR DESCRIPTION
Gargolye has a SwitchNode `{ifswitch switch-name}...{else}...{endifswitch}` with properties `nodelist_true` and `nodelist_false` but not subclass of the standard django IfSwitch. Removing the check in the node traversal code for IfSwitch makes it work with gargoyle SwitchNode.
