### PR TITLE
Fix for TypeError concatenation of None to list

### DIFF
--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -294,6 +294,7 @@ class Command(NoArgsCommand):
     def get_nodelist(self, node):
         # Check if node is an ```if``` switch with true and false branches
         if hasattr(node, 'nodelist_true') and hasattr(node, 'nodelist_false'):
+            if node.nodelist_false != None:
             return node.nodelist_true + node.nodelist_false
         return getattr(node, "nodelist", [])
 

--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -294,8 +294,8 @@ class Command(NoArgsCommand):
     def get_nodelist(self, node):
         # Check if node is an ```if``` switch with true and false branches
         if hasattr(node, 'nodelist_true') and hasattr(node, 'nodelist_false'):
-            if node.nodelist_false != None:
-            return node.nodelist_true + node.nodelist_false
+            if node.nodelist_false is not None:
+                return node.nodelist_true + node.nodelist_false
         return getattr(node, "nodelist", [])
 
     def walk_nodes(self, node, block_name=None):


### PR DESCRIPTION
If node.nodelist_false is None rather than a list, get_nodelist raises a TypeError. Probably could use some tests for that, but at the moment I can't even get the tests to pass with a fresh git clone install.

```
Traceback (most recent call last):
  File "/Users/dang/code/spokesman/bin/django-admin.py", line 5, in <module>
    management.execute_from_command_line()
  File "/Users/dang/code/spokesman/lib/python2.7/site-packages/django/core/management/__init__.py", line 443, in execute_from_command_line
    utility.execute()
  File "/Users/dang/code/spokesman/lib/python2.7/site-packages/django/core/management/__init__.py", line 382, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/Users/dang/code/spokesman/lib/python2.7/site-packages/django/core/management/base.py", line 196, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/Users/dang/code/spokesman/lib/python2.7/site-packages/django/core/management/base.py", line 232, in execute
    output = self.handle(*args, **options)
  File "/Users/dang/code/spokesman/lib/python2.7/site-packages/django/core/management/base.py", line 371, in handle
    return self.handle_noargs(**options)
  File "/Users/dang/code/spokesman/lib/python2.7/site-packages/compressor/management/commands/compress.py", line 340, in handle_noargs
    self.compress(sys.stdout, **options)
  File "/Users/dang/code/spokesman/lib/python2.7/site-packages/compressor/management/commands/compress.py", line 238, in compress
    nodes = list(self.walk_nodes(template))
  File "/Users/dang/code/spokesman/lib/python2.7/site-packages/compressor/management/commands/compress.py", line 306, in walk_nodes
    for node in self.walk_nodes(node, block_name=block_name):
  File "/Users/dang/code/spokesman/lib/python2.7/site-packages/compressor/management/commands/compress.py", line 306, in walk_nodes
    for node in self.walk_nodes(node, block_name=block_name):
  File "/Users/dang/code/spokesman/lib/python2.7/site-packages/compressor/management/commands/compress.py", line 306, in walk_nodes
    for node in self.walk_nodes(node, block_name=block_name):
  File "/Users/dang/code/spokesman/lib/python2.7/site-packages/compressor/management/commands/compress.py", line 299, in walk_nodes
    for node in self.get_nodelist(node):
  File "/Users/dang/code/spokesman/lib/python2.7/site-packages/compressor/management/commands/compress.py", line 295, in get_nodelist
    return node.nodelist_true + node.nodelist_false
TypeError: can only concatenate list (not "NoneType") to list
```