### PR TITLE
Small refactoring of the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,15 @@ testenv:
 	pip install -r requirements/tests.txt
 	pip install Django
 
-test:
+flake8:
 	flake8 compressor --ignore=E501,E128,E701,E261,E301,E126,E127,E131
+
+runtests:
 	coverage run --branch --source=compressor `which django-admin.py` test --settings=compressor.test_settings compressor
+
+coveragereport:
 	coverage report --omit=compressor/test*,compressor/filters/jsmin/rjsmin*,compressor/filters/cssmin/cssmin*,compressor/utils/stringformat*
 
-.PHONY: test
+test: flake8 runtests coveragereport
+
+.PHONY: test runtests flake8 coveragereport


### PR DESCRIPTION
This allows to easily run the tests without flake8, which makes
writing/debugging tests easier for certain workflows. It should be completely
backwards-compatible.