### PR TITLE
Don't continue when raising a `UnicodeDecodeError`

### DIFF
--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -179,6 +179,7 @@ class Command(NoArgsCommand):
                 if verbosity > 0:
                     log.write("UnicodeDecodeError while trying to read "
                               "template %s\n" % template_name)
+                continue
             nodes = list(parser.walk_nodes(template))
             if nodes:
                 template.template_name = template_name


### PR DESCRIPTION
Don't continue executing more code, by adding a `continue` to start the loop over. :)