### PR TITLE
fix utf-8 bug in non english language

### DIFF
--- a/compressor/templatetags/compress.py
+++ b/compressor/templatetags/compress.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from django import template
 from django.core.exceptions import ImproperlyConfigured
 


### PR DESCRIPTION
if user have inline js with utf-8 characters, we have unicode error in the first time execution
