### PR TITLE
Use environment variable DJANGO_SETTINGS_MODULE.

### DIFF
--- a/compressor/conf.py
+++ b/compressor/conf.py
@@ -80,7 +80,7 @@ class CompressorConf(AppConf):
 
     class Meta:
         prefix = 'compress'
-        holder = os.environ['DJANGO_SETTINGS_MODULE']
+        holder = os.getenv('DJANGO_SETTINGS_MODULE', 'django.conf.settings')
 
     def configure_root(self, value):
         # Uses Django's STATIC_ROOT by default

--- a/compressor/conf.py
+++ b/compressor/conf.py
@@ -82,7 +82,6 @@ class CompressorConf(AppConf):
         prefix = 'compress'
         holder = os.environ['DJANGO_SETTINGS_MODULE']
 
-
     def configure_root(self, value):
         # Uses Django's STATIC_ROOT by default
         if value is None:

--- a/compressor/conf.py
+++ b/compressor/conf.py
@@ -80,6 +80,8 @@ class CompressorConf(AppConf):
 
     class Meta:
         prefix = 'compress'
+        holder = os.environ['DJANGO_SETTINGS_MODULE']
+
 
     def configure_root(self, value):
         # Uses Django's STATIC_ROOT by default


### PR DESCRIPTION
After encountering a problem I found in some issues (fixes #333, fixes #273), I decided to make some investigation. The suggestion made by @panosmm (https://github.com/django-compressor/django-compressor/issues/333#issuecomment-54670664) seemed fine to me, but then I went in the django-appconf documentation, and found the following:

"In case you want to use a different settings object instead of the default 'django.conf.settings', set the holder attribute of the inner Meta class to a dotted import path."

Thus, I think django-compressor should use this holder attribute. I made this PR, allowing django-compressor to use the DJANGO_SETTINGS_MODULE defined in our projects.