### PR TITLE
Fix various deprecation warnings on Django 1.7/1.8

### DIFF
--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -60,8 +60,6 @@ class Command(NoArgsCommand):
             dest="engine"),
     )
 
-    requires_model_validation = False
-
     def get_loaders(self):
         if django.VERSION < (1, 8):
             from django.template.loader import template_source_loaders
@@ -302,3 +300,9 @@ class Command(NoArgsCommand):
                     "Offline compression is disabled. Set "
                     "COMPRESS_OFFLINE or use the --force to override.")
         self.compress(sys.stdout, **options)
+
+
+if django.VERSION < (1, 7):
+    Command.requires_model_validation = False
+else:
+    Command.requires_system_checks = False

--- a/compressor/parser/default_htmlparser.py
+++ b/compressor/parser/default_htmlparser.py
@@ -1,3 +1,5 @@
+import sys
+
 from django.utils import six
 from django.utils.encoding import smart_text
 
@@ -5,9 +7,26 @@ from compressor.exceptions import ParserError
 from compressor.parser import ParserBase
 
 
+# Starting in Python 3.2, the HTMLParser constructor takes a 'strict'
+# argument which default to True (which we don't want).
+# In Python 3.3, it defaults to False.
+# In Python 3.4, passing it at all raises a deprecation warning.
+# So we only pass it for 3.2.
+# In Python 3.4, it also takes a 'convert_charrefs' argument
+# which raises a warning if we don't pass it.
+major, minor, release = sys.version_info[:3]
+CONSTRUCTOR_TAKES_STRICT = major == 3 and minor == 2
+CONSTRUCTOR_TAKES_CONVERT_CHARREFS = major == 3 and minor >= 4
+HTML_PARSER_ARGS = {}
+if CONSTRUCTOR_TAKES_STRICT:
+    HTML_PARSER_ARGS['strict'] = False
+if CONSTRUCTOR_TAKES_CONVERT_CHARREFS:
+    HTML_PARSER_ARGS['convert_charrefs'] = False
+
+
 class DefaultHtmlParser(ParserBase, six.moves.html_parser.HTMLParser):
     def __init__(self, content):
-        six.moves.html_parser.HTMLParser.__init__(self)
+        six.moves.html_parser.HTMLParser.__init__(self, **HTML_PARSER_ARGS)
         self.content = content
         self._css_elems = []
         self._js_elems = []

--- a/compressor/storage.py
+++ b/compressor/storage.py
@@ -36,7 +36,7 @@ class CompressorFileStorage(FileSystemStorage):
     def modified_time(self, name):
         return datetime.fromtimestamp(os.path.getmtime(self.path(name)))
 
-    def get_available_name(self, name):
+    def get_available_name(self, name, max_length=None):
         """
         Deletes the given file if it exists.
         """

--- a/compressor/tests/test_offline.py
+++ b/compressor/tests/test_offline.py
@@ -201,9 +201,6 @@ class OfflineCompressBasicTestCase(OfflineTestCaseMixin, TestCase):
         for engine in self.engines:
             self._test_deleting_manifest_does_not_affect_rendering(engine)
 
-    def test_requires_model_validation(self):
-        self.assertFalse(CompressCommand.requires_model_validation)
-
     def test_get_loaders(self):
         TEMPLATE_LOADERS = (
             ('django.template.loaders.cached.Loader', (


### PR DESCRIPTION
Individual commits messages have more info.

There are a few still warnings unaddressed, because they require more work:

* New 'TEMPLATES' setting: https://docs.djangoproject.com/en/1.8/ref/templates/upgrading/#upgrading-templates-to-django-1-8

  If you remove 'TEMPLATE_*' from compressor/test_settings.py (for Django 1.8), as suggested by the instructions above, you get errors because 'TEMPLATE_DIRS' and 'TEMPLATE_LOADERS' are used explicitly by django_compressor.

* Removal or NoArgsCommand - https://docs.djangoproject.com/en/1.8/releases/1.8/#django-core-management-noargscommand

  It is not obvious to me how to succinctly fix this in a way that works the same as it did before but doesn't generate a warning on Django 1.8.
