### PR TITLE
Use multiprocessing to speed up offline compression

### DIFF
--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -12,6 +12,11 @@ try:
 except ImportError:
     from StringIO import StringIO  # noqa
 
+try:
+    import multiprocessing
+except ImportError:
+    multiprocessing = None
+
 from django.core.management.base import  NoArgsCommand, CommandError
 from django.template import (Context, Template,
                              TemplateDoesNotExist, TemplateSyntaxError)
@@ -297,7 +302,7 @@ class Command(NoArgsCommand):
 
         max_processes = options.get('processes', 1)
 
-        if max_processes > 1:
+        if max_processes > 1 and multiprocessing is not None:
             processes = []
             results_queue = multiprocessing.Queue()
             error_queue = multiprocessing.Queue()

--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -1,5 +1,4 @@
 # flake8: noqa
-import multiprocessing
 import os
 import sys
 import time
@@ -329,6 +328,8 @@ class Command(NoArgsCommand):
                 results.append(result)
                 count += 1
         else:
+            if max_processes > 1:
+                log.write("Warning: multiprocessing was requested, but the multiprocessing module is not available.\n")
             for template, nodes in compressor_nodes.iteritems():
                 for key, result in perform_compress(template, nodes, log, verbosity):
                     offline_manifest[key] = result

--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -105,7 +105,7 @@ def patched_get_parent(self, context):
     return compiled_template
 
 
-def perform_compress(template, nodes, log, verbosity, results_queue):
+def perform_compress(template, nodes, log, verbosity, results_queue, error_queue):
     context = Context(settings.COMPRESS_OFFLINE_CONTEXT)
     template._log = log
     template._log_verbosity = verbosity
@@ -126,8 +126,9 @@ def perform_compress(template, nodes, log, verbosity, results_queue):
         try:
             result = node.render(context, forced=True)
         except Exception, e:
-            raise CommandError("An error occured during rendering %s: "
-                               "%s" % (template.template_name, e))
+            error_queue.put(CommandError("An error occured during rendering %s: "
+                               "%s" % (template.template_name, e)))
+            return
         results_queue.put([key, result])
         context.pop()
 
@@ -288,15 +289,18 @@ class Command(NoArgsCommand):
         results = []
         count = 0
 
+        max_processes = options.get('processes', 1)
+
         processes = []
-        # We can't use a process pool because templates aren't pickleable. Instead we implement
-        # a simple one ourselves that doesn't reuse processes, but limits their count.
-        max_processes = options['processes']
         results_queue = multiprocessing.Queue()
+        error_queue = multiprocessing.Queue()
         for template, nodes in compressor_nodes.iteritems():
-            p = multiprocessing.Process(target=perform_compress, args=(template, nodes, log, verbosity, results_queue))
+            p = multiprocessing.Process(target=perform_compress, args=(template, nodes, log,
+                                                                       verbosity, results_queue, error_queue))
             p.start()
             processes.append(p)
+            # We can't use a process pool because templates aren't pickleable. Instead we implement
+            # a simple one ourselves that doesn't reuse processes, but limits their count.
             while len(processes) >= max_processes:
                 time.sleep(0.1)
                 for process in processes:
@@ -305,6 +309,8 @@ class Command(NoArgsCommand):
                         processes.remove(process)
         for p in processes:
             p.join()
+        while not error_queue.empty():
+            raise error_queue.get()
         while not results_queue.empty():
             key, result = results_queue.get()
             offline_manifest[key] = result


### PR DESCRIPTION
For large projects, offline compression starts to take a while because there are many templates with many files each to process. But since each template is compiled separately, we can use multiprocessing to compile them at the same time.

This patch adds an option `--processes` to the `compress` manager command to instruct it to use multiple processes.

I'm submitting this request before writing tests and documentation for the new behavior to see if this is something that you'd be interested in merging. If so, I'm happy to do both.