### PR TITLE
Add caching to CompilerFilter to not re-compile unchanged files (rebased)

### DIFF
--- a/compressor/base.py
+++ b/compressor/base.py
@@ -20,7 +20,7 @@ from compressor.cache import get_hexdigest, get_mtime
 from compressor.conf import settings
 from compressor.exceptions import (CompressorError, UncompressableFileError,
         FilterDoesNotExist)
-from compressor.filters import CompilerFilter
+from compressor.filters import CachedCompilerFilter
 from compressor.storage import compressor_file_storage
 from compressor.signals import post_compress
 from compressor.utils import get_class, get_mod_func, staticfiles
@@ -254,9 +254,9 @@ class Compressor(object):
                 try:
                     mod = import_module(mod_name)
                 except (ImportError, TypeError):
-                    filter = CompilerFilter(
-                        content, filter_type=self.type, filename=filename,
-                        charset=charset, command=filter_or_command)
+                    filter = CachedCompilerFilter(
+                        content=content, filter_type=self.type, filename=filename,
+                        charset=charset, command=filter_or_command, mimetype=mimetype)
                     return True, filter.input(**kwargs)
                 try:
                     precompiler_class = getattr(mod, cls_name)

--- a/compressor/cache.py
+++ b/compressor/cache.py
@@ -136,7 +136,7 @@ def get_hashed_content(filename, length=12):
 
 
 def get_precompiler_cachekey(command, contents):
-    return hashlib.sha1('precompiler.%s.%s' % (command, contents)).hexdigest()
+    return hashlib.sha1(smart_bytes('precompiler.%s.%s' % (command, contents))).hexdigest()
 
 
 def cache_get(key):

--- a/compressor/cache.py
+++ b/compressor/cache.py
@@ -135,6 +135,10 @@ def get_hashed_content(filename, length=12):
         return get_hexdigest(file.read(), length)
 
 
+def get_precompiler_cachekey(command, contents):
+    return hashlib.sha1('precompiler.%s.%s' % (command, contents)).hexdigest()
+
+
 def cache_get(key):
     packed_val = cache.get(key)
     if packed_val is None:

--- a/compressor/conf.py
+++ b/compressor/conf.py
@@ -35,6 +35,7 @@ class CompressorConf(AppConf):
         # ('text/stylus', 'stylus < {infile} > {outfile}'),
         # ('text/x-scss', 'sass --scss {infile} {outfile}'),
     )
+    CACHEABLE_PRECOMPILERS = ()
     CLOSURE_COMPILER_BINARY = 'java -jar compiler.jar'
     CLOSURE_COMPILER_ARGUMENTS = ''
     CSSTIDY_BINARY = 'csstidy'

--- a/compressor/filters/__init__.py
+++ b/compressor/filters/__init__.py
@@ -1,3 +1,3 @@
 # flake8: noqa
 from compressor.filters.base import (FilterBase, CallbackOutputFilter,
-                                     CompilerFilter, FilterError)
+                                     CompilerFilter, CachedCompilerFilter, FilterError)

--- a/compressor/filters/base.py
+++ b/compressor/filters/base.py
@@ -224,7 +224,7 @@ class CachedCompilerFilter(CompilerFilter):
         if self.mimetype in settings.COMPRESS_CACHEABLE_PRECOMPILERS:
             key = self.get_cache_key()
             data = cache.get(key)
-            if data:
+            if data is not None:
                 return data
             filtered = super(CachedCompilerFilter, self).input(**kwargs)
             cache.set(key, filtered, settings.COMPRESS_REBUILD_TIMEOUT)

--- a/compressor/filters/base.py
+++ b/compressor/filters/base.py
@@ -233,4 +233,4 @@ class CachedCompilerFilter(CompilerFilter):
             return super(CachedCompilerFilter, self).input(**kwargs)
 
     def get_cache_key(self):
-        return get_precompiler_cachekey(self.command, self.content.encode('utf8'))
+        return get_precompiler_cachekey(self.command, self.content)

