### PR TITLE
Fix FilterBase clears self.type for subclasses

### DIFF
--- a/compressor/filters/base.py
+++ b/compressor/filters/base.py
@@ -26,7 +26,7 @@ class FilterBase(object):
     """
     def __init__(self, content, filter_type=None, filename=None, verbose=0,
                  charset=None):
-        self.type = filter_type
+        self.type = filter_type or getattr(self, 'type', None)
         self.content = content
         self.verbose = verbose or settings.COMPRESS_VERBOSE
         self.logger = logger

--- a/compressor/tests/precompiler.py
+++ b/compressor/tests/precompiler.py
@@ -7,11 +7,11 @@ import sys
 def main():
     p = optparse.OptionParser()
     p.add_option('-f', '--file', action="store",
-                type="string", dest="filename",
-                help="File to read from, defaults to stdin", default=None)
+                 type="string", dest="filename",
+                 help="File to read from, defaults to stdin", default=None)
     p.add_option('-o', '--output', action="store",
-                type="string", dest="outfile",
-                help="File to write to, defaults to stdout", default=None)
+                 type="string", dest="outfile",
+                 help="File to write to, defaults to stdout", default=None)
 
     options, arguments = p.parse_args()
 

--- a/compressor/tests/test_filters.py
+++ b/compressor/tests/test_filters.py
@@ -17,6 +17,10 @@ from compressor.filters.base import CompilerFilter
 from compressor.filters.cssmin import CSSMinFilter
 from compressor.filters.css_default import CssAbsoluteFilter
 from compressor.filters.template import TemplateFilter
+from compressor.filters.closure import ClosureCompilerFilter
+from compressor.filters.csstidy import CSSTidyFilter
+from compressor.filters.yuglify import YUglifyCSSFilter, YUglifyJSFilter
+from compressor.filters.yui import YUICSSFilter, YUIJSFilter
 from compressor.tests.test_base import test_dir
 
 
@@ -30,7 +34,6 @@ class CssTidyTestCase(TestCase):
         color: black;
         }
         """)
-        from compressor.filters.csstidy import CSSTidyFilter
         ret = CSSTidyFilter(content).input()
         self.assertIsInstance(ret, six.text_type)
         self.assertEqual(
@@ -301,3 +304,34 @@ class TemplateTestCase(TestCase):
         #footer {font-weight: bold;}
         """
         self.assertEqual(input, TemplateFilter(content).input())
+
+
+class SpecializedFiltersTest(TestCase):
+    """
+    Test to check the Specializations of filters.
+    """
+    def test_closure_filter(self):
+        filter = ClosureCompilerFilter('')
+        self.assertEqual(filter.options, (('binary', six.text_type('java -jar compiler.jar')), ('args', six.text_type(''))))
+
+    def test_csstidy_filter(self):
+        filter = CSSTidyFilter('')
+        self.assertEqual(filter.options, (('binary', six.text_type('csstidy')), ('args', six.text_type('--template=highest'))))
+
+    def test_yuglify_filters(self):
+        filter = YUglifyCSSFilter('')
+        self.assertEqual(filter.command, '{binary} {args} --type=css')
+        self.assertEqual(filter.options, (('binary', six.text_type('yuglify')), ('args', six.text_type('--terminal'))))
+
+        filter = YUglifyJSFilter('')
+        self.assertEqual(filter.command, '{binary} {args} --type=js')
+        self.assertEqual(filter.options, (('binary', six.text_type('yuglify')), ('args', six.text_type('--terminal'))))
+
+    def test_yui_filters(self):
+        filter = YUICSSFilter('')
+        self.assertEqual(filter.command, '{binary} {args} --type=css')
+        self.assertEqual(filter.options, (('binary', six.text_type('java -jar yuicompressor.jar')), ('args', six.text_type(''))))
+
+        filter = YUIJSFilter('', verbose=1)
+        self.assertEqual(filter.command, '{binary} {args} --type=js --verbose')
+        self.assertEqual(filter.options, (('binary', six.text_type('java -jar yuicompressor.jar')), ('args', six.text_type('')), ('verbose', 1)))


### PR DESCRIPTION
While adding more test I notice that `compressor.filter.base:FilterBase` clears out self.type with filter_type.
Also increase one space in `compressor.test.precompiler`. 
