### PR TITLE
Allow data-uri filter to handle external/protocol-relative references

### DIFF
--- a/compressor/filters/datauri.py
+++ b/compressor/filters/datauri.py
@@ -37,7 +37,7 @@ class DataUriFilter(FilterBase):
 
     def data_uri_converter(self, matchobj):
         url = matchobj.group(1).strip(' \'"')
-        if not url.startswith('data:'):
+        if not url.startswith('data:') and not url.startswith('//'):
             path = self.get_file_path(url)
             if os.stat(path).st_size <= settings.COMPRESS_DATA_URI_MAX_SIZE:
                 with open(path, 'rb') as file:


### PR DESCRIPTION
With the data-uri filter enabled, compressor fails to compress CSS that references external/protocol-relative URLs, such as appears in Zurb Foundation 5. 

Addresses #455
