### PR TITLE
Convert paths to strings before passing them to os.walk

### DIFF
--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -158,7 +158,7 @@ class Command(NoArgsCommand):
             log.write("Considering paths:\n\t" + "\n\t".join(paths) + "\n")
         templates = set()
         for path in paths:
-            for root, dirs, files in os.walk(path,
+            for root, dirs, files in os.walk(str(path),
                     followlinks=options.get('followlinks', False)):
                 templates.update(os.path.join(root, name)
                     for name in files if not name.startswith('.') and


### PR DESCRIPTION
Otherwise os.walk will raise TypeError: coercing to Unicode: need string or buffer, Origin found with the django 1.9 release candidate. Django now passes Origin classes (https://docs.djangoproject.com/en/1.9/ref/templates/api/#django.template.base.Origin). Using Origin.name would probably be better but I don't know if that works in earlier versions.