### PR TITLE
Recommend lesscpy for text/less

### DIFF
--- a/compressor/conf.py
+++ b/compressor/conf.py
@@ -30,7 +30,7 @@ class CompressorConf(AppConf):
     JS_FILTERS = ['compressor.filters.jsmin.JSMinFilter']
     PRECOMPILERS = (
         # ('text/coffeescript', 'coffee --compile --stdio'),
-        # ('text/less', 'lessc {infile} {outfile}'),
+        # ('text/less', 'lesscpy {infile}'),
         # ('text/x-sass', 'sass {infile} {outfile}'),
         # ('text/stylus', 'stylus < {infile} > {outfile}'),
         # ('text/x-scss', 'sass --scss {infile} {outfile}'),

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -248,7 +248,7 @@ Backend settings
 
         COMPRESS_PRECOMPILERS = (
             ('text/coffeescript', 'coffee --compile --stdio'),
-            ('text/less', 'lessc {infile} {outfile}'),
+            ('text/less', 'lesscpy {infile}'),
             ('text/x-sass', 'sass {infile} {outfile}'),
             ('text/x-scss', 'sass --scss {infile} {outfile}'),
             ('text/stylus', 'stylus < {infile} > {outfile}'),


### PR DESCRIPTION
The nodejs based less.js includes heavy dependencies and is not available on all Linux distributions by default.  Using a pure-Python LESS compiler can be fetched from PyPI and thus better integrated into automated deployment and testing.

I guess this isn't optimal yet, but I'd like to make this a starting point for a discussion. Whether or not it makes sense to recommend a pure-Python solution by default and if that would allow for deeper integration (rather than just calling the binary).
