### PR TITLE
Don't raise an error if BeautifulSoup isn't installed

### DIFF
--- a/compressor/parser/lxml.py
+++ b/compressor/parser/lxml.py
@@ -29,7 +29,7 @@ class LxmlParser(ParserBase):
             try:
                 from lxml.html import soupparser
             except ImportError as err:
-                raise ImportError("Error while importing lxml: %s" % err)
+                soupparser = None
             except Exception as err:
                 raise ParserError("Error while initializing parser: %s" % err)
         else:


### PR DESCRIPTION
In the docs it says BeautifulSoup is an optional dependency:
http://django-compressor.readthedocs.org/en/latest/quickstart/#dependencies

I came across others having the issue of 'Error while importing lxml: No module named BeautifulSoup' while using Python 2:
https://github.com/jezdez/django_compressor/issues/261

This tiny patch lets you carry on without installing BeautifulSoup, just like Python 3 users, instead of raising an error. It makes it possible to just use lxml.
