### PR TITLE
Remove unnecessary filename and existence checks in CssAbsoluteFilter

### DIFF
--- a/compressor/filters/css_default.py
+++ b/compressor/filters/css_default.py
@@ -5,7 +5,6 @@ import posixpath
 from compressor.cache import get_hashed_mtime, get_hashed_content
 from compressor.conf import settings
 from compressor.filters import FilterBase, FilterError
-from compressor.utils import staticfiles
 
 URL_PATTERN = re.compile(r'url\(([^\)]+)\)')
 SRC_PATTERN = re.compile(r'src=([\'"])(.+?)\1')
@@ -22,10 +21,7 @@ class CssAbsoluteFilter(FilterBase):
         self.has_scheme = False
 
     def input(self, filename=None, basename=None, **kwargs):
-        if filename is not None:
-            filename = os.path.normcase(os.path.abspath(filename))
-        if (not (filename and filename.startswith(self.root)) and
-                not self.find(basename)):
+        if not filename:
             return self.content
         self.path = basename.replace(os.sep, '/')
         self.path = self.path.lstrip('/')
@@ -39,10 +35,6 @@ class CssAbsoluteFilter(FilterBase):
         self.directory_name = '/'.join((self.url, os.path.dirname(self.path)))
         return SRC_PATTERN.sub(self.src_converter,
             URL_PATTERN.sub(self.url_converter, self.content))
-
-    def find(self, basename):
-        if settings.DEBUG and basename and staticfiles.finders:
-            return staticfiles.finders.find(basename)
 
     def guess_filename(self, url):
         local_path = url

--- a/compressor/tests/test_filters.py
+++ b/compressor/tests/test_filters.py
@@ -216,6 +216,21 @@ class CssAbsolutizingTestCase(TestCase):
         filter = CssAbsoluteFilter(content)
         self.assertEqual(output, filter.input(filename=filename, basename='css/url/test.css'))
 
+    def test_css_absolute_filter_filename_outside_compress_root(self):
+        filename = '/foo/bar/baz/test.css'
+        content = self.template % blankdict(url='../qux/')
+        params = blankdict({
+            'url': settings.COMPRESS_URL + 'bar/qux/',
+        })
+        output = self.template % params
+        filter = CssAbsoluteFilter(content)
+        self.assertEqual(output, filter.input(filename=filename, basename='bar/baz/test.css'))
+        settings.COMPRESS_URL = 'https://static.example.com/'
+        params['url'] = settings.COMPRESS_URL + 'bar/qux/'
+        output = self.template % params
+        filter = CssAbsoluteFilter(content)
+        self.assertEqual(output, filter.input(filename=filename, basename='bar/baz/test.css'))
+
     def test_css_hunks(self):
         hash_dict = {
             'hash1': self.hashing_func(os.path.join(settings.COMPRESS_ROOT, 'img/python.png')),


### PR DESCRIPTION
@patrys asked in #467 why `CssAbsoluteFilter` requires that `filename` is under `COMPRESS_ROOT`.  Most of the time it will be, because of running `collectstatic`, however there doesn't seem to be any reason for this filter to require that.  This pull request removes the artificial restriction and simplifies the code.
