### PR TITLE
Make a copy of offline context before using

### DIFF
--- a/compressor/offline/django.py
+++ b/compressor/offline/django.py
@@ -26,7 +26,7 @@ def handle_extendsnode(extendsnode, block_context=None, original=None):
                   extendsnode.nodelist.get_nodes_by_type(BlockNode))
     block_context.add_blocks(blocks)
 
-    context = Context(settings.COMPRESS_OFFLINE_CONTEXT)
+    context = Context(dict(settings.COMPRESS_OFFLINE_CONTEXT))
     if original is not None:
         context.template = original
 


### PR DESCRIPTION
The offline context dictionary can be changed by the extends node (or a subclass like django-overextends). To prevent carrying over state from previous parsings, make a copy of the offline context.

This bit me with [`django-overextends`](https://github.com/stephenmcd/django-overextends/blob/master/overextends/templatetags/overextends_tags.py#L105) which keeps state in the context between single template renderings but breaks when state is kept between many template renderings.