### PR TITLE
add usedevelop to tox testenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ envlist =
     py26-1.4.X
 
 [testenv]
+usedevelop = true
 whitelist_externals = make
 downloadcache = {toxworkdir}/_download/
 commands =


### PR DESCRIPTION
this avoids the import missmatches and ensures tox tests run the same way travis tests do
