### PR TITLE
Tests fail with libxml-2.9.1

### DIFF
--- a/compressor/tests/test_base.py
+++ b/compressor/tests/test_base.py
@@ -71,6 +71,14 @@ class CompressorTestCase(SimpleTestCase):
         collapse = lambda x: re.sub(r'\n+', '\n', x).rstrip()
         self.assertEqual(collapse(a), collapse(b))
 
+    def assertEqualSplits(self, a, b):
+        """
+        assertEqual for splits, particularly ignoring the presence of
+        a trailing newline on the content.
+        """
+        mangle = lambda split: [(x[0], x[1], x[2], x[3].rstrip()) for x in split]
+        self.assertEqual(mangle(a), mangle(b))
+
     def test_css_split(self):
         out = [
             (
@@ -92,8 +100,8 @@ class CompressorTestCase(SimpleTestCase):
             ),
         ]
         split = self.css_node.split_contents()
-        split = [(x[0], x[1], x[2], self.css_node.parser.elem_str(x[3]).rstrip()) for x in split]
-        self.assertEqual(out, split)
+        split = [(x[0], x[1], x[2], self.css_node.parser.elem_str(x[3])) for x in split]
+        self.assertEqualSplits(split, out)
 
     def test_css_hunks(self):
         out = ['body { background:#990; }', 'p { border:5px solid green;}', 'body { color:#fff; }']
@@ -139,8 +147,8 @@ class CompressorTestCase(SimpleTestCase):
             ),
         ]
         split = self.js_node.split_contents()
-        split = [(x[0], x[1], x[2], self.js_node.parser.elem_str(x[3]).rstrip()) for x in split]
-        self.assertEqual(out, split)
+        split = [(x[0], x[1], x[2], self.js_node.parser.elem_str(x[3])) for x in split]
+        self.assertEqualSplits(split, out)
 
     def test_js_hunks(self):
         out = ['obj = {};', 'obj.value = "value";']


### PR DESCRIPTION
I'm finding that tests are failing on a fresh clone:

```
$ git clone django-compressor/django-compressor
$ cd django-compressor
$ mkvirtualenv compressor
$ workon compressor
$ pip install tox
$ tox -e py27-1.5.X
py27-1.5.X create: /home/aron/src/pp/django-compressor/.tox/py27-1.5.X
py27-1.5.X installdeps: Django>=1.5,<1.6, django-discover-runner, flake8, coverage, html5lib, mock, jinja2, lxml, BeautifulSoup, unittest2
py27-1.5.X develop-inst: /home/aron/src/pp/django-compressor
py27-1.5.X runtests: PYTHONHASHSEED='101664193'
py27-1.5.X runtests: commands[0] | django-admin.py --version
1.5.5
py27-1.5.X runtests: commands[1] | make test
flake8 compressor --ignore=E501,E128,E701,E261,E301,E126,E127
coverage run --branch --source=compressor `which django-admin.py` test --settings=compressor.test_settings compressor
Creating test database for alias 'default'...
..................................................................................................................................................................F.F......F.F...............................................................
======================================================================
FAIL: test_css_return_if_off (compressor.tests.test_parsers.LxmlParserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/aron/src/pp/django-compressor/compressor/tests/test_base.py", line 107, in test_css_return_if_off
    self.assertEqual(self.css, self.css_node.output())
AssertionError: u'<link rel="stylesheet" href="/static/css/one.css" type="text/css" />\n<style t [truncated]... != u'<link rel="stylesheet" href="/static/css/one.css" type="text/css" />\n\n<style [truncated]...
  <link rel="stylesheet" href="/static/css/one.css" type="text/css" />
+ 
  <style type="text/css">p { border:5px solid green;}</style>
+ 
  <link rel="stylesheet" href="/static/css/two.css" type="text/css" />

======================================================================
FAIL: test_css_split (compressor.tests.test_parsers.LxmlParserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/aron/src/pp/django-compressor/compressor/tests/test_base.py", line 88, in test_css_split
    self.assertEqual(out, split)
AssertionError: Lists differ: [(u'file', u'/home/aron/src/pp... != [(u'file', u'/home/aron/src/pp...

First differing element 0:
(u'file', u'/home/aron/src/pp/django-compressor/compressor/tests/static/css/one.css', u'css/one.css', u'<link rel="stylesheet" href="/static/css/one.css" type="text/css" />')
(u'file', u'/home/aron/src/pp/django-compressor/compressor/tests/static/css/one.css', u'css/one.css', u'<link rel="stylesheet" href="/static/css/one.css" type="text/css" />\n')

Diff is 811 characters long. Set self.maxDiff to None to see it.

======================================================================
FAIL: test_js_return_if_off (compressor.tests.test_parsers.LxmlParserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/aron/src/pp/django-compressor/.tox/py27-1.5.X/lib/python2.7/site-packages/django/test/utils.py", line 224, in inner
    return test_func(*args, **kwargs)
  File "/home/aron/src/pp/django-compressor/compressor/tests/test_base.py", line 157, in test_js_return_if_off
    self.assertEqual(self.js, self.js_node.output())
AssertionError: u'<script src="/static/js/one.js" type="text/javascript"></script>\n<script type [truncated]... != u'<script src="/static/js/one.js" type="text/javascript"></script>\n\n<script ty [truncated]...
  <script src="/static/js/one.js" type="text/javascript"></script>
+ 
  <script type="text/javascript">obj.value = "value";</script>

======================================================================
FAIL: test_js_split (compressor.tests.test_parsers.LxmlParserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/aron/src/pp/django-compressor/compressor/tests/test_base.py", line 135, in test_js_split
    self.assertEqual(out, split)
AssertionError: Lists differ: [(u'file', u'/home/aron/src/pp... != [(u'file', u'/home/aron/src/pp...

First differing element 0:
(u'file', u'/home/aron/src/pp/django-compressor/compressor/tests/static/js/one.js', u'js/one.js', u'<script src="/static/js/one.js" type="text/javascript"></script>')
(u'file', u'/home/aron/src/pp/django-compressor/compressor/tests/static/js/one.js', u'js/one.js', u'<script src="/static/js/one.js" type="text/javascript"></script>\n')

  [(u'file',
    u'/home/aron/src/pp/django-compressor/compressor/tests/static/js/one.js',
    u'js/one.js',
-   u'<script src="/static/js/one.js" type="text/javascript"></script>'),
+   u'<script src="/static/js/one.js" type="text/javascript"></script>\n'),
?                                                                     ++

   (u'inline',
    u'obj.value = "value";',
    None,
    u'<script type="text/javascript">obj.value = "value";</script>')]

----------------------------------------------------------------------
Ran 237 tests in 1.255s

FAILED (failures=4)
Destroying test database for alias 'default'...
make: *** [test] Error 1
ERROR: InvocationError: '/usr/bin/make test'
_________________________________________________________ summary __________________________________________________________
ERROR:   py27-1.5.X: commands failed
```
