### PR TITLE
Remove official support for Django 1.4, 1.7, add 1.9.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,14 @@ install:
 script:
   - tox
 env:
-  - TOXENV=py26-1.4.X
-  - TOXENV=py27-1.4.X
-  - TOXENV=py27-1.7.X
-  - TOXENV=py32-1.7.X
-  - TOXENV=py33-1.7.X
-  - TOXENV=py34-1.7.X
   - TOXENV=py27-1.8.X
   - TOXENV=py32-1.8.X
   - TOXENV=py33-1.8.X
   - TOXENV=py34-1.8.X
+  - TOXENV=py27-1.9.X
+  - TOXENV=py34-1.9.X
 notifications:
   irc: "irc.freenode.org#django-compressor"
-
 after_success:
   - pip install codecov
   - codecov

--- a/tox.ini
+++ b/tox.ini
@@ -12,19 +12,6 @@ two =
     coffin==0.4.0
     django-sekizai==0.8.2
     django-overextends==0.4.0
-two_six =
-    flake8==2.4.0
-    coverage==3.7.1
-    html5lib==0.999
-    mock==1.0.1
-    Jinja2==2.7.3
-    lxml==3.4.2
-    BeautifulSoup==3.2.1
-    unittest2==1.0.0
-    jingo==0.7
-    coffin==0.4.0
-    django-sekizai==0.8.2
-    django-overextends==0.4.0
 three =
     flake8==2.4.0
     coverage==3.7.1
@@ -51,12 +38,10 @@ three_two =
     django-overextends==0.4.0
 [tox]
 envlist =
-    {py26,py27}-1.4.X,
-    {py27,py32,py33,py34}-{1.7.X},
     {py27,py32,py33,py34}-{1.8.X}
+    {py27,py34}-{1.9.X}
 [testenv]
 basepython =
-    py26: python2.6
     py27: python2.7
     py32: python3.2
     py33: python3.3
@@ -70,10 +55,8 @@ commands =
     django-admin.py --version
     make test
 deps =
-    1.4.X: Django>=1.4,<1.5
-    1.7.X: Django>=1.7,<1.8
     1.8.X: Django>=1.8,<1.9
-    py26: {[deps]two_six}
+    1.9.X: Django>=1.9,<1.10
     py27: {[deps]two}
     py32: {[deps]three_two}
     py33: {[deps]three}


### PR DESCRIPTION
This also drops Python 2.6.