### PR TITLE
Bugfix: Issue #541 https://github.com/django-compressor/django-compressor/issues/541

### DIFF
--- a/compressor/filters/cssmin/cssmin.py
+++ b/compressor/filters/cssmin/cssmin.py
@@ -147,7 +147,7 @@ def remove_unnecessary_whitespace(css):
     css = re.sub(r"([!{}:;>+\(\[,])\s+", r"\1", css)
 
     # Restore the original calc() rules
-    for key, val in calc_dict.iteritems():
+    for key, val in calc_dict.items():
         css = css.replace(key, val)
 
     return css

--- a/compressor/filters/cssmin/cssmin.py
+++ b/compressor/filters/cssmin/cssmin.py
@@ -94,7 +94,7 @@ def remove_unnecessary_whitespace(css):
             match = regex.search(css)
         return css
 
-    calc_dict = {}  # used to assist preservecalc() when restoring values
+    calcdict = {}  # used to assist preservecalc() when restoring values
 
     def preservecalc(css):
         """
@@ -116,7 +116,7 @@ def remove_unnecessary_whitespace(css):
         i = 0   # iterator to assure unique dict value
         while match:
             placeholder_text = "___CALCPOSITION-%d___" % i
-            calc_dict[placeholder_text] = match.group()
+            calcdict[placeholder_text] = match.group()
             css = ''.join([
                 css[:match.start()],
                 match.group().replace(match.group(), placeholder_text),
@@ -146,8 +146,12 @@ def remove_unnecessary_whitespace(css):
     # Remove spaces from after things.
     css = re.sub(r"([!{}:;>+\(\[,])\s+", r"\1", css)
 
+    # Retain python 2/3 compatibility with a minimal footprint
+    calcitems = calcdict.iteritems if hasattr(calcdict, 'iteritems') \
+        else calcdict.items
+
     # Restore the original calc() rules
-    for key, val in calc_dict.items():
+    for key, val in calcitems():
         css = css.replace(key, val)
 
     return css

--- a/compressor/filters/cssmin/cssmin.py
+++ b/compressor/filters/cssmin/cssmin.py
@@ -101,7 +101,7 @@ def remove_unnecessary_whitespace(css):
         Prevents the white space in calc() CSS rules from being removed.
 
         Each calc() rule is replaced by a unique string that corresponds to a
-        key in calc_dict which stores the original rule. The original values 
+        key in calc_dict which stores the original rule. The original values
         are restored towards the end of remove_unnecessary_whitespace().
 
         Arguments:

--- a/compressor/tests/test_filters.py
+++ b/compressor/tests/test_filters.py
@@ -108,11 +108,12 @@ class CssMinTestCase(TestCase):
 
 
         background: rgb(51,102,153) url('../../images/image.gif');
-
+        color:     calc(1px + 3% + 43em +5pt)
 
         }
         """
-        output = "p{background:#369 url('../../images/image.gif')}"
+        output = "p{background:#369 url('../../images/image.gif');" \
+                 "color:calc(1px + 3% + 43em +5pt)}"
         self.assertEqual(output, CSSMinFilter(content).output())
 
 

--- a/compressor/tests/test_filters.py
+++ b/compressor/tests/test_filters.py
@@ -110,6 +110,7 @@ class CssMinTestCase(TestCase):
         background: rgb(51,102,153) url('../../images/image.gif');
         color:     calc(1px + 3% + 43em +5pt)
 
+
         }
         """
         output = "p{background:#369 url('../../images/image.gif');" \


### PR DESCRIPTION
A new function in filters.cssmin.remove_unnecessary_whitespace, preservecalc(),  was added to preserve any calc rules from being broken during compression.
A similar solution to pseudoclasscolon() was used to maintain consistent coding style.

The tests were also updated.