### PR TITLE
Add caching to CompilerFilter to not re-compile unchanged files

### DIFF
--- a/compressor/base.py
+++ b/compressor/base.py
@@ -15,7 +15,7 @@ from compressor.cache import get_hexdigest, get_mtime
 from compressor.conf import settings
 from compressor.exceptions import (CompressorError, UncompressableFileError,
         FilterDoesNotExist)
-from compressor.filters import CompilerFilter
+from compressor.filters import CachedCompilerFilter
 from compressor.storage import default_storage, compressor_file_storage
 from compressor.signals import post_compress
 from compressor.utils import get_class, get_mod_func, staticfiles
@@ -212,8 +212,8 @@ class Compressor(object):
                 try:
                     mod = import_module(mod_name)
                 except ImportError:
-                    return True, CompilerFilter(content, filter_type=self.type,
-                            command=filter_or_command, filename=filename).input(
+                    return True, CachedCompilerFilter(content=content, filter_type=self.type,
+                            command=filter_or_command, filename=filename, mimetype=mimetype).input(
                                 **kwargs)
                 try:
                     precompiler_class = getattr(mod, cls_name)

--- a/compressor/cache.py
+++ b/compressor/cache.py
@@ -126,6 +126,10 @@ def get_hashed_content(filename, length=12):
     return get_hexdigest(content, length)
 
 
+def get_precompiler_cachekey(command, contents):
+    return hashlib.sha1('precompiler.%s.%s' % (command, contents)).hexdigest()
+
+
 def cache_get(key):
     packed_val = cache.get(key)
     if packed_val is None:

--- a/compressor/conf.py
+++ b/compressor/conf.py
@@ -34,6 +34,7 @@ class CompressorConf(AppConf):
         # ('text/stylus', 'stylus < {infile} > {outfile}'),
         # ('text/x-scss', 'sass --scss {infile} {outfile}'),
     )
+    CACHEABLE_PRECOMPILERS = ()
     CLOSURE_COMPILER_BINARY = 'java -jar compiler.jar'
     CLOSURE_COMPILER_ARGUMENTS = ''
     CSSTIDY_BINARY = 'csstidy'

--- a/compressor/filters/__init__.py
+++ b/compressor/filters/__init__.py
@@ -1,3 +1,3 @@
 # flake8: noqa
 from compressor.filters.base import (FilterBase, CallbackOutputFilter,
-                                     CompilerFilter, FilterError)
+                                     CompilerFilter, CachedCompilerFilter, FilterError)

--- a/compressor/filters/base.py
+++ b/compressor/filters/base.py
@@ -1,22 +1,19 @@
 from __future__ import absolute_import
 import os
-import hashlib
 import logging
 import subprocess
 
-from django.core.cache import get_cache
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.temp import NamedTemporaryFile
 from django.utils.importlib import import_module
 
+from compressor.cache import cache, get_precompiler_cachekey
 from compressor.conf import settings
 from compressor.exceptions import FilterError
 from compressor.utils import get_mod_func
 from compressor.utils.stringformat import FormattableString as fstr
 
 logger = logging.getLogger("compressor.filters")
-
-cache = get_cache(settings.COMPRESS_CACHE_BACKEND)
 
 
 class FilterBase(object):
@@ -99,10 +96,6 @@ class CompilerFilter(FilterBase):
         self.infile, self.outfile = None, None
 
     def input(self, **kwargs):
-        content_hash = hashlib.sha1(self.command + self.content.encode('utf8')).hexdigest()
-        data = cache.get(content_hash)
-        if data:
-            return data
         options = dict(self.options)
         if self.infile is None:
             if "{infile}" in self.command:
@@ -150,5 +143,26 @@ class CompilerFilter(FilterBase):
             if self.outfile is not None:
                 filtered = self.outfile.read()
                 self.outfile.close()
-        cache.set(content_hash, filtered, settings.COMPRESS_REBUILD_TIMEOUT)
         return filtered
