### PR TITLE
Smarter css absolute filter

### DIFF
--- a/compressor/filters/css_default.py
+++ b/compressor/filters/css_default.py
@@ -52,6 +52,8 @@ class CssAbsoluteFilter(FilterBase):
             local_path = local_path.replace(self.protocol + self.host, "", 1)
         # remove url fragment, if any
         local_path = local_path.rsplit("#", 1)[0]
+        # remove querystring, if any
+        local_path = local_path.rsplit("?", 1)[0]
         # Now, we just need to check if we can find
         # the path from COMPRESS_URL in our url
         if local_path.startswith(self.url_path):

--- a/compressor/tests/test_filters.py
+++ b/compressor/tests/test_filters.py
@@ -142,6 +142,24 @@ class CssAbsolutizingTestCase(TestCase):
         output = "p { background: url('%(url)simg/python.png?%(hash)s#foo') }" % params
         self.assertEqual(output, filter.input(filename=filename, basename='css/url/test.css'))
 
+    def test_css_absolute_filter_querystring(self):
+        filename = os.path.join(settings.COMPRESS_ROOT, 'css/url/test.css')
+        imagefilename = os.path.join(settings.COMPRESS_ROOT, 'img/python.png')
+        params = {
+            'url': settings.COMPRESS_URL,
+            'hash': self.hashing_func(imagefilename),
+        }
+        content = "p { background: url('../../img/python.png?foo') }"
+
+        output = "p { background: url('%(url)simg/python.png?foo&%(hash)s') }" % params
+        filter = CssAbsoluteFilter(content)
+        self.assertEqual(output, filter.input(filename=filename, basename='css/url/test.css'))
+        settings.COMPRESS_URL = params['url'] = 'http://media.example.com/'
+        filter = CssAbsoluteFilter(content)
+        filename = os.path.join(settings.COMPRESS_ROOT, 'css/url/test.css')
+        output = "p { background: url('%(url)simg/python.png?foo&%(hash)s') }" % params
+        self.assertEqual(output, filter.input(filename=filename, basename='css/url/test.css'))
+
     def test_css_absolute_filter_https(self):
         filename = os.path.join(settings.COMPRESS_ROOT, 'css/url/test.css')
         imagefilename = os.path.join(settings.COMPRESS_ROOT, 'img/python.png')


### PR DESCRIPTION
The `guess_filename` method of `CssAbsoluteFilter` wasn't smart about asset URLs with hash fragments or querystrings, and this caused such assets to never have cachebusting querystrings added.

I guess maybe some of this code could be rewritten to use urlparse, but I didn't go that route here, just added the minimum necessary smarts.
