### PR TITLE
fix Beatifulsoup v4

### DIFF
--- a/compressor/parser/beautifulsoup.py
+++ b/compressor/parser/beautifulsoup.py
@@ -1,36 +1,34 @@
 from __future__ import absolute_import
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
 from django.utils.encoding import smart_text
 
-from compressor.exceptions import ParserError
 from compressor.parser import ParserBase
-from compressor.utils.decorators import cached_property
 
 
 class BeautifulSoupParser(ParserBase):
 
-    @cached_property
-    def soup(self):
+    def __init__(self, content):
+        super(BeautifulSoupParser, self).__init__(content)
         try:
-            if six.PY3:
-                from bs4 import BeautifulSoup
-            else:
+            from bs4 import BeautifulSoup
+            self.use_bs4 = True
+            self.soup = BeautifulSoup(self.content, "html.parser")
+        except ImportError:
+            try:
                 from BeautifulSoup import BeautifulSoup
-            return BeautifulSoup(self.content)
-        except ImportError as err:
-            raise ImproperlyConfigured("Error while importing BeautifulSoup: %s" % err)
-        except Exception as err:
-            raise ParserError("Error while initializing Parser: %s" % err)
+                self.use_bs4 = False
+                self.soup = BeautifulSoup(self.content)
+            except ImportError as err:
+                raise ImproperlyConfigured("Error while importing BeautifulSoup: %s" % err)
 
     def css_elems(self):
-        if six.PY3:
+        if self.use_bs4:
             return self.soup.find_all({'link': True, 'style': True})
         else:
             return self.soup.findAll({'link': True, 'style': True})
 
     def js_elems(self):
-        if six.PY3:
+        if self.use_bs4:
             return self.soup.find_all('script')
         else:
             return self.soup.findAll('script')

--- a/compressor/parser/beautifulsoup.py
+++ b/compressor/parser/beautifulsoup.py
@@ -34,7 +34,13 @@ class BeautifulSoupParser(ParserBase):
             return self.soup.findAll('script')
 
     def elem_attribs(self, elem):
-        return dict(elem.attrs)
+        attrs = dict(elem.attrs)
+        # hack around changed behaviour in bs4, it returns lists now instead of one string, see
+        # http://www.crummy.com/software/BeautifulSoup/bs4/doc/#multi-valued-attributes
+        for key, value in attrs.items():
+            if type(value) is list:
+                attrs[key] = " ".join(value)
+        return attrs
 
     def elem_content(self, elem):
         return elem.string

--- a/compressor/tests/test_parsers.py
+++ b/compressor/tests/test_parsers.py
@@ -113,6 +113,44 @@ class Html5LibParserTests(ParserTestCase, CompressorTestCase):
 
 class BeautifulSoupParserTests(ParserTestCase, CompressorTestCase):
     parser_cls = 'compressor.parser.BeautifulSoupParser'
+    # just like in the Html5LibParserTests, provide special tests because
+    # in bs4 attributes are held in dictionaries
+
+    def test_css_split(self):
+        split = self.css_node.split_contents()
+        out0 = (
+            SOURCE_FILE,
+            os.path.join(settings.COMPRESS_ROOT, 'css', 'one.css'),
+            'css/one.css',
+            None,
+            None,
+        )
+        self.assertEqual(out0, split[0][:3] + (split[0][3].tag,
+                                               split[0][3].attrib))
+        out1 = (
+            SOURCE_HUNK,
+            'p { border:5px solid green;}',
+            None,
+            '<style type="text/css">p { border:5px solid green;}</style>',
+        )
+        self.assertEqual(out1, split[1][:3] +
+                         (self.css_node.parser.elem_str(split[1][3]),))
+        out2 = (
+            SOURCE_FILE,
+            os.path.join(settings.COMPRESS_ROOT, 'css', 'two.css'),
+            'css/two.css',
+            None,
+            None,
+        )
+        self.assertEqual(out2, split[2][:3] + (split[2][3].tag,
+                                               split[2][3].attrib))
+
+    @override_settings(COMPRESS_ENABLED=False)
+    def test_css_return_if_off(self):
+        # in addition to unspecified attribute order,
+        # bs4 output doesn't have the extra space, so we add that here
+        fixed_output = self.css_node.output().replace('"/>', '" />')
+        self.assertEqual(len(self.css), len(fixed_output))
 
 
 class HtmlParserTests(ParserTestCase, CompressorTestCase):

--- a/compressor/tests/test_parsers.py
+++ b/compressor/tests/test_parsers.py
@@ -11,11 +11,6 @@ try:
 except ImportError:
     html5lib = None
 
-try:
-    from BeautifulSoup import BeautifulSoup
-except ImportError:
-    BeautifulSoup = None
-
 from django.utils import unittest
 from django.test.utils import override_settings
 
@@ -116,7 +111,6 @@ class Html5LibParserTests(ParserTestCase, CompressorTestCase):
         self.assertEqual(len(self.js), len(self.js_node.output()))
 
 
-@unittest.skipIf(BeautifulSoup is None, 'BeautifulSoup not found')
 class BeautifulSoupParserTests(ParserTestCase, CompressorTestCase):
     parser_cls = 'compressor.parser.BeautifulSoupParser'
 

--- a/docs/quickstart.txt
+++ b/docs/quickstart.txt
@@ -66,7 +66,7 @@ Optional
   ``compressor.parser.BeautifulSoupParser`` and
   ``compressor.parser.LxmlParser``::
 
-      pip install "BeautifulSoup<4.0"
+      pip install beautifulsoup4
 
 - lxml_
 

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -4,7 +4,7 @@ html5lib==0.999
 mock==1.0.1
 Jinja2==2.7.3
 lxml==3.4.2
-BeautifulSoup==3.2.1
+beautifulsoup4==4.4.0
 unittest2==1.0.0
 coffin==0.4.0
 jingo==0.7

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ two =
     mock==1.0.1
     Jinja2==2.7.3
     lxml==3.4.2
-    BeautifulSoup==3.2.1
+    beautifulsoup4==4.4.0
     unittest2==1.0.0
     jingo==0.7
     coffin==0.4.0


### PR DESCRIPTION
this makes the beautifulsoup tests actually run with py3. it also fixes the mess that was the selection of which version of beautifulsoup should be used.

the tests fail as bs4 seems to render some stuff differently. i'd like to get some feedback before i fix the remaining tests.

fixes #532, fixes #531, fixes #616