### PR TITLE
Fixed CompilerFilter to always output Unicode strings

### DIFF
--- a/compressor/filters/base.py
+++ b/compressor/filters/base.py
@@ -6,6 +6,7 @@ import subprocess
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.temp import NamedTemporaryFile
 from django.utils.importlib import import_module
+from django.utils.encoding import smart_unicode
 
 from compressor.conf import settings
 from compressor.exceptions import FilterError
@@ -142,4 +143,5 @@ class CompilerFilter(FilterBase):
             if self.outfile is not None:
                 filtered = self.outfile.read()
                 self.outfile.close()
-        return filtered
+
+        return smart_unicode(filtered)

--- a/compressor/tests/test_filters.py
+++ b/compressor/tests/test_filters.py
@@ -67,6 +67,11 @@ class PrecompilerTestCase(TestCase):
         compiler = CompilerFilter(content=self.content, filename=self.filename, command=command)
         self.assertEqual(u"body { color:#990; }%s" % os.linesep, compiler.input())
 
+    def test_precompiler_output_unicode(self):
+        command = '%s %s' % (sys.executable, self.test_precompiler)
+        compiler = CompilerFilter(content=self.content, filename=self.filename, command=command)
+        self.assertEqual(type(compiler.input()), unicode)
+
 
 class CssMinTestCase(TestCase):
     def test_cssmin_filter(self):


### PR DESCRIPTION
This fixes #311. 
