### PR TITLE
Stop calling fsync in CompilerFilter

### DIFF
--- a/compressor/filters/base.py
+++ b/compressor/filters/base.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-import os
 import logging
 import subprocess
 
@@ -102,7 +101,6 @@ class CompilerFilter(FilterBase):
                     self.infile = NamedTemporaryFile(mode="w")
                     self.infile.write(self.content.encode('utf8'))
                     self.infile.flush()
-                    os.fsync(self.infile)
                     options["infile"] = self.infile.name
                 else:
                     self.infile = open(self.filename)


### PR DESCRIPTION
`self.infile.flush()` is sufficient to ensure that the input is flushed from the Python process to the filesystem.  We were also calling `os.fsync(self.infile)`, which flushes the file to disk.  This is overly conservative for a temporary file.

On my system this change saves ~50 ms per filter execution.
