### PR TITLE
Allow compiller class to decide if the file needs to be precompiled

### DIFF
--- a/compressor/base.py
+++ b/compressor/base.py
@@ -190,6 +190,7 @@ class Compressor(object):
                 'kind': kind,
                 'basename': basename,
                 'charset': charset,
+                'enabled': enabled,
             }
 
             if kind == SOURCE_FILE:
@@ -261,6 +262,8 @@ class Compressor(object):
                     filter = precompiler_class(
                         content, attrs, filter_type=self.type, charset=charset,
                         filename=filename)
+                    if hasattr(filter, 'precompile'):
+                        return filter.precompile(**kwargs)
                     return True, filter.input(**kwargs)
 
         return False, content


### PR DESCRIPTION
It allow to write a precompiler class which will decide wherever that tag should be compiled or not, based on tag attributes and enabled setting.

It's useful if you wish to precompile require.js modules using django-compressor, the require.js script tag looks like:
`<script type="type/javascript" src="{{ STATIC_URL }}lib/require.js" data-main="{{ STATIC_URL }}module"></script>`

Here's the example precompiler class for type text/javascript which will only use r.js compiler when compression is enabled, when it's disabled it will render the `<script>` tag as it is in the template.

```
import os
from django.conf import settings


class Compiler(object):
    def __init__(self, content, *args, **kwargs):
        self.kwargs = kwargs
        self.args = args
        self.content = content.encode('utf-8')

    def input(self, **kwargs):
        path = self.args[0]['data-main'].replace(settings.STATIC_URL, '')
        require = self.args[0]['src'].replace(settings.STATIC_URL, '').replace('.js', '')
        tmpfile = 'tmpfile'
        command = 'r.js -o baseUrl=%s paths.requireLib=%s include=requireLib optimize=none name=%s out=%s;' % (os.path.join(settings.STATIC_ROOT, 'src-js'), require, path, tmpfile)
        os.system(command)
        file = open(tmpfile, 'r')
        self.content = file.read()
        os.unlink(tmpfile)
        return self.content

    def precompile(self, **kwargs):
        if self.args[0].get('data-main') and kwargs.get('enabled'):
            return True, self.input(**kwargs)
        return False, self.content
```
