### PR TITLE
Faster 'pseudoclasscolon' implementation in cssmin

### DIFF
--- a/compressor/filters/cssmin/cssmin.py
+++ b/compressor/filters/cssmin/cssmin.py
@@ -80,14 +80,15 @@ def remove_unnecessary_whitespace(css):
         """
 
         regex = re.compile(r"(^|\})(([^\{\:])+\:)+([^\{]*\{)")
-        match = regex.search(css)
-        while match:
-            css = ''.join([
-                css[:match.start()],
-                match.group().replace(":", "___PSEUDOCLASSCOLON___"),
-                css[match.end():]])
-            match = regex.search(css)
-        return css
+        fragments = []
+        offset = 0
+        for match in regex.finditer(css):
+            start, end = match.span()
+            fragments.append(css[offset:start])
+            fragments.append(match.group().replace(":", "___PSEUDOCLASSCOLON___"))
+            offset = end
+        fragments.append(css[offset:])
+        return ''.join(fragments)
 
     css = pseudoclasscolon(css)
     # Remove spaces from before things.


### PR DESCRIPTION
Some profiling revealed that the `pseudoclasscolon(css)` function was taking a lot of time due to the inefficient use of N string joins. Changed implementation to use a single string join and offline compress times for my project dropped from 75 seconds to 13 seconds.

After implementing the change I found an [alternative port](https://github.com/simonwiles/cssmin.py/blob/master/cssmin.py#L93) of the YUI CSS Compressor which has a more compact version using re.sub, if that's preferred.