### PR TITLE
Encode compiled content when writing it w/o compression

### DIFF
--- a/compressor/base.py
+++ b/compressor/base.py
@@ -271,7 +271,7 @@ class Compressor(object):
         """
         new_filepath = self.get_filepath(content, basename=basename)
         if not self.storage.exists(new_filepath) or forced:
-            self.storage.save(new_filepath, ContentFile(content))
+            self.storage.save(new_filepath, ContentFile(content.encode('utf8')))
         url = mark_safe(self.storage.url(new_filepath))
         return self.render_output(mode, {"url": url})
 

--- a/compressor/base.py
+++ b/compressor/base.py
@@ -271,7 +271,9 @@ class Compressor(object):
         """
         new_filepath = self.get_filepath(content, basename=basename)
         if not self.storage.exists(new_filepath) or forced:
-            self.storage.save(new_filepath, ContentFile(content.encode('utf8')))
+            if isinstance(content, unicode):
+                content = content.encode('utf8')
+            self.storage.save(new_filepath, ContentFile(content))
         url = mark_safe(self.storage.url(new_filepath))
         return self.render_output(mode, {"url": url})
 


### PR DESCRIPTION
When COMPRESS_ENABLE=False and CSS or JS is sent through a precompiler,
the resulting file output appears to be encoded using UTF-32.