### PR TITLE
Fix Django 1.9 test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,25 +5,23 @@ install:
 script:
   - tox
 env:
-  - TOXENV=py26-1.4.X
-  - TOXENV=py27-1.4.X
-  - TOXENV=py27-1.7.X
-  - TOXENV=py32-1.7.X
-  - TOXENV=py33-1.7.X
-  - TOXENV=py34-1.7.X
   - TOXENV=py27-1.8.X
   - TOXENV=py32-1.8.X
   - TOXENV=py33-1.8.X
   - TOXENV=py34-1.8.X
+  - TOXENV=py27-1.9.X
+  - TOXENV=py34-1.9.X
 # https://github.com/travis-ci/travis-ci/issues/4794
 matrix:
   include:
     - python: 3.5
       env:
         - TOXENV=py35-1.8.X
+    - python: 3.5
+      env:
+        - TOXENV=py35-1.9.X
 notifications:
   irc: "irc.freenode.org#django-compressor"
-
 after_success:
   - pip install codecov
   - codecov

--- a/compressor/base.py
+++ b/compressor/base.py
@@ -1,19 +1,12 @@
 from __future__ import with_statement, unicode_literals
 import os
 import codecs
+from importlib import import_module
+from six.moves.urllib.request import url2pathname
 
-import django
 from django.core.files.base import ContentFile
-try:
-    from importlib import import_module
-except:
-    from django.utils.importlib import import_module
 from django.utils.safestring import mark_safe
-
-try:
-    from urllib.request import url2pathname
-except ImportError:
-    from urllib import url2pathname
+from django.template.loader import render_to_string
 
 from compressor.cache import get_hexdigest, get_mtime
 from compressor.conf import settings
@@ -23,7 +16,6 @@ from compressor.filters import CachedCompilerFilter
 from compressor.filters.css_default import CssAbsoluteFilter
 from compressor.storage import compressor_file_storage
 from compressor.signals import post_compress
-from django.template.loader import render_to_string
 from compressor.utils import get_class, get_mod_func, staticfiles
 from compressor.utils.decorators import cached_property
 

--- a/compressor/base.py
+++ b/compressor/base.py
@@ -23,24 +23,13 @@ from compressor.filters import CachedCompilerFilter
 from compressor.filters.css_default import CssAbsoluteFilter
 from compressor.storage import compressor_file_storage
 from compressor.signals import post_compress
+from django.template.loader import render_to_string
 from compressor.utils import get_class, get_mod_func, staticfiles
 from compressor.utils.decorators import cached_property
 
 # Some constants for nicer handling.
 SOURCE_HUNK, SOURCE_FILE = 'inline', 'file'
 METHOD_INPUT, METHOD_OUTPUT = 'input', 'output'
-
-
-if django.VERSION < (1, 8):
-    # Provide render_to_string that is similar to Django 1.8 version, for our
-    # needs, using what < 1.8 provides:
-    from django.template.loader import render_to_string as django_render_to_string
-
-    def render_to_string(template_name, context=None):
-        return django_render_to_string(template_name, dictionary=context)
-
-else:
-    from django.template.loader import render_to_string
 
 
 class Compressor(object):

--- a/compressor/cache.py
+++ b/compressor/cache.py
@@ -3,22 +3,12 @@ import hashlib
 import os
 import socket
 import time
+from importlib import import_module
 
-try:
-    from django.core.cache import caches
-    def get_cache(name):
-        return caches[name]
-except ImportError:
-    from django.core.cache import get_cache
-
+from django.core.cache import caches
 from django.core.files.base import ContentFile
 from django.utils.encoding import force_text, smart_bytes
 from django.utils.functional import SimpleLazyObject
-
-try:
-    from importlib import import_module
-except:
-    from django.utils.importlib import import_module
 
 from compressor.conf import settings
 from compressor.storage import default_storage
@@ -162,4 +152,4 @@ def cache_set(key, val, refreshed=False, timeout=None):
     return cache.set(key, packed_val, real_timeout)
 
 
-cache = SimpleLazyObject(lambda: get_cache(settings.COMPRESS_CACHE_BACKEND))
+cache = SimpleLazyObject(lambda: caches[settings.COMPRESS_CACHE_BACKEND])

