### PR TITLE
Fix compress command for 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,9 @@ env:
   - TOXENV=py32-1.7.X
   - TOXENV=py33-1.7.X
   - TOXENV=py34-1.7.X
+  - TOXENV=py27-1.8.X
+  - TOXENV=py32-1.8.X
+  - TOXENV=py33-1.8.X
+  - TOXENV=py34-1.8.X
 notifications:
   irc: "irc.freenode.org#django-compressor"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install csstidy libxml2-dev libxslt-dev
 install:
-  - pip install tox coveralls
+  - pip install tox
 script:
   - tox
 env:
@@ -21,4 +21,3 @@ env:
   - TOXENV=py34-1.7.X
 notifications:
   irc: "irc.freenode.org#django-compressor"
-after_success: coveralls

--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -5,6 +5,7 @@ import sys
 from fnmatch import fnmatch
 from optparse import make_option
 
+import django
 from django.core.management.base import NoArgsCommand, CommandError
 import django.template
 from django.template import Context
@@ -53,24 +54,30 @@ class Command(NoArgsCommand):
     requires_model_validation = False
 
     def get_loaders(self):
-        from django.template.loader import template_source_loaders
-        if template_source_loaders is None:
-            try:
-                from django.template.loader import (
-                    find_template as finder_func)
-            except ImportError:
-                from django.template.loader import (
-                    find_template_source as finder_func)  # noqa
-            try:
-                # Force django to calculate template_source_loaders from
-                # TEMPLATE_LOADERS settings, by asking to find a dummy template
-                source, name = finder_func('test')
-            except django.template.TemplateDoesNotExist:
-                pass
-            # Reload template_source_loaders now that it has been calculated ;
-            # it should contain the list of valid, instanciated template loaders
-            # to use.
+        if django.VERSION < (1, 8):
             from django.template.loader import template_source_loaders
+            if template_source_loaders is None:
+                try:
+                    from django.template.loader import (
+                        find_template as finder_func)
+                except ImportError:
+                    from django.template.loader import (
+                        find_template_source as finder_func)  # noqa
+                try:
+                    # Force django to calculate template_source_loaders from
+                    # TEMPLATE_LOADERS settings, by asking to find a dummy template
+                    source, name = finder_func('test')
+                except django.template.TemplateDoesNotExist:
+                    pass
+                # Reload template_source_loaders now that it has been calculated ;
+                # it should contain the list of valid, instanciated template loaders
+                # to use.
+                from django.template.loader import template_source_loaders
+        else:
+            from django.template import engines
+            template_source_loaders = []
+            for e in engines.all():
+                template_source_loaders.extend(e.engine.get_template_loaders(e.engine.loaders))
         loaders = []
         # If template loader is CachedTemplateLoader, return the loaders
         # that it wraps around. So if we have

