### PR TITLE
Configure tox and requirements to test with django 1.6

### DIFF
--- a/compressor/test_settings.py
+++ b/compressor/test_settings.py
@@ -1,4 +1,5 @@
 import os
+import django
 
 TEST_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'tests')
 
@@ -27,7 +28,8 @@ TEMPLATE_DIRS = (
     os.path.join(TEST_DIR, 'test_templates'),
 )
 
-TEST_RUNNER = 'discover_runner.DiscoverRunner'
+if django.VERSION[:2] < (1, 6):
+    TEST_RUNNER = 'discover_runner.DiscoverRunner'
 
 SECRET_KEY = "iufoj=mibkpdz*%bob952x(%49rqgv8gg45k36kjcg76&-y5=!"
 

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,7 +1,8 @@
 flake8
-django-discover-runner
 coverage
 html5lib
 mock
 jinja2
 lxml
+BeautifulSoup
+unittest2

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [deps]
 two =
     flake8
-    django-discover-runner
     coverage
     html5lib
     mock
@@ -11,7 +10,6 @@ two =
     unittest2
 three =
     flake8
-    django-discover-runner
     coverage
     html5lib
     mock
@@ -21,6 +19,10 @@ three =
 
 [tox]
 envlist =
+    py33-1.6.X,
+    py32-1.6.X,
+    py27-1.6.X,
+    py26-1.6.X,
     py33-1.5.X,
     py32-1.5.X,
     py27-1.5.X,
@@ -30,44 +32,74 @@ envlist =
 
 [testenv]
 usedevelop = true
-whitelist_externals = make
+whitelist_externals = /usr/bin/make
 downloadcache = {toxworkdir}/_download/
 commands =
     django-admin.py --version
     make test
 
+[testenv:py33-1.6.X]
+basepython = python3.3
+deps =
+    Django>=1.6,<1.7
+    {[deps]three}
+
+[testenv:py32-1.6.X]
+basepython = python3.2
+deps =
+    Django>=1.6,<1.7
+    {[deps]three}
+
+[testenv:py27-1.6.X]
+basepython = python2.7
+deps =
+    Django>=1.6,<1.7
+    {[deps]two}
+
+[testenv:py26-1.6.X]
+basepython = python2.6
+deps =
+    Django>=1.6,<1.7
+    {[deps]two}
+
 [testenv:py33-1.5.X]
 basepython = python3.3
 deps =
     Django>=1.5,<1.6
+    django-discover-runner
     {[deps]three}
 
 [testenv:py32-1.5.X]
 basepython = python3.2
 deps =
     Django>=1.5,<1.6
+    django-discover-runner
     {[deps]three}
 
 [testenv:py27-1.5.X]
 basepython = python2.7
 deps =
     Django>=1.5,<1.6
+    django-discover-runner
     {[deps]two}
 
 [testenv:py26-1.5.X]
 basepython = python2.6
 deps =
     Django>=1.5,<1.6
+    django-discover-runner
     {[deps]two}
 
 [testenv:py27-1.4.X]
 basepython = python2.7
 deps =
     Django>=1.4,<1.5
+    django-discover-runner
     {[deps]two}
 
 [testenv:py26-1.4.X]
 basepython = python2.6
 deps =
     Django>=1.4,<1.5
+    django-discover-runner
     {[deps]two}


### PR DESCRIPTION
This adds django 1.6 to the tests.

My local `tox` is acting a little weird, so this is not 100% tested yet - `make testenv` + `make test` in a clean virtualenv work, though.
