### PR TITLE
Fix avoid getting UnicodeDecodeError

### DIFF
--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -234,8 +234,7 @@ class Command(NoArgsCommand):
                 try:
                     result = parser.render_node(template, context, node)
                 except Exception as e:
-                    raise CommandError("An error occured during rendering %s: "
-                                       "%s" % (template.template_name, e))
+                    raise CommandError("An error occured during rendering {template}: {error}".format(template=template.template_name, error=e))
                 offline_manifest[key] = result
                 context.pop()
                 results.append(result)


### PR DESCRIPTION
I ran in to this when the output of uglify-js (the compressor we're using) is outputting something that can't be read as a regular Python string. This PR fixes that bug.

When I was debugging:

```
(Pdb) "An error occured during rendering %s: %s" % (template.template_name, e.message)
*** UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 124: ordinal not in range(128)
(Pdb) "An error occured during rendering {template}: {error}".format(template=template.template_name, error=e)
'An error occured during rendering /Users/mrpi/Workspace/.../assets.html: util.error: Use console.error instead\nParse error at -:29,7\nutil.error: Use console.error instead\nUnexpected token operator \xc2\xab!\xc2\xbb, expected punc \xc2\xab(\xc2\xbb\nutil.error: Use console.error instead\nError\n    at new JS_Parse_Error (/usr/local/lib/node_modules/uglify-js/lib/parse.js:196:18)\n    at js_error (/usr/local/lib/node_modules/uglify-js/lib/parse.js:204:11)\n    at croak (/usr/local/lib/node_modules/uglify-js/lib/parse.js:679:41)\n    at token_error (/usr/local/lib/node_modules/uglify-js/lib/parse.js:683:9)\n    at expect_token (/usr/local/lib/node_modules/uglify-js/lib/parse.js:696:9)\n    at expect (/usr/local/lib/node_modules/uglify-js/lib/parse.js:699:36)\n    at parenthesised (/usr/local/lib/node_modules/uglify-js/lib/parse.js:713:9)\n    at if_ (/usr/local/lib/node_modules/uglify-js/lib/parse.js:985:20)\n    at /usr/local/lib/node_modules/uglify-js/lib/parse.js:813:24\n    at /usr/local/lib/node_modules/uglify-js/lib/parse.js:722:24\n'
```
