### PR TITLE
contrib.sekizai: handle "kind" prefix with names, e.g. "js_extra"

### DIFF
--- a/compressor/contrib/sekizai.py
+++ b/compressor/contrib/sekizai.py
@@ -15,4 +15,10 @@ def compress(context, data, name):
     Name is either 'js' or 'css' (the sekizai namespace)
     Basically passes the string through the {% compress 'js' %} template tag
     """
+    # Handle multiple namespaces, like "js_page" or "css_extra".
+    if name not in ('js', 'css'):
+        if name.startswith('js'):
+            name = 'js'
+        elif name.startswith('css'):
+            name = 'css'
     return CompressorNode(nodelist=Template(data).nodelist, kind=name, mode='file').render(context=context)


### PR DESCRIPTION
It might be useful to have multiple (compressed) blocks with
django-sekizai, e.g. for global and extra/per-page JavaScript.

While you can usually just use a regular `{% compress js %}` tag for the
global JS then, there are use cases where multiple different
django-sekizai tags are useful.

This patch handles this by looking at the namespace used with the
`render_block` tag and derives the `kind` argument for `CompressorNode`
from its prefix.

This would also address #500 automatically.  /cc @nagyv
