### PR TITLE
django 1.9 fix template loader Origin

### DIFF
--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -131,7 +131,7 @@ class Command(BaseCommand):
             log.write("Considering paths:\n\t" + "\n\t".join(paths) + "\n")
         templates = set()
         for path in paths:
-            for root, dirs, files in os.walk(path,
+            for root, dirs, files in os.walk(str(path),
                     followlinks=options.get('followlinks', False)):
                 templates.update(os.path.join(root, name)
                     for name in files if not name.startswith('.') and


### PR DESCRIPTION
a tiny change to fix the os.walk `path` parameter in Django 1.9, the problem occurs because the template loaders are yielding an Origin instance and not a string(template name), therefore we need the `name` property

see:
https://github.com/django/django/blob/stable/1.9.x/django/template/loaders/filesystem.py#L47