### PR TITLE
Fix crash in offline compression when child nodelist is None

### DIFF
--- a/compressor/offline/django.py
+++ b/compressor/offline/django.py
@@ -138,7 +138,7 @@ class DjangoParser(object):
         nodelist = []
         if isinstance(node, Node):
             for attr in node.child_nodelists:
-                nodelist += getattr(node, attr, [])
+                nodelist += getattr(node, attr, None) or []
         else:
             nodelist = getattr(node, 'nodelist', [])
         return nodelist


### PR DESCRIPTION
If a Node had an attribute set to `None` present in `child_nodelist`, `DjangoParser.get_nodelist` would fail.
It happened to me while using compressor in conjunction with sorl-thumbnail.
I have not enough knowledge of the Django template engine to know if sorl-thumbnail is doing something wrong or not but anyway it does not hurt to be more robust.
