### PR TITLE
Support {% else %} for when compression is off.

### DIFF
--- a/compressor/templatetags/compress.py
+++ b/compressor/templatetags/compress.py
@@ -123,13 +123,16 @@ class CompressorMixin(object):
 
 class CompressorNode(CompressorMixin, template.Node):
 
-    def __init__(self, nodelist, kind=None, mode=OUTPUT_FILE, name=None):
+    def __init__(self, nodelist, nodelist_else=None, kind=None, mode=OUTPUT_FILE, name=None):
         self.nodelist = nodelist
+        self.nodelist_else = nodelist_else
         self.kind = kind
         self.mode = mode
         self.name = name
 
     def get_original_content(self, context):
+        if not settings.COMPRESS_ENABLED and self.nodelist_else:
+            return self.nodelist_else.render(context)
         return self.nodelist.render(context)
 
     def debug_mode(self, context):
@@ -158,7 +161,11 @@ def compress(parser, token):
 
         {% compress <js/css> %}
         <html of inline or linked JS/CSS>
+        {% else %}
+        <html of inline or linked JS/CSS if compression is disabled>
         {% endcompress %}
+
+    The else part is optional.
 
     Examples::
 
@@ -188,9 +195,6 @@ def compress(parser, token):
     they will be silently stripped.
     """
 
-    nodelist = parser.parse(('endcompress',))
-    parser.delete_first_token()
-
     args = token.split_contents()
 
     if not len(args) in (2, 3, 4):
@@ -211,4 +215,14 @@ def compress(parser, token):
         name = args[3]
     else:
         name = None
-    return CompressorNode(nodelist, kind, mode, name)
+
+    nodelist = parser.parse(('endcompress', 'else'))
+    token = parser.next_token()
+
+    nodelist_else = None
+    if token.contents.startswith('else'):
+        nodelist_else = parser.parse(('endcompress',))
+        token = parser.next_token()
+        assert token.contents == 'endcompress'
+
+    return CompressorNode(nodelist, nodelist_else, kind, mode, name)

--- a/compressor/tests/test_templatetags.py
+++ b/compressor/tests/test_templatetags.py
@@ -165,6 +165,15 @@ class PrecompilerTemplatetagTestCase(TestCase):
         out = script(src="/static/CACHE/js/ef6b32a54575.js")
         self.assertEqual(out, render(template, self.context))
 
+    def test_compress_coffeescript_tag_with_else(self):
+        template = """{% load compress %}{% compress js %}
+            <script type="text/coffeescript"># this is a comment.</script>
+            {% else %}
+            <marquee>Roulette</marquee>
+            {% endcompress %}"""
+        out = script(src="/static/CACHE/js/e920d58f166d.js")
+        self.assertEqual(out, render(template, self.context))
+
     @override_settings(COMPRESS_ENABLED=False)
     def test_coffeescript_and_js_tag_with_compress_enabled_equals_false(self):
         template = """{% load compress %}{% compress js %}
@@ -184,6 +193,16 @@ class PrecompilerTemplatetagTestCase(TestCase):
         self.assertEqual(out, render(template, self.context))
 
     @override_settings(COMPRESS_ENABLED=False)
+    def test_compress_coffeescript_tag_compress_enabled_is_false_with_else(self):
+        template = """{% load compress %}{% compress js %}
+            <script type="text/coffeescript"># this is a comment.</script>
+            {% else %}
+            <script type="text/javascript"># this is a comment in JS.</script>
+            {% endcompress %}"""
+        out = script("# this is a comment in JS.")
+        self.assertEqual(out, render(template, self.context))
+
+    @override_settings(COMPRESS_ENABLED=False)
     def test_compress_coffeescript_file_tag_compress_enabled_is_false(self):
         template = """
         {% load compress %}{% compress js %}
@@ -192,6 +211,19 @@ class PrecompilerTemplatetagTestCase(TestCase):
         {% endcompress %}"""
 
         out = script(src="/static/CACHE/js/one.95cfb869eead.js")
+        self.assertEqual(out, render(template, self.context))
+
+    @override_settings(COMPRESS_ENABLED=False)
+    def test_compress_coffeescript_file_tag_compress_enabled_is_false_with_else(self):
+        template = """
+        {% load compress %}{% compress js %}
+        <script type="text/coffeescript" src="{{ STATIC_URL }}js/one.coffee">
+        </script>
+        {% else %}
+        <script type="text/javascript" src="{{ STATIC_URL }}js/one.js"></script>
+        {% endcompress %}"""
+
+        out = script(src="/static/js/one.js")
         self.assertEqual(out, render(template, self.context))
 
     @override_settings(COMPRESS_ENABLED=False)

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -19,8 +19,11 @@ Base settings
     when ``DEBUG`` is ``True`` ``COMPRESS_ENABLED`` must also be set to
     ``True``.
 
-    When ``COMPRESS_ENABLED`` is ``False`` the input will be rendered without
-    any compression except for code with a mimetype matching one listed in the
+    When ``COMPRESS_ENABLED`` is ``False`` and there is an ``else`` block, the
+    ``else`` block will be rendered unaltered. When ``COMPRESS_ENABLED`` is
+    ``False`` and there is no ``else`` block, the input will be rendered
+    without any compression except for code with a mimetype matching one
+    listed in the
     :attr:`~django.conf.settings.COMPRESS_PRECOMPILERS` setting. These
     matching files are still passed to the precompiler before rendering.
 

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -8,7 +8,11 @@ Usage
     {% load compress %}
     {% compress <js/css> [<file/inline> [block_name]] %}
     <html of inline or linked JS/CSS>
+    {% else %}
+    <html of inline or linked JS/CSS if compression is disabled>
     {% endcompress %}
+
+The else part is optional.
 
 Examples
 --------


### PR DESCRIPTION
The use case is: a frontend developer uses django to render the templates to the browser. django-compressor doesn't detect changes in source less or sass files and therefore doesn't know when to invalidate the cache. The frontend developer uses grunt or gulp or some similar tool to compile her less or sass files to CSS, which are then served directly by django without involving django-compressor.