--- a/compressor/test_settings.py
+++ b/compressor/test_settings.py
@@ -21,8 +21,9 @@ DATABASES = {
 INSTALLED_APPS = [
     'compressor',
     'coffin',
-    'jingo',
 ]
+if django.VERSION < (1, 8):
+    INSTALLED_APPS.append('jingo')
 
 STATIC_URL = '/static/'
 

--- a/compressor/tests/test_offline.py
+++ b/compressor/tests/test_offline.py
@@ -3,6 +3,7 @@ import io
 import os
 import sys
 
+import django
 from django.core.management.base import CommandError
 from django.template import Template, Context
 from django.test import TestCase
@@ -29,6 +30,8 @@ else:
 #     compressor_nodes.setdefault(template, []).extend(nodes)
 # causes the error "unhashable type: 'Template'"
 _TEST_JINJA2 = not(sys.version_info[0] == 3 and sys.version_info[1] == 2)
+if django.VERSION >= (1, 8):
+    _TEST_JINJA2 = False
 
 
 class OfflineTestCaseMixin(object):
@@ -454,6 +457,8 @@ class OfflineGenerationComplexTestCase(OfflineTestCaseMixin, TestCase):
 # It seems there is no evidence nor indicated support for Python 3+.
 @unittest.skipIf(sys.version_info >= (3, 2),
     "Coffin does not support 3.2+")
+@unittest.skipIf(django.VERSION >= (1, 8),
+    "Import error on 1.8")
 class OfflineGenerationCoffinTestCase(OfflineTestCaseMixin, TestCase):
     templates_dir = "test_coffin"
     expected_hash = "32c8281e3346"
@@ -478,6 +483,8 @@ class OfflineGenerationCoffinTestCase(OfflineTestCaseMixin, TestCase):
 # is also evident in its tox.ini file.
 @unittest.skipIf(sys.version_info >= (3, 2) and sys.version_info < (3, 3),
     "Jingo does not support 3.2")
+@unittest.skipIf(django.VERSION >= (1, 8),
+    "Import error on 1.8")
 class OfflineGenerationJingoTestCase(OfflineTestCaseMixin, TestCase):
     templates_dir = "test_jingo"
     expected_hash = "61ec584468eb"

--- a/compressor/tests/test_offline.py
+++ b/compressor/tests/test_offline.py
@@ -65,8 +65,8 @@ class OfflineTestCaseMixin(object):
         if "jinja2" in self.engines:
             override_settings["COMPRESS_JINJA2_GET_ENVIRONMENT"] = lambda: self._get_jinja2_env()
 
-        self.override_template_dirs = self.settings(**override_settings)
-        self.override_template_dirs.__enter__()
+        self.override_settings = self.settings(**override_settings)
+        self.override_settings.__enter__()
 
         if "django" in self.engines:
             self.template_path = os.path.join(django_template_dir, self.template_name)
@@ -82,7 +82,7 @@ class OfflineTestCaseMixin(object):
                 self.template_jinja2 = jinja2_env.from_string(file.read())
 
     def tearDown(self):
-        self.override_template_dirs.__exit__(None, None, None)
+        self.override_settings.__exit__(None, None, None)
 
         manifest_path = os.path.join('CACHE', 'manifest.json')
         if default_storage.exists(manifest_path):

--- a/compressor/tests/test_offline.py
+++ b/compressor/tests/test_offline.py
@@ -6,10 +6,6 @@ import sys
 import django
 from django.core.management.base import CommandError
 from django.template import Template, Context
-try:
-    from django.template import EngineHandler
-except ImportError:
-    pass
 from django.test import TestCase
 from django.utils import six, unittest
 
@@ -51,8 +47,6 @@ class OfflineTestCaseMixin(object):
         engines = ("django",)
 
     def setUp(self):
-        if django.VERSION >= (1, 8):
-            django.template.engines = EngineHandler()
         self._old_compress = settings.COMPRESS_ENABLED
         self._old_compress_offline = settings.COMPRESS_OFFLINE
         self._old_template_dirs = settings.TEMPLATE_DIRS
@@ -67,7 +61,12 @@ class OfflineTestCaseMixin(object):
         # template to be skipped over.
         django_template_dir = os.path.join(settings.TEST_DIR, 'test_templates', self.templates_dir)
         jinja2_template_dir = os.path.join(settings.TEST_DIR, 'test_templates_jinja2', self.templates_dir)
-        settings.TEMPLATE_DIRS = (django_template_dir, jinja2_template_dir)
+
+        if django.VERSION >= (1, 8):
+            self.override_template_dirs = self.settings(TEMPLATE_DIRS=(django_template_dir, jinja2_template_dir))
+            self.override_template_dirs.__enter__()
+        else:
+            settings.TEMPLATE_DIRS = (django_template_dir, jinja2_template_dir)
 
         # Enable offline compress
         settings.COMPRESS_ENABLED = True
@@ -91,10 +90,14 @@ class OfflineTestCaseMixin(object):
                 self.template_jinja2 = jinja2_env.from_string(file.read())
 
     def tearDown(self):
+        if django.VERSION >= (1, 8):
+            self.override_template_dirs.__exit__(None, None, None)
+        else:
+            settings.TEMPLATE_DIRS = self._old_template_dirs
+
         settings.COMPRESS_JINJA2_GET_ENVIRONMENT = self._old_jinja2_get_environment
         settings.COMPRESS_ENABLED = self._old_compress
         settings.COMPRESS_OFFLINE = self._old_compress_offline
-        settings.TEMPLATE_DIRS = self._old_template_dirs
         manifest_path = os.path.join('CACHE', 'manifest.json')
         if default_storage.exists(manifest_path):
             default_storage.delete(manifest_path)

--- a/compressor/tests/test_offline.py
+++ b/compressor/tests/test_offline.py
@@ -5,7 +5,7 @@ import sys
 
 import django
 from django.core.management.base import CommandError
-from django.template import Template, Context
+from django.template import Template, Context, EngineHandler
 from django.test import TestCase
 from django.utils import six, unittest
 
@@ -47,6 +47,8 @@ class OfflineTestCaseMixin(object):
         engines = ("django",)
 
     def setUp(self):
+        if django.VERSION >= (1, 8):
+            django.template.engines = EngineHandler()
         self._old_compress = settings.COMPRESS_ENABLED
         self._old_compress_offline = settings.COMPRESS_OFFLINE
         self._old_template_dirs = settings.TEMPLATE_DIRS

--- a/compressor/tests/test_offline.py
+++ b/compressor/tests/test_offline.py
@@ -5,7 +5,11 @@ import sys
 
 import django
 from django.core.management.base import CommandError
-from django.template import Template, Context, EngineHandler
+from django.template import Template, Context
+try:
+    from django.template import EngineHandler
+except ImportError:
+    pass
 from django.test import TestCase
 from django.utils import six, unittest
 

--- a/compressor/tests/test_offline.py
+++ b/compressor/tests/test_offline.py
@@ -30,8 +30,6 @@ else:
 #     compressor_nodes.setdefault(template, []).extend(nodes)
 # causes the error "unhashable type: 'Template'"
 _TEST_JINJA2 = not(sys.version_info[0] == 3 and sys.version_info[1] == 2)
-if django.VERSION >= (1, 8):
-    _TEST_JINJA2 = False
 
 
 class OfflineTestCaseMixin(object):

--- a/tox.ini
+++ b/tox.ini
@@ -35,8 +35,8 @@ three_two =
 envlist =
     {py26,py27}-{1.4.X,1.5.X},
     {py26,py27,py32,py33}-{1.6.X},
-    {py27,py32,py33,py34}-{1.7.X}
-
+    {py27,py32,py33,py34}-{1.7.X},
+    {py27,py32,py33,py34}-{1.8.X}
 [testenv]
 basepython =
     py26: python2.6
@@ -57,6 +57,7 @@ deps =
     1.5.X: Django>=1.5,<1.6
     1.6.X: Django>=1.6,<1.7
     1.7.X: Django>=1.7,<1.8
+    1.8.X: Django==1.8b2
     py26: {[deps]two}
     py27: {[deps]two}
     py32: {[deps]three_two}


### PR DESCRIPTION
Work in progress. Build should pass but probably not ready to merge. 

Will Fix #588. 

This is steps towards fixing the `compress` command for 1.8. 

**1**  
I needed to remove `jingo` from `INSTALLED_APPS` for 1.8 — without this, the tests don't even get passed importing. (See 7706bae)

**2**
Having made the changes pointed to by @aaugustin (Thanks again there — you rock!) I was able to get the `compress` command running through with only small changes — and the existing `tox` run still passing.

But...

**3**
The are a lot of test failures if you run against 1.8 (See summary on 72b33ddbcd). These fail into two kinds:

1. Too many compress tags found. 
2. Missing keys from the manifest. 

I'm not currently sure what's a genuine error and what's a result of (for example) **1** above. I'm not familiar enough with the test suite yet to see how the dual tempting works there (and how it might interact with 1.8). 

My next step will be to pull this into a real project to see if the results are as expected. I'll then come back to the tests here. 

I'm hoping that you (@jezdez or @diox or anyone else who knows the test suite) can run this against 1.8 and input some advice about what's happening. (That would be awesome.)

(I can add 1.8 to the tox and/or travis configs if that's a help.)