### PR TITLE
Added test of "js inline" with non-ascii character

### DIFF
--- a/compressor/tests/test_offline.py
+++ b/compressor/tests/test_offline.py
@@ -236,3 +236,23 @@ class OfflineGenerationTestCase(OfflineTestCaseMixin, TestCase):
             self.assertTrue(isinstance(loaders[1], AppDirectoriesLoader))
         finally:
             settings.TEMPLATE_LOADERS = old_loaders
+
+
+class OfflineGenerationInlineNonAsciiTestCase(OfflineTestCaseMixin, TestCase):
+    templates_dir = "test_inline_non_ascii"
+
+    def setUp(self):
+        self.old_offline_context = settings.COMPRESS_OFFLINE_CONTEXT
+        settings.COMPRESS_OFFLINE_CONTEXT = {
+            'test_non_ascii_value': u'\u2014',
+        }
+        super(OfflineGenerationInlineNonAsciiTestCase, self).setUp()
+
+    def tearDown(self):
+        self.COMPRESS_OFFLINE_CONTEXT = self.old_offline_context
+        super(OfflineGenerationInlineNonAsciiTestCase, self).tearDown()
+
+    def test_offline(self):
+        count, result = CompressCommand().compress(log=self.log, verbosity=self.verbosity)
+        rendered_template = self.template.render(Context(settings.COMPRESS_OFFLINE_CONTEXT))
+        self.assertEqual(rendered_template, "".join(result) + "\n")

--- a/compressor/tests/test_templates/test_inline_non_ascii/test_compressor_offline.html
+++ b/compressor/tests/test_templates/test_inline_non_ascii/test_compressor_offline.html
@@ -1,0 +1,7 @@
+{% load compress %}{% spaceless %}
+
+{% compress js inline %}
+    <script type="text/javascript">
+        var value = '{{ test_non_ascii_value }}';
+    </script>
+{% endcompress %}{% endspaceless %}


### PR DESCRIPTION
Test reproduces `'ascii' codec can't encode character u'\u2014'` when using non-ascii characters in `{% compress js inline %}`.
