### PR TITLE
-Fix: compare against six.string_types.

### DIFF
--- a/compressor/templatetags/compress.py
+++ b/compressor/templatetags/compress.py
@@ -108,7 +108,7 @@ class CompressorMixin(object):
             rendered_output = self.render_output(compressor, mode, forced=forced)
             if cache_key:
                 cache_set(cache_key, rendered_output)
-            assert isinstance(rendered_output, six.text_type)
+            assert isinstance(rendered_output, six.string_types)
             return rendered_output
         except Exception:
             if settings.DEBUG or forced:


### PR DESCRIPTION
six.text_type can throw errors if the result is an empty string in
python 2.7, where six.string_types will correctly detect it.

Mind, this should only occur when {% compress %} will yield no output (which is a rare case, but still).
