### PR TITLE
Clarifying default for COMPRESS_CACHE_BACKEND

### DIFF
--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -334,7 +334,7 @@ Caching settings
 
 .. attribute:: COMPRESS_CACHE_BACKEND
 
-    :Default: ``"default"`` or ``CACHE_BACKEND``
+    :Default: ``CACHES["default"]`` or ``CACHE_BACKEND``
 
     The backend to use for caching, in case you want to use a different cache
     backend for Django Compressor.


### PR DESCRIPTION
It looks more clear to me to say that COMPRESS_CACHE_BACKEND's default is CACHES['default'] instead of just 'default'. Please, accept the pull request if you agree.
