### PR TITLE
fix for using block.super when there is no block.super parent

### DIFF
--- a/compressor/offline/django.py
+++ b/compressor/offline/django.py
@@ -54,7 +54,8 @@ def remove_block_nodes(nodelist, block_stack, block_context):
             if var_name == 'block.super':
                 if not block_stack:
                     continue
-                node = block_context.get_block(block_stack[-1].name)
+                new_node = block_context.get_block(block_stack[-1].name)
+                node = new_node if new_node is not None else node
         if isinstance(node, BlockNode):
             expanded_block = expand_blocknode(node, block_stack, block_context)
             new_nodelist.extend(expanded_block)


### PR DESCRIPTION
For whatever reason, some places define {{ block.super }} in templates that aren't extending any other templates (the root). Unfortunately, a few apps I've depended on have done this and cause offline compression to fail. This is a work-around for it. Given there is no block.super to render, skipping the extension of the current node with the block.super is not needed and I don't believe this will break anything.