### PR TITLE
Add a very simple testcase for compressor.finders.

### DIFF
--- a/compressor/tests/test_finder.py
+++ b/compressor/tests/test_finder.py
@@ -1,0 +1,15 @@
+from django.test import TestCase
+
+from compressor.finders import CompressorFinder
+from compressor.storage import CompressorFileStorage
+
+
+class FinderTestCase(TestCase):
+
+    def test_has_correct_storage(self):
+        finder = CompressorFinder()
+        self.assertTrue(type(finder.storage) is CompressorFileStorage)
+
+    def test_list_returns_empty_list(self):
+        finder = CompressorFinder()
+        self.assertEquals(finder.list([]), [])


### PR DESCRIPTION
These tests are very trivial, but so is the unit they test, so I guess that is ok. At least ``compressor.finders`` is covered by the testsuite now (it wasn't before, as far as I was able to see).