### PR TITLE
Leave alone fragment-only URLs.

### DIFF
--- a/compressor/filters/css_default.py
+++ b/compressor/filters/css_default.py
@@ -91,7 +91,9 @@ class CssAbsoluteFilter(FilterBase):
     def _converter(self, matchobj, group, template):
         url = matchobj.group(group)
         url = url.strip(' \'"')
-        if url.startswith(SCHEMES):
+        if url.startswith('#'):
+            return "url('%s')" % url
+        elif url.startswith(SCHEMES):
             return "url('%s')" % self.add_suffix(url)
         full_url = posixpath.normpath('/'.join([str(self.directory_name),
                                                 url]))

--- a/compressor/tests/test_filters.py
+++ b/compressor/tests/test_filters.py
@@ -142,6 +142,16 @@ class CssAbsolutizingTestCase(TestCase):
         output = "p { background: url('%(url)simg/python.png?%(hash)s#foo') }" % params
         self.assertEqual(output, filter.input(filename=filename, basename='css/url/test.css'))
 
+    def test_css_absolute_filter_only_url_fragment(self):
+        filename = os.path.join(settings.COMPRESS_ROOT, 'css/url/test.css')
+        content = "p { background: url('#foo') }"
+        filter = CssAbsoluteFilter(content)
+        self.assertEqual(content, filter.input(filename=filename, basename='css/url/test.css'))
+        settings.COMPRESS_URL = 'http://media.example.com/'
+        filter = CssAbsoluteFilter(content)
+        filename = os.path.join(settings.COMPRESS_ROOT, 'css/url/test.css')
+        self.assertEqual(content, filter.input(filename=filename, basename='css/url/test.css'))
+
     def test_css_absolute_filter_querystring(self):
         filename = os.path.join(settings.COMPRESS_ROOT, 'css/url/test.css')
         imagefilename = os.path.join(settings.COMPRESS_ROOT, 'img/python.png')


### PR DESCRIPTION
Without this change, mangling such URLs produces invalid results.