--- a/compressor/tests/test_base.py
+++ b/compressor/tests/test_base.py
@@ -14,7 +14,7 @@ from django.test.utils import override_settings
 
 from compressor import cache as cachemod
 from compressor.base import SOURCE_FILE, SOURCE_HUNK
-from compressor.cache import get_cachekey
+from compressor.cache import get_cachekey, get_precompiler_cachekey
 from compressor.conf import settings
 from compressor.css import CssCompressor
 from compressor.exceptions import FilterDoesNotExist, FilterError
@@ -331,3 +331,9 @@ class CacheTestCase(SimpleTestCase):
     @override_settings(COMPRESS_CACHE_KEY_FUNCTION='invalid.module')
     def test_get_cachekey_invalid_mod(self):
         self.assertRaises(ImportError, lambda: get_cachekey("foo"))
+
+    def test_get_precompiler_cachekey(self):
+        try:
+            get_precompiler_cachekey("asdf", "asdf")
+        except TypeError:
+            self.fail("get_precompiler_cachekey raised TypeError unexpectedly")

--- a/compressor/tests/test_filters.py
+++ b/compressor/tests/test_filters.py
@@ -14,7 +14,7 @@ from compressor.cache import get_hashed_mtime, get_hashed_content
 from compressor.conf import settings
 from compressor.css import CssCompressor
 from compressor.utils import find_command
-from compressor.filters.base import CompilerFilter
+from compressor.filters.base import CompilerFilter, CachedCompilerFilter
 from compressor.filters.cssmin import CSSMinFilter, rCSSMinFilter
 from compressor.filters.css_default import CssAbsoluteFilter
 from compressor.filters.jsmin import JSMinFilter
@@ -51,6 +51,7 @@ class PrecompilerTestCase(TestCase):
     def setUp(self):
         self.test_precompiler = os.path.join(test_dir, 'precompiler.py')
         self.setup_infile()
+        settings.COMPRESS_CACHEABLE_PRECOMPILERS = ('text/css',)
 
     def setup_infile(self, filename='static/css/one.css'):
         self.filename = os.path.join(test_dir, filename)
@@ -104,18 +105,28 @@ class PrecompilerTestCase(TestCase):
 
     def test_precompiler_cache(self):
         command = '%s %s -f {infile} -o {outfile}' % (sys.executable, self.test_precompiler)
-        compiler = CompilerFilter(content=self.content, filename=self.filename, command=command)
+        compiler = CachedCompilerFilter(content=self.content, filename=self.filename, command=command, mimetype='text/css')
         self.assertEqual(u"body { color:#990; }", compiler.input())
         # We tell whether the precompiler actually ran by inspecting compiler.infile. If not None, the compiler had to
         # write the input out to the file for the external command. If None, it was in the cache and thus skipped.
         self.assertIsNotNone(compiler.infile)  # Not cached
 
-        compiler = CompilerFilter(content=self.content, filename=self.filename, command=command)
+        compiler = CachedCompilerFilter(content=self.content, filename=self.filename, command=command, mimetype='text/css')
         self.assertEqual(u"body { color:#990; }", compiler.input())
         self.assertIsNone(compiler.infile)  # Cached
 
         self.content += ' '  # Invalidate cache by slightly changing content
-        compiler = CompilerFilter(content=self.content, filename=self.filename, command=command)
+        compiler = CachedCompilerFilter(content=self.content, filename=self.filename, command=command, mimetype='text/css')
+        self.assertEqual(u"body { color:#990; }", compiler.input())
+        self.assertIsNotNone(compiler.infile)  # Not cached
+
+    def test_precompiler_not_cacheable(self):
+        command = '%s %s -f {infile} -o {outfile}' % (sys.executable, self.test_precompiler)
+        compiler = CachedCompilerFilter(content=self.content, filename=self.filename, command=command, mimetype='text/different')
+        self.assertEqual(u"body { color:#990; }", compiler.input())
+        self.assertIsNotNone(compiler.infile)  # Not cached
+
+        compiler = CachedCompilerFilter(content=self.content, filename=self.filename, command=command, mimetype='text/different')
         self.assertEqual(u"body { color:#990; }", compiler.input())
         self.assertIsNotNone(compiler.infile)  # Not cached
 