--- a/compressor/filters/base.py
+++ b/compressor/filters/base.py
@@ -3,6 +3,7 @@ import io
 import logging
 import subprocess
 
+from importlib import import_module
 from platform import system
 
 if system() != "Windows":
@@ -18,11 +19,6 @@ else:
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.temp import NamedTemporaryFile
-
-try:
-    from importlib import import_module
-except ImportError:
-    from django.utils.importlib import import_module
 
 from django.utils.encoding import smart_text
 from django.utils import six

--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -143,7 +143,7 @@ class Command(NoArgsCommand):
                     'get_template_sources', None)
                 if get_template_sources is None:
                     get_template_sources = loader.get_template_sources
-                paths.update(list(get_template_sources('')))
+                paths.update(str(origin) for origin in get_template_sources(''))
             except (ImportError, AttributeError, TypeError):
                 # Yeah, this didn't work out so well, let's move on
                 pass

--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -2,8 +2,10 @@
 import os
 import sys
 
+from collections import OrderedDict
 from fnmatch import fnmatch
 from optparse import make_option
+from importlib import import_module
 
 import django
 from django.core.management.base import BaseCommand, CommandError
@@ -11,15 +13,6 @@ import django.template
 from django.template import Context
 from django.utils import six
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    from django.utils.datastructures import SortedDict as OrderedDict
-
-try:
-    from importlib import import_module
-except:
-    from django.utils.importlib import import_module
 from django.template.loader import get_template  # noqa Leave this in to preload template locations
 from django.template import engines
 

--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -6,7 +6,7 @@ from fnmatch import fnmatch
 from optparse import make_option
 
 import django
-from django.core.management.base import NoArgsCommand, CommandError
+from django.core.management.base import BaseCommand, CommandError
 import django.template
 from django.template import Context
 from django.utils import six
