### PR TITLE
Fix AttributeError in offline compression

### DIFF
--- a/compressor/offline/django.py
+++ b/compressor/offline/django.py
@@ -54,6 +54,8 @@ def remove_block_nodes(nodelist, block_stack, block_context):
                 if not block_stack:
                     continue
                 node = block_context.get_block(block_stack[-1].name)
+                if not node:
+                    continue
         if isinstance(node, BlockNode):
             expanded_block = expand_blocknode(node, block_stack, block_context)
             new_nodelist.extend(expanded_block)

--- a/compressor/tests/test_templates/test_block_super_base_compressed/test_compressor_offline.html
+++ b/compressor/tests/test_templates/test_block_super_base_compressed/test_compressor_offline.html
@@ -5,4 +5,9 @@
     <script type="text/javascript">
         alert("this alert shouldn't be alone!");
     </script>
+    {% block orphan %}
+        {{ block.super }}
+        An 'orphan' block that refers to a non-existent super block.
+        Contents of this block are ignored.
+    {% endblock %}
 {% endspaceless %}{% endblock %}


### PR DESCRIPTION
Fixes #542 
This fix ignores  a `block.super` when finding compressed blocks during offline compression instead of raising an `AttributeError`.
