### PR TITLE
Compass suport

### DIFF
--- a/compressor/filters/base.py
+++ b/compressor/filters/base.py
@@ -11,6 +11,7 @@ from compressor.conf import settings
 from compressor.exceptions import FilterError
 from compressor.utils import get_mod_func
 from compressor.utils.stringformat import FormattableString as fstr
+from compressor.utils.apppath import get_app_path_for_filepath
 
 logger = logging.getLogger("compressor.filters")
 
@@ -77,11 +78,14 @@ class CompilerFilter(FilterBase):
 
     def __init__(self, content, command=None, *args, **kwargs):
         super(CompilerFilter, self).__init__(content, *args, **kwargs)
-        self.cwd = None
         if command:
             self.command = command
         if self.command is None:
             raise FilterError("Required attribute 'command' not given")
+        if self.filename is not None:
+            self.cwd = get_app_path_for_filepath(self.filename)
+        else:
+            self.cwd = None
         if isinstance(self.options, dict):
             new_options = ()
             for item in kwargs.iteritems():

--- a/compressor/utils/apppath.py
+++ b/compressor/utils/apppath.py
@@ -12,31 +12,55 @@ def __get_app_paths():
 
     return app_paths
 
-def __get_root_paths():
-    root_paths = set()
-    root_paths.add(settings.STATIC_ROOT)
-    for path in settings.STATICFILES_DIRS:
-        root_paths.add(path)
-    return root_paths
-
 __app_paths = __get_app_paths()
-__root_paths = __get_root_paths()
+
+def search_in_apps(file):
+    try:
+        file_path = AppDirectoriesFinder().find(file)
+        if len(file_path) > 0:
+            if isinstance(file_path, list):
+                file_path = file_path[0]
+            return file_path
+        return None
+    except:
+        return None
+
+def search_in_dirs(file):
+    for dir in settings.STATICFILES_DIRS:
+        path = os.path.join(dir, file)
+        if os.path.isfile(path):
+            return os.path.dirname(dir)
+    return None
+
+def get_filename(dir, full_path):
+    file = full_path.replace(dir, '')
+    if file[:1] == '/':
+        file = file[1:]
+    return file
 
 def get_app_path_for_filepath(file_path):
-    for path in __root_paths:
-        if file_path.startswith(path):
-            file = file_path.replace(path, '')
-            if file[:1] == '/':
-                file = file[1:]
-            try:
-                file_path = AppDirectoriesFinder().find(file)
-                if len(file_path) == 0:
-                    return os.path.dirname(path)
-            except:
-                return None
-    for path in __app_paths:
-        if file_path.startswith(path):
-            return path
-    return None
+    if file_path.startswith(settings.STATIC_ROOT):
+        file = get_filename(settings.STATIC_ROOT, file_path)
+        file_path = search_in_apps(file)
+        if file_path is None:
+            path = search_in_dirs(file)
+            if path is not None:
+                return path
+    else:
+        for dir in settings.STATICFILES_DIRS:
+            if file_path.startswith(dir):
+                file = get_filename(dir, file_path)
+                path = search_in_apps(file)
+                if path is None:
+                    return search_in_dirs(file)
+                else:
+                    file_path = path
+                break
+
+    if file_path is not None:
+        for path in __app_paths:
+            if file_path.startswith(path):
+                return path
+    return settings.STATIC_ROOT
 
 

--- a/compressor/utils/apppath.py
+++ b/compressor/utils/apppath.py
@@ -30,6 +30,8 @@ def get_app_path_for_filepath(file_path):
                 file = file[1:]
             try:
                 file_path = AppDirectoriesFinder().find(file)
+                if len(file_path) == 0:
+                    return os.path.dirname(path)
             except:
                 return None
     for path in __app_paths:

--- a/compressor/utils/apppath.py
+++ b/compressor/utils/apppath.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+import os
+from django.conf import settings
+
+__app_paths = None
+
+def __get_app_paths():
+    if __app_paths is None:
+	app_paths = []
+        for app in settings.INSTALLED_APPS:
+            module = __import__(app)
+            app_paths.append(dir(module))
+	__app_paths = app_paths
+    return __app_paths
+
+__get_app_paths()
+
+def get_app_path_for_filepath(file_path):
+    app_paths = __get_app_paths()
+    for path in app_paths:
+        if file_path.startswith(path):
+            return path
+    return None
+

--- a/compressor/utils/apppath.py
+++ b/compressor/utils/apppath.py
@@ -7,7 +7,7 @@ def __get_app_paths():
     app_paths = set()
     for app in settings.INSTALLED_APPS:
         module = __import__(app)
-        app_paths.add(module.__path__[0])
+        app_paths.add(os.path.abspath(module.__path__[0]))
 
     return app_paths
 

--- a/compressor/utils/apppath.py
+++ b/compressor/utils/apppath.py
@@ -1,19 +1,39 @@
 # -*- coding: utf-8 -*-
 import os
 from django.conf import settings
+from django.contrib.staticfiles.finders import AppDirectoriesFinder
 
 def __get_app_paths():
     app_paths = set()
     for app in settings.INSTALLED_APPS:
         module = __import__(app)
         app_paths.add(module.__path__[0])
+
     return app_paths
 
+def __get_root_paths():
+    root_paths = set()
+    root_paths.add(settings.STATIC_ROOT)
+    for path in settings.STATICFILES_DIRS:
+        root_paths.add(path)
+    return root_paths
+
 __app_paths = __get_app_paths()
+__root_paths = __get_root_paths()
 
 def get_app_path_for_filepath(file_path):
+    for path in __root_paths:
+        if file_path.startswith(path):
+            file = file_path.replace(path, '')
+            if file[:1] == '/':
+                file = file[1:]
+            try:
+                file_path = AppDirectoriesFinder().find(file)
+            except:
+                return None
     for path in __app_paths:
         if file_path.startswith(path):
             return path
     return None
+
 

--- a/compressor/utils/apppath.py
+++ b/compressor/utils/apppath.py
@@ -2,11 +2,12 @@
 import os
 from django.conf import settings
 from django.contrib.staticfiles.finders import AppDirectoriesFinder
+import importlib
 
 def __get_app_paths():
     app_paths = set()
     for app in settings.INSTALLED_APPS:
-        module = __import__(app)
+        module = importlib.import_module(app)
         app_paths.add(os.path.abspath(module.__path__[0]))
 
     return app_paths

--- a/compressor/utils/apppath.py
+++ b/compressor/utils/apppath.py
@@ -2,22 +2,17 @@
 import os
 from django.conf import settings
 
-__app_paths = None
-
 def __get_app_paths():
-    if __app_paths is None:
-	app_paths = []
-        for app in settings.INSTALLED_APPS:
-            module = __import__(app)
-            app_paths.append(dir(module))
-	__app_paths = app_paths
-    return __app_paths
+    app_paths = set()
+    for app in settings.INSTALLED_APPS:
+        module = __import__(app)
+        app_paths.add(module.__path__[0])
+    return app_paths
 
-__get_app_paths()
+__app_paths = __get_app_paths()
 
 def get_app_path_for_filepath(file_path):
-    app_paths = __get_app_paths()
-    for path in app_paths:
+    for path in __app_paths:
         if file_path.startswith(path):
             return path
     return None


### PR DESCRIPTION
Added support of compass config files.
Realization quick and dirty, but works. Main idea - change command directory to current app directory, so we can put config.rb to this dir.

So we can add to compress precompilers:
('text/x-sass', 'sass --compass -C {infile} {outfile}'),

And then put config.rb to app dir(if we need compass in this app) or in project directory if we need compass for project static folder