--- a/compressor/tests/test_filters.py
+++ b/compressor/tests/test_filters.py
@@ -102,6 +102,23 @@ class PrecompilerTestCase(TestCase):
         compiler = CompilerFilter(content=self.content, filename=self.filename, command=command)
         self.assertEqual(type(compiler.input()), six.text_type)
 
+    def test_precompiler_cache(self):
+        command = '%s %s -f {infile} -o {outfile}' % (sys.executable, self.test_precompiler)
+        compiler = CompilerFilter(content=self.content, filename=self.filename, command=command)
+        self.assertEqual(u"body { color:#990; }", compiler.input())
+        # We tell whether the precompiler actually ran by inspecting compiler.infile. If not None, the compiler had to
+        # write the input out to the file for the external command. If None, it was in the cache and thus skipped.
+        self.assertIsNotNone(compiler.infile)  # Not cached
+
+        compiler = CompilerFilter(content=self.content, filename=self.filename, command=command)
+        self.assertEqual(u"body { color:#990; }", compiler.input())
+        self.assertIsNone(compiler.infile)  # Cached
+
+        self.content += ' '  # Invalidate cache by slightly changing content
+        compiler = CompilerFilter(content=self.content, filename=self.filename, command=command)
+        self.assertEqual(u"body { color:#990; }", compiler.input())
+        self.assertIsNotNone(compiler.infile)  # Not cached
+
 
 class CssMinTestCase(TestCase):
     def test_cssmin_filter(self):

--- a/compressor/tests/test_filters.py
+++ b/compressor/tests/test_filters.py
@@ -10,7 +10,7 @@ from django.test import TestCase
 from django.utils import unittest
 from django.test.utils import override_settings
 
-from compressor.cache import get_hashed_mtime, get_hashed_content
+from compressor.cache import cache, get_hashed_mtime, get_hashed_content
 from compressor.conf import settings
 from compressor.css import CssCompressor
 from compressor.utils import find_command
@@ -133,6 +133,15 @@ class PrecompilerTestCase(TestCase):
         compiler = CachedCompilerFilter(command=command, **self.cached_precompiler_args)
         self.assertEqual("body { color:#990; }", compiler.input())
         self.assertIsNotNone(compiler.infile)  # Not cached
+
+    def test_precompiler_caches_empty_files(self):
+        command = '%s %s -f {infile} -o {outfile}' % (sys.executable, self.test_precompiler)
+        compiler = CachedCompilerFilter(command=command, **self.cached_precompiler_args)
+        self.assertEqual("body { color:#990; }", compiler.input())
+
+        cache.set(compiler.get_cache_key(), "")
+        compiler = CachedCompilerFilter(command=command, **self.cached_precompiler_args)
+        self.assertEqual("", compiler.input())
 
 
 class CssMinTestCase(TestCase):

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -418,6 +418,19 @@ Caching settings
     :attr:`~django.conf.settings.COMPRESS_REBUILD_TIMEOUT` and
     :attr:`~django.conf.settings.COMPRESS_MINT_DELAY`.
 
+.. attribute:: COMPRESS_CACHEABLE_PRECOMPILERS
+
+    :Default: ``()``
+
+    An iterable of precompiler mimetypes as defined in :attr:`~django.conf.settings.COMPRESS_PRECOMPILERS`
+    for which the compiler output can be cached based solely on the contents
+    of the input file. This lets Django Compressor avoid recompiling unchanged
+    files. Caching is appropriate for compilers such as CoffeeScript where files
+    are compiled one-to-one, but not for compilers such as SASS that have an
+    ``import`` mechanism for including one file from another. If caching is enabled
+    for such a compiler, Django Compressor will not know to recompile files when a file
+    they import is modified.
+
 .. attribute:: COMPRESS_DEBUG_TOGGLE
 
     :Default: None


### PR DESCRIPTION
this is a rebase of #346 plus a fix that was necessary to make it work for me.

please let me know whether this kind of functionality can be included and what is missing in this PR, if anything.