+
+
+class CachedCompilerFilter(CompilerFilter):
+
+    def __init__(self, mimetype, **kwargs):
+        self.mimetype = mimetype
+        super(CachedCompilerFilter, self).__init__(**kwargs)
+
+    def input(self, **kwargs):
+        if self.mimetype in settings.COMPRESS_CACHEABLE_PRECOMPILERS:
+            key = self.get_cache_key()
+            data = cache.get(key)
+            if data:
+                return data
+            filtered = super(CachedCompilerFilter, self).input(**kwargs)
+            cache.set(key, filtered, settings.COMPRESS_REBUILD_TIMEOUT)
+            return filtered
+        else:
+            return super(CachedCompilerFilter, self).input(**kwargs)
+
+    def get_cache_key(self):
+        return get_precompiler_cachekey(self.command, self.content.encode('utf8'))

--- a/compressor/filters/base.py
+++ b/compressor/filters/base.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import
 import os
+import hashlib
 import logging
 import subprocess
 
+from django.core.cache import get_cache
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.temp import NamedTemporaryFile
 from django.utils.importlib import import_module
@@ -13,6 +15,8 @@ from compressor.utils import get_mod_func
 from compressor.utils.stringformat import FormattableString as fstr
 
 logger = logging.getLogger("compressor.filters")
+
+cache = get_cache(settings.COMPRESS_CACHE_BACKEND)
 
 
 class FilterBase(object):
@@ -95,6 +99,10 @@ class CompilerFilter(FilterBase):
         self.infile, self.outfile = None, None
 
     def input(self, **kwargs):
+        content_hash = hashlib.sha1(self.command + self.content.encode('utf8')).hexdigest()
+        data = cache.get(content_hash)
+        if data:
+            return data
         options = dict(self.options)
         if self.infile is None:
             if "{infile}" in self.command:
@@ -142,4 +150,5 @@ class CompilerFilter(FilterBase):
             if self.outfile is not None:
                 filtered = self.outfile.read()
                 self.outfile.close()
+        cache.set(content_hash, filtered, settings.COMPRESS_REBUILD_TIMEOUT)
         return filtered

--- a/compressor/tests/test_filters.py
+++ b/compressor/tests/test_filters.py
@@ -9,7 +9,7 @@ from compressor.cache import get_hashed_mtime, get_hashed_content
 from compressor.conf import settings
 from compressor.css import CssCompressor
 from compressor.utils import find_command
-from compressor.filters.base import CompilerFilter
+from compressor.filters.base import CompilerFilter, CachedCompilerFilter
 from compressor.filters.cssmin import CSSMinFilter
 from compressor.filters.css_default import CssAbsoluteFilter
 from compressor.filters.template import TemplateFilter
@@ -41,6 +41,7 @@ class PrecompilerTestCase(TestCase):
         with open(self.filename) as f:
             self.content = f.read()
         self.test_precompiler = os.path.join(test_dir, 'precompiler.py')
+        settings.COMPRESS_CACHEABLE_PRECOMPILERS = ('text/css',)
 
     def test_precompiler_infile_outfile(self):
         command = '%s %s -f {infile} -o {outfile}' % (sys.executable, self.test_precompiler)
@@ -69,18 +70,28 @@ class PrecompilerTestCase(TestCase):
 
     def test_precompiler_cache(self):
         command = '%s %s -f {infile} -o {outfile}' % (sys.executable, self.test_precompiler)
-        compiler = CompilerFilter(content=self.content, filename=self.filename, command=command)
+        compiler = CachedCompilerFilter(content=self.content, filename=self.filename, command=command, mimetype='text/css')
         self.assertEqual(u"body { color:#990; }", compiler.input())
         # We tell whether the precompiler actually ran by inspecting compiler.infile. If not None, the compiler had to
         # write the input out to the file for the external command. If None, it was in the cache and thus skipped.
         self.assertIsNotNone(compiler.infile)  # Not cached
 
-        compiler = CompilerFilter(content=self.content, filename=self.filename, command=command)
+        compiler = CachedCompilerFilter(content=self.content, filename=self.filename, command=command, mimetype='text/css')
         self.assertEqual(u"body { color:#990; }", compiler.input())
         self.assertIsNone(compiler.infile)  # Cached
 
         self.content += ' '  # Invalidate cache by slightly changing content
