### PR TITLE
Fix list formatting in docs/contributing.txt

### DIFF
--- a/docs/contributing.txt
+++ b/docs/contributing.txt
@@ -11,9 +11,9 @@ Community
 
 People interested in developing for the Django Compressor should:
 
-1. Head over to #django-compressor on the `freenode`_ IRC network for help and to
-discuss the development.
-2. Open an issue on GitHub explaining your ideas.
+#. Head over to #django-compressor on the `freenode`_ IRC network for help and to
+   discuss the development.
+#. Open an issue on GitHub explaining your ideas.
 
 
 In a nutshell


### PR DESCRIPTION
Fix formatting in list in docs/contributing.txt.

No list markup was generated at all.