### PR TITLE
Make a copy of offline context before using (includes test)

### DIFF
--- a/compressor/offline/django.py
+++ b/compressor/offline/django.py
@@ -26,7 +26,7 @@ def handle_extendsnode(extendsnode, block_context=None, original=None):
                   extendsnode.nodelist.get_nodes_by_type(BlockNode))
     block_context.add_blocks(blocks)
 
-    context = Context(settings.COMPRESS_OFFLINE_CONTEXT)
+    context = Context(dict(settings.COMPRESS_OFFLINE_CONTEXT))
     if original is not None:
         context.template = original
 

--- a/compressor/test_settings.py
+++ b/compressor/test_settings.py
@@ -23,6 +23,7 @@ INSTALLED_APPS = [
     'compressor',
     'coffin',
     'sekizai',
+    'overextends',
 ]
 if django.VERSION < (1, 8):
     INSTALLED_APPS.append('jingo')

--- a/compressor/tests/test_offline.py
+++ b/compressor/tests/test_offline.py
@@ -517,3 +517,10 @@ class OfflineGenerationJingoTestCase(OfflineTestCaseMixin, TestCase):
         env.globals['url_for'] = url_for
 
         return env
+
+
+class OfflineGenerationOverextendsTestCase(OfflineTestCaseMixin, TestCase):
+    templates_dir = "test_overextends"
+    expected_hash = "e993b2a53994"
+    # overextends not supported for Jinja2 yet.
+    engines = ("django",)

--- a/compressor/tests/test_templates/test_overextends/base.html
+++ b/compressor/tests/test_templates/test_overextends/base.html
@@ -1,0 +1,7 @@
+{% load compress %}{% spaceless %}
+{% compress js %}
+    <script type="text/javascript">
+        alert("test overextends");
+    </script>
+{% endcompress %}
+{% endspaceless %}

--- a/compressor/tests/test_templates/test_overextends/test_compressor_offline.html
+++ b/compressor/tests/test_templates/test_overextends/test_compressor_offline.html
@@ -1,0 +1,1 @@
+{% overextends "base.html" %}

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -9,3 +9,4 @@ unittest2==1.0.0
 coffin==0.4.0
 jingo==0.7
 django-sekizai==0.8.2
+django-overextends==0.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ two =
     jingo==0.7
     coffin==0.4.0
     django-sekizai==0.8.2
+    django-overextends==0.4.0
 two_six =
     flake8==2.4.0
     coverage==3.7.1
@@ -23,6 +24,7 @@ two_six =
     jingo==0.7
     coffin==0.4.0
     django-sekizai==0.8.2
+    django-overextends==0.4.0
 three =
     flake8==2.4.0
     coverage==3.7.1
@@ -34,6 +36,7 @@ three =
     jingo==0.7
     coffin==0.4.0
     django-sekizai==0.8.2
+    django-overextends==0.4.0
 three_two =
     flake8==2.4.0
     coverage==3.7.1
@@ -45,6 +48,7 @@ three_two =
     jingo==0.7
     coffin==0.4.0
     django-sekizai==0.8.2
+    django-overextends==0.4.0
 [tox]
 envlist =
     {py26,py27}-1.4.X,


### PR DESCRIPTION
Redo of #640, with a test added as requested.

This is slightly unrepresentative of real-world use of the django-overextends library, because it's being used to extend a differently-named template rather than a same-named one (i.e. 'extends' would work perfectly well in this case) - but it's enough to reproduce the error, and doing it properly would require additional hacking of `OfflineTestCaseMixin` to allow specifying multiple template dirs.