### PR TITLE
nodelist does not exist in jinja2ext

### DIFF
--- a/compressor/templatetags/compress.py
+++ b/compressor/templatetags/compress.py
@@ -62,7 +62,7 @@ class CompressorMixin(object):
         and return the result if given
         """
         if self.is_offline_compression_enabled(forced) and not forced:
-            key = get_offline_hexdigest(self.nodelist.render(context))
+            key = get_offline_hexdigest(self.get_original_content(context))
             offline_manifest = get_offline_manifest()
             if key in offline_manifest:
                 return offline_manifest[key]


### PR DESCRIPTION
I use jinja2/coffin and was getting an error about self.nodelist not existing when it tried to call render_offline. Updated the call to get_offline_hexdigest not to rely on self.nodelist existing.
