### PR TITLE
Quote filenames in case they contain e.g. spaces, etc.

### DIFF
--- a/compressor/filters/base.py
+++ b/compressor/filters/base.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, unicode_literals
 import io
 import logging
 import subprocess
+import pipes
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.temp import NamedTemporaryFile
@@ -30,7 +31,7 @@ class FilterBase(object):
         self.content = content
         self.verbose = verbose or settings.COMPRESS_VERBOSE
         self.logger = logger
-        self.filename = filename
+        self.filename = pipes.quote(filename)
         self.charset = charset
 
     def input(self, **kwargs):

--- a/compressor/filters/base.py
+++ b/compressor/filters/base.py
@@ -31,7 +31,7 @@ class FilterBase(object):
         self.content = content
         self.verbose = verbose or settings.COMPRESS_VERBOSE
         self.logger = logger
-        self.filename = pipes.quote(filename)
+        self.filename = filename
         self.charset = charset
 
     def input(self, **kwargs):
@@ -132,7 +132,7 @@ class CompilerFilter(FilterBase):
                 self.infile = NamedTemporaryFile(mode='wb')
                 self.infile.write(self.content.encode(encoding))
                 self.infile.flush()
-                options["infile"] = self.infile.name
+                infile_name = self.infile.name
             else:
                 # we use source file directly, which may be encoded using
                 # something different than utf8. If that's the case file will
@@ -140,7 +140,8 @@ class CompilerFilter(FilterBase):
                 # charset will be available as filter's charset attribute
                 encoding = self.charset  # or self.default_encoding
                 self.infile = open(self.filename)
-                options["infile"] = self.filename
+                infile_name = self.filename
+            options["infile"] = pipes.quote(infile_name)
 
         if "{outfile}" in self.command and "outfile" not in options:
             # create temporary output file if needed

--- a/compressor/filters/base.py
+++ b/compressor/filters/base.py
@@ -147,7 +147,7 @@ class CompilerFilter(FilterBase):
             # create temporary output file if needed
             ext = self.type and ".%s" % self.type or ""
             self.outfile = NamedTemporaryFile(mode='r+', suffix=ext)
-            options["outfile"] = self.outfile.name
+            options["outfile"] = pipes.quote(self.outfile.name)
 
         try:
             command = self.command.format(**options)


### PR DESCRIPTION
I got an Error: ENOENT when compressing a less CSS file through less because it had a space in the filename. 

Solution: Quote filenames in case they contain e.g. spaces, etc.

Seem to remember contributing a pull request before for this bug, not sure what happened to it.