### PR TITLE
apply CssAbsoluteFilter to precompiled css even when compression is disabled

### DIFF
--- a/compressor/base.py
+++ b/compressor/base.py
@@ -21,6 +21,7 @@ from compressor.conf import settings
 from compressor.exceptions import (CompressorError, UncompressableFileError,
         FilterDoesNotExist)
 from compressor.filters import CachedCompilerFilter
+from compressor.filters.css_default import CssAbsoluteFilter
 from compressor.storage import compressor_file_storage
 from compressor.signals import post_compress
 from compressor.utils import get_class, get_mod_func, staticfiles
@@ -211,20 +212,24 @@ class Compressor(object):
                 precompiled, value = self.precompile(value, **options)
 
             if enabled:
-                yield self.filter(value, **options)
+                yield self.filter(value, self.cached_filters, **options)
+            elif precompiled:
+                # since precompiling moves files around, it breaks url()
+                # statements in css files. therefore we run the absolute filter
+                # on precompiled css files even if compression is disabled.
+                if CssAbsoluteFilter in self.cached_filters:
+                    value = self.filter(value, [CssAbsoluteFilter], **options)
+                yield self.handle_output(kind, value, forced=True,
+                                         basename=basename)
             else:
-                if precompiled:
-                    yield self.handle_output(kind, value, forced=True,
-                                             basename=basename)
-                else:
-                    yield self.parser.elem_str(elem)
+                yield self.parser.elem_str(elem)
 
     def filter_output(self, content):
         """
         Passes the concatenated content to the 'output' methods
         of the compressor filters.
         """
-        return self.filter(content, method=METHOD_OUTPUT)
+        return self.filter(content, self.cached_filters, method=METHOD_OUTPUT)
 
     def filter_input(self, forced=False):
         """
@@ -275,8 +280,8 @@ class Compressor(object):
             filename=filename)
         return True, filter.input(**kwargs)
 
-    def filter(self, content, method, **kwargs):
-        for filter_cls in self.cached_filters:
+    def filter(self, content, filters, method, **kwargs):
+        for filter_cls in filters:
             filter_func = getattr(
                 filter_cls(content, filter_type=self.type), method)
             try:

--- a/compressor/tests/static/css/relative_url.css
+++ b/compressor/tests/static/css/relative_url.css
@@ -1,0 +1,1 @@
+p { background: url('../img/python.png'); }


### PR DESCRIPTION
this is what i was imagining. ref #331.

fixes #226, fixes #296 