### PR TITLE
Add version 1.4 changelog docs.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,14 +1,45 @@
 Changelog
 =========
 
+v1.4 (as of 04/23/2014)
+-----------------------
+
+- Added Python 3 compatibility.
+
+- Added compatibility with Django 1.6.
+
+- Easier setting up of test environment using Make.
+
+- Allowed data-uri filter to handle external/protocol-relative references
+
+- Made CssCompressor class easier to extend
+
+- Added support for explictly stating the block being ended
+
+- Added rcssmin
+
+- Added offline compression for Jinja2 with Jingo and Coffin integration
+
+- Removed implicit requirement on BeautifulSoup
+
+- Set timestamps of files written by GzipCompressorFileStorage to be equal
+
+- Defaulted to using django's simplejson, if present
+
+- Fixed CompilerFilter to always output Unicode strings
+
+- Fixed compatibility with html5lib 1.0
+
+- Fixed windows line endings in offline compress
+
 v1.3 (03/18/2013)
 -----------------
 
 - *Backward incompatible changes*
 
-  -  Dropped support for Python 2.5. Removed ``any`` and ``walk`` compatibility 
+  -  Dropped support for Python 2.5. Removed ``any`` and ``walk`` compatibility
      functions in ``compressor.utils``.
-  
+
   - Removed compatibility with Django 1.2 for default values of some settings:
 
     - :attr:`~COMPRESS_ROOT` no longer uses ``MEDIA_ROOT`` if ``STATIC_ROOT`` is
@@ -17,7 +48,7 @@ v1.3 (03/18/2013)
     - :attr:`~COMPRESS_URL` no longer uses ``MEDIA_URL`` if ``STATIC_URL`` is
       not defined. It expects ``STATIC_URL`` to be defined instead.
 
-    - :attr:`~COMPRESS_CACHE_BACKEND` no longer uses ``CACHE_BACKEND`` and simply 
+    - :attr:`~COMPRESS_CACHE_BACKEND` no longer uses ``CACHE_BACKEND`` and simply
       defaults to ``default``.
 
 - Added precompiler class support. This enables you to write custom precompilers
@@ -29,8 +60,8 @@ v1.3 (03/18/2013)
 - Removed a ``fsync()`` call in ``CompilerFilter`` to improve performance.
   We already called ``self.infile.flush()`` so that call was not necessary.
 
-- Added an extension to provide django-sekizai support. 
-  See :ref:`django-sekizai Support <django-sekizai_support>` for more 
+- Added an extension to provide django-sekizai support.
+  See :ref:`django-sekizai Support <django-sekizai_support>` for more
   information.
 
 - Fixed a ``DeprecationWarning`` regarding the use of ``django.utils.hashcompat``


### PR DESCRIPTION
After speaking to @diox in the #django-compressor channel on irc, I decided to contribute a changelog. I'm not sure what changes are backwards incompatible, nor how granular you would like the changelog to be, but here's a start anyway.

I generated a list of the PRs that have been merged in post-1.3 by doing the following:

```
$ pip install nodeenv
$ nodeenv -p
$ npm install -g github-changes
$ github-changes -o django-compressor -r django-compressor -a -b develop  --only-pulls --use-commit-body
```

This generated a file containing the following, which I have attempted to convert into the `changelog.txt` file in the docs folder:
### upcoming (1.4) (2014/04/23 23:32 +00:00)
- [#312](https://github.com/django-compressor/django-compressor/pull/312) Fixed CompilerFilter to always output Unicode strings (@anttihirvonen)
- [#382](https://github.com/django-compressor/django-compressor/pull/382) Clarifying default for COMPRESS_CACHE_BACKEND (@alecxe)
- [#406](https://github.com/django-compressor/django-compressor/pull/406) Fix #405 - compatibility with html5lib 1.0 (@ambv)
- [#402](https://github.com/django-compressor/django-compressor/pull/402) Set timestamps of files written by GzipCompressorFileStorage (@bgilbert)
- [#387](https://github.com/django-compressor/django-compressor/pull/387) Add make target for setting up test environment (@codeinthehole)
- [#439](https://github.com/django-compressor/django-compressor/pull/439) add usedevelop to tox testenv (@RonnyPfannschmidt)
- [#463](https://github.com/django-compressor/django-compressor/pull/463) Fix for extracting version number in Python 3 (@maikhoepfel)
- [#451](https://github.com/django-compressor/django-compressor/pull/451) Configure tox and requirements to test with django 1.6 (@diox)
- [#427](https://github.com/django-compressor/django-compressor/pull/427) Make CssCompressor class easier to extend (@jor123)
- [#453](https://github.com/django-compressor/django-compressor/pull/453) Support for the kind in the endblock (@WoLpH)
- [#456](https://github.com/django-compressor/django-compressor/pull/456) Allow data-uri filter to handle external/protocol-relative references (@shacker)
- [#447](https://github.com/django-compressor/django-compressor/pull/447) Fix windows line endings in offline compress (@apmorton)
- [#416](https://github.com/django-compressor/django-compressor/pull/416) Don't raise an error if BeautifulSoup isn't installed (@damianmoore)
- [#444](https://github.com/django-compressor/django-compressor/pull/444) + add rcssmin (@Mystic-Mirage)
- [#464](https://github.com/django-compressor/django-compressor/pull/464) -Fix: compare against six.string_types. (@Xaroth)
- [#437](https://github.com/django-compressor/django-compressor/pull/437) change DEBUG_TOGGLE default value from 'None' to None (@fsw)
- [#469](https://github.com/django-compressor/django-compressor/pull/469) Fix README.rst to show percentage instead of 'unknown'. (@iknite)
- [#472](https://github.com/django-compressor/django-compressor/pull/472) Try import django.utils.simplejson, except import json (@agriffis)
- [#474](https://github.com/django-compressor/django-compressor/pull/474) Fixed grammar in Readme (@vishalsodani)
- [#468](https://github.com/django-compressor/django-compressor/pull/468) Tests fail with libxml-2.9.1 (@agriffis)
- [#473](https://github.com/django-compressor/django-compressor/pull/473) Spelling fixes in README.rst (@entrepreneurj)
- [#478](https://github.com/django-compressor/django-compressor/pull/478) Fix: #477 Enhanced Error display if COMPRESS_ROOT nor STATIC_ROOT is defined (@iknite)
- [#480](https://github.com/django-compressor/django-compressor/pull/480) Fix #477: Add install instructions for COMPRESS_ROOT and STATIC_ROOT. (@iknite)
- [#494](https://github.com/django-compressor/django-compressor/pull/494) Spelling correction in docs/behind-the-scenes.txt (@eric-fish)
- [#488](https://github.com/django-compressor/django-compressor/pull/488) Offline compression for Jinja2 with Jingo and Coffin integration (@lucastan)
- [#489](https://github.com/django-compressor/django-compressor/pull/489) Document settings.COMPRESS_CACHE_KEY_FUNCTION (@adamjforster)
- [#498](https://github.com/django-compressor/django-compressor/pull/498) Relax the test for a configured CachedLoader. Fixes #493. (@mikebryant)
