### PR TITLE
DeprecationWarning: django.utils.hashcompat is deprecated; use hashlib instead

### DIFF
--- a/compressor/cache.py
+++ b/compressor/cache.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 import socket
 import time
@@ -7,7 +8,6 @@ from django.core.files.base import ContentFile
 from django.utils import simplejson
 from django.utils.encoding import smart_str
 from django.utils.functional import SimpleLazyObject
-from django.utils.hashcompat import md5_constructor
 from django.utils.importlib import import_module
 
 from compressor.conf import settings
@@ -18,7 +18,7 @@ _cachekey_func = None
 
 
 def get_hexdigest(plaintext, length=None):
-    digest = md5_constructor(smart_str(plaintext)).hexdigest()
+    digest = hashlib.md5(smart_str(plaintext)).hexdigest()
     if length:
         return digest[:length]
     return digest


### PR DESCRIPTION
DeprecationWarning: django.utils.hashcompat is deprecated; use hashlib instead

https://github.com/django/django/blob/master/django/utils/hashcompat.py
