### PR TITLE
Report test coverage via Codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,7 @@ env:
   - TOXENV=py34-1.8.X
 notifications:
   irc: "irc.freenode.org#django-compressor"
+
+after_success:
+  - pip install codecov
+  - codecov

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Django Compressor
 =================
 
-.. image:: https://coveralls.io/repos/django-compressor/django-compressor/badge.png?branch=develop 
-  :target: https://coveralls.io/r/django-compressor/django-compressor?branch=develop
+.. image:: http://codecov.io/github/django-compressor/django-compressor/coverage.svg?branch=develop
+    :target: http://codecov.io/github/django-compressor/django-compressor?branch=develop
 
 .. image:: https://pypip.in/v/django_compressor/badge.svg
         :target: https://pypi.python.org/pypi/django_compressor


### PR DESCRIPTION
**Full disclosure**: I work for Codecov

Coveralls was disabled in 7c887546dec4990882b33c73d1c0cba2e406c9e9.  I was asked to open this pull request adding Codecov in [this comment][].

Changes:
- Report code coverage to [Codecov][]
- Change Coveralls badge to Codecov

Here are a few reasons you might prefer Codecov over Coveralls:

- The reports are easier to navigate (Codecov uses a tree view, like GitHub)
- Codecov supports branch coverage (this was the main thing that attracted me to Codecov initially)
- Codecov has a browser plugin for viewing coverage overlaid on GitHub

[Here's an example Codecov report for django-compressor][example]

[Example of branch coverage][branch]

[codecov]: https://codecov.io/
[example]: https://codecov.io/github/treyhunner/django-compressor?branch=add-codecov
[this comment]: https://github.com/django-compressor/django-compressor/pull/657#issuecomment-140205004
[branch]: https://codecov.io/github/treyhunner/django-compressor/compressor/cache.py?ref=29c5a341cff6b589a4ef11dac0a4853243686d9b#l-108