### PR TITLE
Fix CSS Absolute Filter bug when working with remote files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+venv
 compressor/tests/static/CACHE
 compressor/tests/static/custom
 compressor/tests/static/js/066cd253eada.js

--- a/compressor/filters/css_default.py
+++ b/compressor/filters/css_default.py
@@ -24,8 +24,9 @@ class CssAbsoluteFilter(FilterBase):
     def input(self, filename=None, basename=None, **kwargs):
         if self.url.startswith(('http://', 'https://')):
             self.has_scheme = True
-        if filename is not None:
-            filename = os.path.normcase(os.path.abspath(filename))
+        if filename is None: # like inline css
+            return self.content
+        filename = os.path.normcase(os.path.abspath(filename))
         if (not self.has_scheme and not (filename and filename.startswith(self.root)) and
                 not self.find(basename)):
             return self.content

--- a/compressor/filters/css_default.py
+++ b/compressor/filters/css_default.py
@@ -22,15 +22,16 @@ class CssAbsoluteFilter(FilterBase):
         self.has_scheme = False
 
     def input(self, filename=None, basename=None, **kwargs):
+        if self.url.startswith(('http://', 'https://')):
+            self.has_scheme = True
         if filename is not None:
             filename = os.path.normcase(os.path.abspath(filename))
-        if (not (filename and filename.startswith(self.root)) and
+        if (not self.has_scheme and not (filename and filename.startswith(self.root)) and
                 not self.find(basename)):
             return self.content
         self.path = basename.replace(os.sep, '/')
         self.path = self.path.lstrip('/')
-        if self.url.startswith(('http://', 'https://')):
-            self.has_scheme = True
+        if self.has_scheme:
             parts = self.url.split('/')
             self.url = '/'.join(parts[2:])
             self.url_path = '/%s' % '/'.join(parts[3:])

--- a/compressor/filters/css_default.py
+++ b/compressor/filters/css_default.py
@@ -24,7 +24,7 @@ class CssAbsoluteFilter(FilterBase):
     def input(self, filename=None, basename=None, **kwargs):
         if self.url.startswith(('http://', 'https://')):
             self.has_scheme = True
-        if filename is None: # like inline css
+        if filename is None:  # like inline css
             return self.content
         filename = os.path.normcase(os.path.abspath(filename))
         if (not self.has_scheme and not (filename and filename.startswith(self.root)) and


### PR DESCRIPTION
Hi,

It seems to me that every time I tried to set my production app setting DEBUG to False, the css absolute filter wasn't applied. So after a little digging, I found that the condition

``` python
if (not (filename and filename.startswith(self.root)) and
        not self.find(basename)):
    return self.content
```

wasn't taking into account if the file wasn't stored on the server root path. 
Indeed, I was forced to set COMPRESS_ROOT equal to STATIC_ROOT (correct me if I'm wrong). Then STATIC_ROOT need to be a local path on the server and can't be a remote path to a S3 bucket.

So `filename` never starts with `this.root` value.

If I'm miss-understading the usual settings to work well with Amazon S3 assets tell me, I'm sure I'm not the first one to use this configuration.
