### PR TITLE
quote filename e.g. in case it contains spaces

### DIFF
--- a/compressor/filters/base.py
+++ b/compressor/filters/base.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, unicode_literals
 import io
 import logging
 import subprocess
+import pipes
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.temp import NamedTemporaryFile
@@ -30,7 +31,7 @@ class FilterBase(object):
         self.content = content
         self.verbose = verbose or settings.COMPRESS_VERBOSE
         self.logger = logger
-        self.filename = filename
+        self.filename = pipes.quote(filename)
         self.charset = charset
 
     def input(self, **kwargs):


### PR DESCRIPTION
Without this, it gives a template error.

Sorry for no test, in the middle of fixing a web-server.
