### PR TITLE
Support of python3.2 was dropped in Jinja2 since version 2.7.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,14 @@ three =
     jinja2
     lxml
     BeautifulSoup4
+three_two =
+    flake8
+    coverage
+    html5lib
+    mock
+    jinja2==2.6
+    lxml
+    BeautifulSoup4
 
 [tox]
 envlist =
@@ -50,7 +58,7 @@ deps =
 basepython = python3.2
 deps =
     Django>=1.6,<1.7
-    {[deps]three}
+    {[deps]three_two}
 
 [testenv:py27-1.6.X]
 basepython = python2.7
@@ -76,7 +84,7 @@ basepython = python3.2
 deps =
     Django>=1.5,<1.6
     django-discover-runner
-    {[deps]three}
+    {[deps]three_two}
 
 [testenv:py27-1.5.X]
 basepython = python2.7


### PR DESCRIPTION
tox test fails whitout freezeing the version. TravisCI ignores it.

http://jinja.pocoo.org/docs/intro/#prerequisites
