### PR TITLE
Prefer stdlib json (silences a DeprecationWarning)

### DIFF
--- a/compressor/cache.py
+++ b/compressor/cache.py
@@ -10,9 +10,9 @@ from django.utils.functional import SimpleLazyObject
 from django.utils.importlib import import_module
 
 try:
-    import django.utils.simplejson as json
-except ImportError:
     import json
+except ImportError:
+    import django.utils.simplejson as json
 
 from compressor.conf import settings
 from compressor.storage import default_storage


### PR DESCRIPTION
django.utils.simplejson was deprecated in Django 1.5. The standard library package should be preferred, if available.
