### PR TITLE
Empty static files cause a missed hit when running in offline mode - check for None rather than False

### DIFF
--- a/compressor/templatetags/compress.py
+++ b/compressor/templatetags/compress.py
@@ -87,7 +87,7 @@ class CompressorMixin(object):
 
         # See if it has been rendered offline
         cached_offline = self.render_offline(context, forced=forced)
-        if cached_offline:
+        if cached_offline is not None:
             return cached_offline
 
         # Take a shortcut if we really don't have anything to do


### PR DESCRIPTION
When verifying the content of cached_offline check for None rather than simply False

An empty file results in an empty string, causes the cache hit to fail and thus to recompress the section.