-        compiler = CompilerFilter(content=self.content, filename=self.filename, command=command)
+        compiler = CachedCompilerFilter(content=self.content, filename=self.filename, command=command, mimetype='text/css')
+        self.assertEqual(u"body { color:#990; }", compiler.input())
+        self.assertIsNotNone(compiler.infile)  # Not cached
+
+    def test_precompiler_not_cacheable(self):
+        command = '%s %s -f {infile} -o {outfile}' % (sys.executable, self.test_precompiler)
+        compiler = CachedCompilerFilter(content=self.content, filename=self.filename, command=command, mimetype='text/different')
+        self.assertEqual(u"body { color:#990; }", compiler.input())
+        self.assertIsNotNone(compiler.infile)  # Not cached
+
+        compiler = CachedCompilerFilter(content=self.content, filename=self.filename, command=command, mimetype='text/different')
         self.assertEqual(u"body { color:#990; }", compiler.input())
         self.assertIsNotNone(compiler.infile)  # Not cached
 

--- a/compressor/tests/test_filters.py
+++ b/compressor/tests/test_filters.py
@@ -67,6 +67,23 @@ class PrecompilerTestCase(TestCase):
         compiler = CompilerFilter(content=self.content, filename=self.filename, command=command)
         self.assertEqual(u"body { color:#990; }%s" % os.linesep, compiler.input())
 
+    def test_precompiler_cache(self):
+        command = '%s %s -f {infile} -o {outfile}' % (sys.executable, self.test_precompiler)
+        compiler = CompilerFilter(content=self.content, filename=self.filename, command=command)
+        self.assertEqual(u"body { color:#990; }", compiler.input())
+        # We tell whether the precompiler actually ran by inspecting compiler.infile. If not None, the compiler had to
+        # write the input out to the file for the external command. If None, it was in the cache and thus skipped.
+        self.assertIsNotNone(compiler.infile)  # Not cached
+
+        compiler = CompilerFilter(content=self.content, filename=self.filename, command=command)
+        self.assertEqual(u"body { color:#990; }", compiler.input())
+        self.assertIsNone(compiler.infile)  # Cached
+
+        self.content += ' '  # Invalidate cache by slightly changing content
+        compiler = CompilerFilter(content=self.content, filename=self.filename, command=command)
+        self.assertEqual(u"body { color:#990; }", compiler.input())
+        self.assertIsNotNone(compiler.infile)  # Not cached
+
 
 class CssMinTestCase(TestCase):
     def test_cssmin_filter(self):

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -371,6 +371,19 @@ Caching settings
     :attr:`~django.conf.settings.COMPRESS_REBUILD_TIMEOUT` and
     :attr:`~django.conf.settings.COMPRESS_MINT_DELAY`.
 
+.. attribute:: COMPRESS_CACHEABLE_PRECOMPILERS
+
+    :Default: ``()``
+
+    An iterable of precompiler mimetypes as defined in :attr:`~django.conf.settings.COMPRESS_PRECOMPILERS`
+    for which the compiler output can be cached based solely on the contents
+    of the input file. This lets Django Compressor avoid recompiling unchanged
+    files. Caching is appropriate for compilers such as CoffeeScript where files
+    are compiled one-to-one, but not for compilers such as SASS that have an
+    ``import`` mechanism for including one file from another. If caching is enabled
+    for such a compiler, Django Compressor will not know to recompile files when a file
+    they import is modified.
+
 .. attribute:: COMPRESS_DEBUG_TOGGLE
 
     :Default: None


### PR DESCRIPTION
Currently django_compressor seems to re-run precompilers on each compression, even if files are completely unchanged. I haven't been able to stop this through any combination of existing caching options. In my large project, this has gotten to the point where it takes 10-15 seconds to load every page. 

This patch adds caching directly to the `CompilerFilter` class. Before running the compiler, it computes a hash of the input contents and checks the compressor cache for a cached output. If not found, the compiler runs as normal and the output is saved to the cache for next time. Thus, only files that have actually changed are recompiled. When used in combination with a file-based caching backend to persist across server restarts, this greatly speeds up development.