### PR TITLE
Allow for more flexible compressor setups

### DIFF
--- a/compressor/templatetags/compress.py
+++ b/compressor/templatetags/compress.py
@@ -22,10 +22,11 @@ class CompressorMixin(object):
 
     @property
     def compressors(self):
-        return {
+        defaults = {
             'js': settings.COMPRESS_JS_COMPRESSOR,
             'css': settings.COMPRESS_CSS_COMPRESSOR,
         }
+        return getattr(settings, 'COMPRESS_COMPROCESSORS', defaults)
 
     def compressor_cls(self, kind, *args, **kwargs):
         if kind not in self.compressors.keys():


### PR DESCRIPTION
The above is necessary if someone uses django-compressor with django-sekizai, and has other blocks than "js" and "css". It's 100% backward compatible.