@@ -40,9 +40,9 @@ else:
         from StringIO import StringIO
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = "Compress content outside of the request/response cycle"
-    option_list = NoArgsCommand.option_list + (
+    option_list = BaseCommand.option_list + (
         make_option('--extension', '-e', action='append', dest='extensions',
             help='The file extension(s) to examine (default: ".html", '
                 'separate multiple extensions with commas, or use -e '

--- a/compressor/management/commands/mtime_cache.py
+++ b/compressor/management/commands/mtime_cache.py
@@ -2,15 +2,15 @@ import fnmatch
 import os
 from optparse import make_option
 
-from django.core.management.base import NoArgsCommand, CommandError
+from django.core.management.base import BaseCommand, CommandError
 
 from compressor.conf import settings
 from compressor.cache import cache, get_mtime, get_mtime_cachekey
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = "Add or remove all mtime values from the cache"
-    option_list = NoArgsCommand.option_list + (
+    option_list = BaseCommand.option_list + (
         make_option('-i', '--ignore', action='append', default=[],
             dest='ignore_patterns', metavar='PATTERN',
             help="Ignore files or directories matching this glob-style "

--- a/compressor/offline/django.py
+++ b/compressor/offline/django.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from copy import copy
 
-import django
 from django import template
 from django.template import Context
 from django.template.base import Node, VariableNode, TextNode, NodeList
@@ -101,10 +100,7 @@ class DjangoParser(object):
 
     def parse(self, template_name):
         try:
-            if django.VERSION < (1, 8):
-                return get_template(template_name)
-            else:
-                return get_template(template_name).template
+            return get_template(template_name).template
         except template.TemplateSyntaxError as e:
             raise TemplateSyntaxError(str(e))
         except template.TemplateDoesNotExist as e:
@@ -120,8 +116,7 @@ class DjangoParser(object):
         pass
 
     def render_nodelist(self, template, context, node):
-        if django.VERSION >= (1, 8):
-            context.template = template
+        context.template = template
         return node.nodelist.render(context)
 
     def render_node(self, template, context, node):
@@ -146,7 +141,7 @@ class DjangoParser(object):
         return nodelist
 
     def walk_nodes(self, node, original=None):
-        if django.VERSION >= (1, 8) and original is None:
+        if original is None:
             original = node
         for node in self.get_nodelist(node, original):
             if isinstance(node, CompressorNode) and node.is_offline_compression_enabled(forced=True):

--- a/compressor/parser/__init__.py
+++ b/compressor/parser/__init__.py
@@ -1,9 +1,7 @@
+from importlib import import_module
+
 from django.utils import six
 from django.utils.functional import LazyObject
-try:
-    from importlib import import_module
-except ImportError:
-    from django.utils.importlib import import_module
 
 # support legacy parser module usage
 from compressor.parser.base import ParserBase  # noqa

--- a/compressor/test_settings.py
+++ b/compressor/test_settings.py
@@ -23,10 +23,14 @@ INSTALLED_APPS = [
     'compressor',
     'coffin',
     'sekizai',
-    'overextends',
 ]
 if django.VERSION < (1, 8):
     INSTALLED_APPS.append('jingo')
+
+ # currently, we can't use overextends and django 1.9 since that would
+ # require updating the templates settings to the new format.
+if django.VERSION < (1, 9):
+    INSTALLED_APPS.append('overextends')
 
 STATICFILES_FINDERS = [
     'django.contrib.staticfiles.finders.FileSystemFinder',

--- a/compressor/test_settings.py
+++ b/compressor/test_settings.py
@@ -24,8 +24,8 @@ INSTALLED_APPS = [
     'sekizai',
 ]
 
- # currently, we can't use overextends and django 1.9 since that would
- # require updating the templates settings to the new format.
+# currently, we can't use overextends and django 1.9 since that would
+# require updating the templates settings to the new format.
 if django.VERSION < (1, 9):
     INSTALLED_APPS.append('overextends')
 
@@ -46,9 +46,6 @@ TEMPLATE_DIRS = (
     # a specific template without considering the others.
     os.path.join(TEST_DIR, 'test_templates'),
 )
-
-if django.VERSION[:2] < (1, 6):
-    TEST_RUNNER = 'discover_runner.DiscoverRunner'
 
 SECRET_KEY = "iufoj=mibkpdz*%bob952x(%49rqgv8gg45k36kjcg76&-y5=!"
 

--- a/compressor/test_settings.py
+++ b/compressor/test_settings.py
@@ -21,7 +21,6 @@ DATABASES = {
 INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'compressor',
-    'coffin',
     'sekizai',
 ]
 if django.VERSION < (1, 8):

--- a/compressor/test_settings.py
+++ b/compressor/test_settings.py
@@ -23,8 +23,6 @@ INSTALLED_APPS = [
     'compressor',
     'sekizai',
 ]
-if django.VERSION < (1, 8):
-    INSTALLED_APPS.append('jingo')
 
  # currently, we can't use overextends and django 1.9 since that would
  # require updating the templates settings to the new format.

--- a/compressor/tests/test_jinja2ext.py
+++ b/compressor/tests/test_jinja2ext.py
@@ -2,9 +2,10 @@
 from __future__ import with_statement, unicode_literals
 
 import sys
+import unittest
 
 from django.test import TestCase
-from django.utils import unittest, six
+from django.utils import six
 from django.test.utils import override_settings
 
 from compressor.conf import settings

--- a/compressor/tests/test_offline.py
+++ b/compressor/tests/test_offline.py
@@ -589,31 +589,6 @@ class OfflineCompressComplexTestCase(OfflineTestCaseMixin, TestCase):
         self.assertEqual(rendered_template, ''.join(result) + '\n')
 
 
-# Coffin does not work on Python 3.2+ due to:
-# The line at coffin/template/__init__.py:15
-#     from library import *
-# causing 'ImportError: No module named library'.
-# It seems there is no evidence nor indicated support for Python 3+.
-@unittest.skipIf(sys.version_info >= (3, 2), 'Coffin does not support 3.2+')
-@unittest.skipIf(django.VERSION >= (1, 8), 'Import error on 1.8')
-class OfflineCompressCoffinTestCase(OfflineTestCaseMixin, TestCase):
-    templates_dir = 'test_coffin'
-    expected_hash = '32c8281e3346'
-    engines = ('jinja2',)
-
-    def _get_jinja2_env(self):
-        import jinja2
-        from coffin.common import env
-        from compressor.contrib.jinja2ext import CompressorExtension
-
-        # Could have used the env.add_extension method, but it's only available
-        # in Jinja2 v2.5
-        new_env = jinja2.Environment(extensions=[CompressorExtension])
-        env.extensions.update(new_env.extensions)
-
-        return env
-
-
 # Jingo does not work when using Python 3.2 due to the use of Unicode string
 # prefix (and possibly other stuff), but it actually works when using Python
 # 3.3 since it tolerates the use of the Unicode string prefix. Python 3.3

--- a/compressor/tests/test_offline.py
+++ b/compressor/tests/test_offline.py
@@ -2,13 +2,14 @@ from __future__ import with_statement, unicode_literals
 import io
 import os
 import sys
+import unittest
+from importlib import import_module
 
 import django
 from django.core.management.base import CommandError
 from django.template import Template, Context
 from django.test import TestCase
-from django.utils import six, unittest
-from django.utils.importlib import import_module
+from django.utils import six
 
 from compressor.cache import flush_offline_manifest, get_offline_manifest
 from compressor.conf import settings

--- a/compressor/tests/test_offline.py
+++ b/compressor/tests/test_offline.py
@@ -590,35 +590,6 @@ class OfflineCompressComplexTestCase(OfflineTestCaseMixin, TestCase):
         self.assertEqual(rendered_template, ''.join(result) + '\n')
 
 
-# Jingo does not work when using Python 3.2 due to the use of Unicode string
-# prefix (and possibly other stuff), but it actually works when using Python
-# 3.3 since it tolerates the use of the Unicode string prefix. Python 3.3
-# support is also evident in its tox.ini file.
-@unittest.skipIf(sys.version_info >= (3, 2) and sys.version_info < (3, 3),
-                 'Jingo does not support 3.2')
-@unittest.skipIf(django.VERSION >= (1, 8), 'Import error on 1.8')
-class OfflineCompressJingoTestCase(OfflineTestCaseMixin, TestCase):
-    templates_dir = 'test_jingo'
-    expected_hash = '61ec584468eb'
-    engines = ('jinja2',)
-
-    def _get_jinja2_env(self):
-        import jinja2
-        import jinja2.ext
-        from jingo import env
-        from compressor.contrib.jinja2ext import CompressorExtension
-        from compressor.offline.jinja2 import SpacelessExtension, url_for
-
-        # Could have used the env.add_extension method, but it's only available
-        # in Jinja2 v2.5
-        new_env = jinja2.Environment(extensions=[
-            CompressorExtension, SpacelessExtension, jinja2.ext.with_])
-        env.extensions.update(new_env.extensions)
-        env.globals['url_for'] = url_for
-
-        return env
-
-
 @unittest.skipIf(django.VERSION >= (1, 9), 'overextends does not yet support django 1.9')
 class OfflineGenerationOverextendsTestCase(OfflineTestCaseMixin, TestCase):
     templates_dir = "test_overextends"

--- a/compressor/tests/test_offline.py
+++ b/compressor/tests/test_offline.py
@@ -643,6 +643,7 @@ class OfflineCompressJingoTestCase(OfflineTestCaseMixin, TestCase):
         return env
 
 
+@unittest.skipIf(django.VERSION >= (1, 9), 'overextends does not yet support django 1.9')
 class OfflineGenerationOverextendsTestCase(OfflineTestCaseMixin, TestCase):
     templates_dir = "test_overextends"
     expected_hash = "e993b2a53994"

--- a/compressor/tests/test_parsers.py
+++ b/compressor/tests/test_parsers.py
@@ -1,5 +1,6 @@
 from __future__ import with_statement
 import os
+import unittest
 
 try:
     import lxml
@@ -11,7 +12,6 @@ try:
 except ImportError:
     html5lib = None
 
-from django.utils import unittest
 from django.test.utils import override_settings
 
 from compressor.base import SOURCE_HUNK, SOURCE_FILE

--- a/compressor/tests/test_utils.py
+++ b/compressor/tests/test_utils.py
@@ -1,4 +1,5 @@
-from django.utils import unittest
+import unittest
+
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.conf import settings

--- a/compressor/tests/test_utils.py
+++ b/compressor/tests/test_utils.py
@@ -1,5 +1,3 @@
-import unittest
-
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.conf import settings
@@ -31,8 +29,6 @@ class StaticFilesTestCase(TestCase):
         self.assertTrue(compressor.utils.staticfiles.finders is
                         django.contrib.staticfiles.finders)
 
-    @unittest.skipIf(django.VERSION < (1, 7),
-                     "No app registry in Django < 1.7")
     def test_has_finders_from_staticfiles_if_configured_per_appconfig(self):
         apps = get_apps_with_staticfiles_using_appconfig(
             settings.INSTALLED_APPS)

--- a/compressor/tests/test_utils.py
+++ b/compressor/tests/test_utils.py
@@ -6,11 +6,7 @@ import django
 
 import compressor.utils.staticfiles
 
-try:
-    import imp
-    reload = imp.reload  # Python 3
-except ImportError:
-    pass
+from imp import reload
 
 
 def get_apps_without_staticfiles(apps):

--- a/compressor/utils/staticfiles.py
+++ b/compressor/utils/staticfiles.py
@@ -1,19 +1,12 @@
 from __future__ import absolute_import, unicode_literals
 
-import django
+from django.apps import apps
 from django.core.exceptions import ImproperlyConfigured
 
 from compressor.conf import settings
 
 
-def staticfiles_installed():
-    if django.VERSION < (1, 7):
-        return "django.contrib.staticfiles" in settings.INSTALLED_APPS
-    from django.apps import apps
-    return apps.is_installed("django.contrib.staticfiles")
-
-
-if staticfiles_installed():
+if apps.is_installed("django.contrib.staticfiles"):
     from django.contrib.staticfiles import finders  # noqa
 
     if ("compressor.finders.CompressorFinder"

--- a/docs/jinja2.txt
+++ b/docs/jinja2.txt
@@ -72,10 +72,7 @@ method, and is in the ``TEMPLATE_LOADERS`` setting.
 
 If you're using Jinja2, you're likely to have a Jinja2 template loader in the
 ``TEMPLATE_LOADERS`` setting, otherwise Django won't know how to load Jinja2
-templates. You could use Jingo_ or your own custom loader.
-
-Unfortunately, Jingo_ does not implement such a method in its loader,
-read on to understand how to make Compressor work nicely with Jingo_.
+templates.
 
 By default, if you don't override the ``TEMPLATE_LOADERS`` setting,
 it will include the app directories loader that searches for templates under
@@ -87,29 +84,6 @@ However, if you have Jinja2 templates in other location(s), you could include
 the filesystem loader (``django.template.loaders.filesystem.Loader``) in the
 ``TEMPLATE_LOADERS`` setting and specify the custom location in the
 ``TEMPLATE_DIRS`` setting.
-
-For Jingo users
----------------
-You should configure ``TEMPLATE_LOADERS`` as such::
-
-    TEMPLATE_LOADERS = (
-        'jingo.Loader',
-        'django.template.loaders.filesystem.Loader',
-        'django.template.loaders.app_directories.Loader',
-    )
-
-    def COMPRESS_JINJA2_GET_ENVIRONMENT():
-        # TODO: ensure the CompressorExtension is installed with Jingo via
-        # Jingo's JINJA_CONFIG setting.
-        # Additional globals, filters, tests,
-        # and extensions used within {%compress%} blocks must be configured
-        # with Jingo.
-        from jingo import env
-
-        return env
-
-This will enable the Jingo_ loader to load Jinja2 templates and the other
-loaders to report the templates location(s).
 
 Using your custom loader
 ------------------------
@@ -123,12 +97,6 @@ You should configure ``TEMPLATE_LOADERS`` as such::
 You could implement the `get_template_sources` method in your loader or make
 use of the Django's builtin loaders to report the Jinja2 template location(s).
 
-Python 3 Support
-----------------
-Jingo with Jinja2 are tested and work on Python 2.6, 2.7, and 3.3.
-Jinja2 alone (with custom loader) are tested and work on Python 2.6, 2.7 and
-3.3 only.
 
 
 .. _Jinja2: http://jinja.pocoo.org/docs/
-.. _Jingo: https://jingo.readthedocs.org/en/latest/

--- a/docs/jinja2.txt
+++ b/docs/jinja2.txt
@@ -24,19 +24,6 @@ From now on, you can use same code you'd normally use within Django templates::
     ]))
     template.render({'STATIC_URL': settings.STATIC_URL})
 
-For coffin users
-----------------
-
-Coffin_ makes it very easy to include additional Jinja2_ extensions as it
-only requires to add extension to ``JINJA2_EXTENSIONS`` at main settings
-module::
-
-    JINJA2_EXTENSIONS = [
-        'compressor.contrib.jinja2ext.CompressorExtension',
-    ]
-
-And that's it - our extension is loaded and ready to be used.
-
 
 Jinja2 Offline Compression Support
 ==================================
@@ -85,13 +72,10 @@ method, and is in the ``TEMPLATE_LOADERS`` setting.
 
 If you're using Jinja2, you're likely to have a Jinja2 template loader in the
 ``TEMPLATE_LOADERS`` setting, otherwise Django won't know how to load Jinja2
-templates. You could use Jingo_ or your own custom loader. Coffin_ works
-differently by providing a custom rendering method instead of a custom loader.
+templates. You could use Jingo_ or your own custom loader.
 
-Unfortunately, Jingo_ does not implement such a method in its loader;
-Coffin_ does not seem to have a template loader in the first place.
-Read on to understand how to make Compressor work nicely with Jingo_
-and Coffin_.
+Unfortunately, Jingo_ does not implement such a method in its loader,
+read on to understand how to make Compressor work nicely with Jingo_.
 
 By default, if you don't override the ``TEMPLATE_LOADERS`` setting,
 it will include the app directories loader that searches for templates under
@@ -127,28 +111,6 @@ You should configure ``TEMPLATE_LOADERS`` as such::
 This will enable the Jingo_ loader to load Jinja2 templates and the other
 loaders to report the templates location(s).
 
-For Coffin users
-----------------
-You might want to configure ``TEMPLATE_LOADERS`` as such::
-
-    TEMPLATE_LOADERS = (
-        'django.template.loaders.filesystem.Loader',
-        'django.template.loaders.app_directories.Loader',
-    )
-
-    def COMPRESS_JINJA2_GET_ENVIRONMENT():
-        # TODO: ensure the CompressorExtension is installed with Coffin
-        # as described in the "In-Request Support" section above.
-        # Additional globals, filters, tests,
-        # and extensions used within {%compress%} blocks must be configured
-        # with Coffin.
-        from coffin.common import env
-
-        return env
-
-Again, if you have the Jinja2 templates in the app template directories, you're
-done here. Otherwise, specify the location in ``TEMPLATE_DIRS``.
-
 Using your custom loader
 ------------------------
 You should configure ``TEMPLATE_LOADERS`` as such::
@@ -164,11 +126,9 @@ use of the Django's builtin loaders to report the Jinja2 template location(s).
 Python 3 Support
 ----------------
 Jingo with Jinja2 are tested and work on Python 2.6, 2.7, and 3.3.
-Coffin with Jinja2 are tested and work on Python 2.6 and 2.7 only.
 Jinja2 alone (with custom loader) are tested and work on Python 2.6, 2.7 and
 3.3 only.
 
 
 .. _Jinja2: http://jinja.pocoo.org/docs/
-.. _Coffin: http://pypi.python.org/pypi/Coffin
 .. _Jingo: https://jingo.readthedocs.org/en/latest/

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -5,7 +5,6 @@ mock==1.0.1
 Jinja2==2.7.3
 lxml==3.4.2
 beautifulsoup4==4.4.0
-jingo==0.7
 django-sekizai==0.9.0
 django-overextends==0.4.0
 csscompressor==0.9.4

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -6,7 +6,6 @@ Jinja2==2.7.3
 lxml==3.4.2
 beautifulsoup4==4.4.0
 unittest2==1.0.0
-coffin==0.4.0
 jingo==0.7
 django-sekizai==0.8.2
 django-overextends==0.4.0

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -7,7 +7,7 @@ lxml==3.4.2
 beautifulsoup4==4.4.0
 unittest2==1.0.0
 jingo==0.7
-django-sekizai==0.8.2
+django-sekizai==0.9.0
 django-overextends==0.4.0
 csscompressor==0.9.4
 rcssmin==1.0.6

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -5,7 +5,6 @@ mock==1.0.1
 Jinja2==2.7.3
 lxml==3.4.2
 beautifulsoup4==4.4.0
-unittest2==1.0.0
 jingo==0.7
 django-sekizai==0.9.0
 django-overextends==0.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -15,22 +15,6 @@ two =
     csscompressor==0.9.4
     rcssmin==1.0.6
     rjsmin==1.0.12
-two_six =
-    flake8==2.4.0
-    coverage==3.7.1
-    html5lib==0.999
-    mock==1.0.1
-    Jinja2==2.7.3
-    lxml==3.4.2
-    beautifulsoup4==4.4.0
-    unittest2==1.0.0
-    jingo==0.7
-    coffin==0.4.0
-    django-sekizai==0.8.2
-    django-overextends==0.4.0
-    csscompressor==0.9.4
-    rcssmin==1.0.6
-    rjsmin==1.0.12
 three =
     flake8==2.4.0
     coverage==3.7.1
@@ -63,12 +47,10 @@ three_two =
     rjsmin==1.0.12
 [tox]
 envlist =
-    {py26,py27}-1.4.X,
-    {py27,py32,py33,py34}-{1.7.X},
     {py27,py32,py33,py34,py35}-{1.8.X}
+    {py27,py34,py35}-{1.9.X}
 [testenv]
 basepython =
-    py26: python2.6
     py27: python2.7
     py32: python3.2
     py33: python3.3
@@ -83,10 +65,8 @@ commands =
     django-admin.py --version
     make test
 deps =
-    1.4.X: Django>=1.4,<1.5
-    1.7.X: Django>=1.7,<1.8
     1.8.X: Django>=1.8,<1.9
-    py26: {[deps]two_six}
+    1.9.X: Django>=1.9,<1.10
     py27: {[deps]two}
     py32: {[deps]three_two}
     py33: {[deps]three}

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ two =
     beautifulsoup4==4.4.0
     unittest2==1.0.0
     jingo==0.7
-    django-sekizai==0.8.2
+    django-sekizai==0.9.0
     django-overextends==0.4.0
     csscompressor==0.9.4
     rcssmin==1.0.6
@@ -23,7 +23,7 @@ three =
     lxml==3.4.2
     beautifulsoup4==4.4.0
     jingo==0.7
-    django-sekizai==0.8.2
+    django-sekizai==0.9.0
     django-overextends==0.4.0
     csscompressor==0.9.4
     rcssmin==1.0.6
@@ -37,7 +37,7 @@ three_two =
     lxml==3.4.2
     beautifulsoup4==4.4.0
     jingo==0.7
-    django-sekizai==0.8.2
+    django-sekizai==0.9.0
     django-overextends==0.4.0
     csscompressor==0.9.4
     rcssmin==1.0.6

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ two =
     Jinja2==2.7.3
     lxml==3.4.2
     beautifulsoup4==4.4.0
-    jingo==0.7
     django-sekizai==0.9.0
     django-overextends==0.4.0
     csscompressor==0.9.4
@@ -21,7 +20,6 @@ three =
     Jinja2==2.7.3
     lxml==3.4.2
     beautifulsoup4==4.4.0
-    jingo==0.7
     django-sekizai==0.9.0
     django-overextends==0.4.0
     csscompressor==0.9.4
@@ -35,7 +33,6 @@ three_two =
     Jinja2==2.6
     lxml==3.4.2
     beautifulsoup4==4.4.0
-    jingo==0.7
     django-sekizai==0.9.0
     django-overextends==0.4.0
     csscompressor==0.9.4

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ two =
     beautifulsoup4==4.4.0
     unittest2==1.0.0
     jingo==0.7
-    coffin==0.4.0
     django-sekizai==0.8.2
     django-overextends==0.4.0
     csscompressor==0.9.4
@@ -24,7 +23,6 @@ three =
     lxml==3.4.2
     beautifulsoup4==4.4.0
     jingo==0.7
-    coffin==0.4.0
     django-sekizai==0.8.2
     django-overextends==0.4.0
     csscompressor==0.9.4
@@ -39,7 +37,6 @@ three_two =
     lxml==3.4.2
     beautifulsoup4==4.4.0
     jingo==0.7
-    coffin==0.4.0
     django-sekizai==0.8.2
     django-overextends==0.4.0
     csscompressor==0.9.4

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ two =
     Jinja2==2.7.3
     lxml==3.4.2
     beautifulsoup4==4.4.0
-    unittest2==1.0.0
     jingo==0.7
     django-sekizai==0.9.0
     django-overextends==0.4.0


### PR DESCRIPTION
fixes #675, fixes #676

closes #697 which is included
closes #695 which is kinda included as well

@diox, could you have a look at the remaining test failures? one is that the overextends tag could not be found, the other that some hashes are not in the manifest. you have any idea about either of these?