### PR TITLE
Switch remaining tests to use override_settings. Fixes #669

### DIFF
--- a/compressor/tests/test_base.py
+++ b/compressor/tests/test_base.py
@@ -89,12 +89,14 @@ class PrecompilerAndAbsoluteFilterTestCase(SimpleTestCase):
         self.helper(enabled=True, use_precompiler=True, use_absolute_filter=True, expected_output=self.css_absolutized)
 
 
+@override_settings(
+    COMPRESS_ENABLED=True,
+    COMPRESS_PRECOMPILERS=(),
+    COMPRESS_DEBUG_TOGGLE='nocompress',
+)
 class CompressorTestCase(SimpleTestCase):
 
     def setUp(self):
-        settings.COMPRESS_ENABLED = True
-        settings.COMPRESS_PRECOMPILERS = ()
-        settings.COMPRESS_DEBUG_TOGGLE = 'nocompress'
         self.css = """\
 <link rel="stylesheet" href="/static/css/one.css" type="text/css" />
 <style type="text/css">p { border:5px solid green;}</style>
@@ -315,11 +317,9 @@ class CssMediaTestCase(SimpleTestCase):
                          [l.get('media', None) for l in output])
 
 
+@override_settings(COMPRESS_VERBOSE=True)
 class VerboseTestCase(CompressorTestCase):
-
-    def setUp(self):
-        super(VerboseTestCase, self).setUp()
-        settings.COMPRESS_VERBOSE = True
+    pass
 
 
 class CacheBackendTestCase(CompressorTestCase):

--- a/compressor/tests/test_filters.py
+++ b/compressor/tests/test_filters.py
@@ -191,8 +191,9 @@ class CssAbsolutizingTestCase(TestCase):
                 "p { filter: Alpha(src='%(url)simg/python.png%(query)s%(hash)s%(frag)s') }")
 
     def setUp(self):
-        self.old_hashing_method = settings.COMPRESS_CSS_HASHING_METHOD
-        settings.COMPRESS_CSS_HASHING_METHOD = self.hashing_method
+        self.override_settings = self.settings(COMPRESS_CSS_HASHING_METHOD=self.hashing_method)
+        self.override_settings.__enter__()
+
         self.css = """
         <link rel="stylesheet" href="/static/css/url/url1.css" type="text/css">
         <link rel="stylesheet" href="/static/css/url/2/url2.css" type="text/css">
@@ -200,7 +201,7 @@ class CssAbsolutizingTestCase(TestCase):
         self.css_node = CssCompressor(self.css)
 
     def tearDown(self):
-        settings.COMPRESS_CSS_HASHING_METHOD = self.old_hashing_method
+        self.override_settings.__exit__(None, None, None)
 
     @override_settings(COMPRESS_CSS_HASHING_METHOD=None)
     def test_css_no_hash(self):

--- a/compressor/tests/test_parsers.py
+++ b/compressor/tests/test_parsers.py
@@ -21,12 +21,12 @@ from compressor.tests.test_base import CompressorTestCase
 
 class ParserTestCase(object):
     def setUp(self):
-        self.old_parser = settings.COMPRESS_PARSER
-        settings.COMPRESS_PARSER = self.parser_cls
+        self.override_settings = self.settings(COMPRESS_PARSER=self.parser_cls)
+        self.override_settings.__enter__()
         super(ParserTestCase, self).setUp()
 
     def tearDown(self):
-        settings.COMPRESS_PARSER = self.old_parser
+        self.override_settings.__exit__(None, None, None)
 
 
 @unittest.skipIf(lxml is None, 'lxml not found')

--- a/compressor/tests/test_templatetags.py
+++ b/compressor/tests/test_templatetags.py
@@ -141,22 +141,23 @@ class TemplatetagTestCase(TestCase):
 
 class PrecompilerTemplatetagTestCase(TestCase):
     def setUp(self):
-        self.old_enabled = settings.COMPRESS_ENABLED
-        self.old_precompilers = settings.COMPRESS_PRECOMPILERS
-
         precompiler = os.path.join(test_dir, 'precompiler.py')
         python = sys.executable
 
-        settings.COMPRESS_ENABLED = True
-        settings.COMPRESS_PRECOMPILERS = (
-            ('text/coffeescript', '%s %s' % (python, precompiler)),
-            ('text/less', '%s %s' % (python, precompiler)),
-        )
+        override_settings = {
+            'COMPRESS_ENABLED': True,
+            'COMPRESS_PRECOMPILERS': (
+                ('text/coffeescript', '%s %s' % (python, precompiler)),
+                ('text/less', '%s %s' % (python, precompiler)),
+            )
+        }
+        self.override_settings = self.settings(**override_settings)
+        self.override_settings.__enter__()
+
         self.context = {'STATIC_URL': settings.COMPRESS_URL}
 
     def tearDown(self):
-        settings.COMPRESS_ENABLED = self.old_enabled
-        settings.COMPRESS_PRECOMPILERS = self.old_precompilers
+        self.override_settings.__exit__(None, None, None)
 
     def test_compress_coffeescript_tag(self):
         template = """{% load compress %}{% compress js %}


### PR DESCRIPTION
Fixes #669.

I didn't use the decorator in some places because the new value was determined dynamically.