### PR TITLE
Put charset back into kwargs

### DIFF
--- a/compressor/base.py
+++ b/compressor/base.py
@@ -225,13 +225,14 @@ class Compressor(object):
             content.append(hunk)
         return content
 
-    def precompile(self, content, kind=None, elem=None, filename=None,
-                   charset=None, **kwargs):
+    def precompile(self, content, kind=None, elem=None, filename=None, **kwargs):
         """
         Processes file using a pre compiler.
 
         This is the place where files like coffee script are processed.
         """
+        charset = kwargs.get('charset', None)
+
         if not kind:
             return False, content
         attrs = self.parser.elem_attribs(elem)


### PR DESCRIPTION
Moving charset out of kwargs creates an issue with precompile in the base.py.

TypeError at /admin/widgy_mezzanine/widgypage/add/
**init**() got an unexpected keyword argument 'charset'
Request Method: GET
Request URL:    http://localhost:8000/admin/widgy_mezzanine/widgypage/add/
Django Version: 1.6.5
Exception Type: TypeError
Exception Value:  
**init**() got an unexpected keyword argument 'charset'
