### PR TITLE
Adds working stylus call as an alternative to the precompilers.

### DIFF
--- a/compressor/conf.py
+++ b/compressor/conf.py
@@ -31,6 +31,7 @@ class CompressorConf(AppConf):
         # ('text/coffeescript', 'coffee --compile --stdio'),
         # ('text/less', 'lessc {infile} {outfile}'),
         # ('text/x-sass', 'sass {infile} {outfile}'),
+        # ('text/stylus', 'stylus < {infile} > {outfile}'),
         # ('text/x-scss', 'sass --scss {infile} {outfile}'),
     )
     CLOSURE_COMPILER_BINARY = 'java -jar compiler.jar'

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -226,6 +226,7 @@ Backend settings
             ('text/less', 'lessc {infile} {outfile}'),
             ('text/x-sass', 'sass {infile} {outfile}'),
             ('text/x-scss', 'sass --scss {infile} {outfile}'),
+            ('text/stylus', 'stylus < {infile} > {outfile}'),
             ('text/foobar', 'path.to.MyPrecompilerFilter'),
         )
 


### PR DESCRIPTION
Hi,

since I had some troubles finding the correct stylus call for the precompiler I thought it might be nice to add it to the docs in case somebody else stumbles upon this.
