### PR TITLE
Remove Django 1.5 and 1.6 from tox and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,7 @@ script:
   - tox
 env:
   - TOXENV=py26-1.4.X
-  - TOXENV=py26-1.5.X
   - TOXENV=py27-1.4.X
-  - TOXENV=py27-1.5.X
-  - TOXENV=py26-1.6.X
-  - TOXENV=py27-1.6.X
-  - TOXENV=py32-1.6.X
-  - TOXENV=py33-1.6.X
   - TOXENV=py27-1.7.X
   - TOXENV=py32-1.7.X
   - TOXENV=py33-1.7.X

--- a/tox.ini
+++ b/tox.ini
@@ -43,8 +43,7 @@ three_two =
     coffin==0.4.0
 [tox]
 envlist =
-    {py26,py27}-{1.4.X,1.5.X},
-    {py26,py27,py32,py33}-{1.6.X},
+    {py26,py27}-1.4.X,
     {py27,py32,py33,py34}-{1.7.X},
     {py27,py32,py33,py34}-{1.8.X}
 [testenv]
@@ -64,8 +63,6 @@ commands =
     make test
 deps =
     1.4.X: Django>=1.4,<1.5
-    1.5.X: Django>=1.5,<1.6
-    1.6.X: Django>=1.6,<1.7
     1.7.X: Django>=1.7,<1.8
     1.8.X: Django>=1.8,<1.9
     py26: {[deps]two_six}


### PR DESCRIPTION
As per discussion on django-compressor/django-appconf#23