### PR TITLE
Pin requirements for travis/tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ three_two =
     flake8
     coverage
     html5lib
-    mock
+    mock==1.0.1
     jinja2==2.6
     lxml
     BeautifulSoup4

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,17 @@ two =
     unittest2
     jingo
     coffin<2.0.0
+two_six =
+    flake8
+    coverage
+    html5lib
+    mock==1.0.1
+    jinja2
+    lxml
+    BeautifulSoup
+    unittest2
+    jingo
+    coffin<2.0.0
 three =
     flake8
     coverage
@@ -58,7 +69,7 @@ deps =
     1.6.X: Django>=1.6,<1.7
     1.7.X: Django>=1.7,<1.8
     1.8.X: Django>=1.8,<1.9
-    py26: {[deps]two}
+    py26: {[deps]two_six}
     py27: {[deps]two}
     py32: {[deps]three_two}
     py33: {[deps]three}


### PR DESCRIPTION
Fixes #633.

* Adds specific mock version for Python 2.6

First pass gets the build running again on 2.6. More to do...


