### PR TITLE
Allow compressor to fallback to remote files

### DIFF
--- a/compressor/base.py
+++ b/compressor/base.py
@@ -131,8 +131,8 @@ class Compressor(object):
         if not filename and self.finders:
             filename = self.finders.find(url2pathname(basename))
         # third, attempt to find the file remotely if the compressor storage
-        # is remote and the 'COMPRESS_PULL_FROM_REMOTE' setting is True
-        if not filename and storage_is_remote and compressor_settings.PULL_FROM_REMOTE and self.storage.exists(basename):
+        # is remote and the 'COMPRESS_FETCH_FROM_REMOTE' setting is True
+        if not filename and storage_is_remote and compressor_settings.FETCH_FROM_REMOTE and self.storage.exists(basename):
             compressor_file_storage.save(basename, self.storage.open(basename))
             filename = compressor_file_storage.path(basename)
         if filename:

--- a/compressor/conf.py
+++ b/compressor/conf.py
@@ -17,7 +17,7 @@ class CompressorConf(AppConf):
     PARSER = 'compressor.parser.AutoSelectParser'
     OUTPUT_DIR = 'CACHE'
     STORAGE = 'compressor.storage.CompressorFileStorage'
-    
+
     # if a static file cannot be found locally, should we pull from the remote storage?
     FETCH_FROM_REMOTE = False
 

--- a/compressor/conf.py
+++ b/compressor/conf.py
@@ -17,6 +17,9 @@ class CompressorConf(AppConf):
     PARSER = 'compressor.parser.AutoSelectParser'
     OUTPUT_DIR = 'CACHE'
     STORAGE = 'compressor.storage.CompressorFileStorage'
+    
+    # if a static file cannot be found locally, should we pull from the remote storage?
+    PULL_FROM_REMOTE = False
 
     CSS_COMPRESSOR = 'compressor.css.CssCompressor'
     JS_COMPRESSOR = 'compressor.js.JsCompressor'

--- a/compressor/conf.py
+++ b/compressor/conf.py
@@ -19,7 +19,7 @@ class CompressorConf(AppConf):
     STORAGE = 'compressor.storage.CompressorFileStorage'
     
     # if a static file cannot be found locally, should we pull from the remote storage?
-    PULL_FROM_REMOTE = False
+    FETCH_FROM_REMOTE = False
 
     CSS_COMPRESSOR = 'compressor.css.CssCompressor'
     JS_COMPRESSOR = 'compressor.js.JsCompressor'

--- a/compressor/filters/base.py
+++ b/compressor/filters/base.py
@@ -3,10 +3,18 @@ import io
 import logging
 import subprocess
 
-try:
-    from shlex import quote as shell_quote  # Python 3
-except ImportError:
-    from pipes import quote as shell_quote  # Python 2
+from platform import system
+
+if system() != "Windows":
+    try:
+        from shlex import quote as shell_quote  # Python 3
+    except ImportError:
+        from pipes import quote as shell_quote  # Python 2
+else:
+    from subprocess import list2cmdline
+    def shell_quote(s):
+        # shlex.quote/pipes.quote is not compatible with Windows
+        return list2cmdline([s])
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.temp import NamedTemporaryFile


### PR DESCRIPTION
Attempt to find files remotely when they cannot be found locally if the compressor storage is remote and the 'COMPRESS_FETCH_FROM_REMOTE' setting is True

This includes the Windows compatibility patch from https://github.com/django-compressor/django-compressor/pull/561
