### PR TITLE
Fix offline extends recursion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 sudo: false
 install:
+  - if [[ $TOXENV == py32-1.8.X ]]; then pip install pip\<8.0.0 virtualenv\<14.0.0; fi
   - pip install tox
 script:
   - tox

--- a/compressor/offline/django.py
+++ b/compressor/offline/django.py
@@ -18,8 +18,9 @@ def handle_extendsnode(extendsnode, context):
     all blocks tags with the nodes of appropriate blocks.
     Also handles {{ block.super }} tags.
     """
-    context.render_context.setdefault(BLOCK_CONTEXT_KEY, BlockContext())
-    block_context = context.render_context.get(BLOCK_CONTEXT_KEY)
+    if BLOCK_CONTEXT_KEY not in context.render_context:
+        context.render_context[BLOCK_CONTEXT_KEY] = BlockContext()
+    block_context = context.render_context[BLOCK_CONTEXT_KEY]
     blocks = dict((n.name, n) for n in
                   extendsnode.nodelist.get_nodes_by_type(BlockNode))
     block_context.add_blocks(blocks)

--- a/compressor/tests/test_offline.py
+++ b/compressor/tests/test_offline.py
@@ -1,5 +1,6 @@
 from __future__ import with_statement, unicode_literals
 import copy
+import django
 import io
 import os
 import sys
@@ -9,7 +10,6 @@ from importlib import import_module
 from mock import patch
 from unittest import SkipTest, skipIf
 
-from django import VERSION as DJANGO_VERSION
 from django.core.management.base import CommandError
 from django.template import Template, Context
 from django.test import TestCase
@@ -633,7 +633,7 @@ class OfflineCompressComplexTestCase(OfflineTestCaseMixin, TestCase):
         self.assertEqual(rendered_template, ''.join(result) + '\n')
 
 
-@skipIf(DJANGO_VERSION[0] <= 1 and DJANGO_VERSION[1] < 9, "Needs Django >= 1.9, recursive templates were fixed in Django 1.9")
+@skipIf(django.VERSION < (1, 9), "Needs Django >= 1.9, recursive templates were fixed in Django 1.9")
 class OfflineCompressExtendsRecursionTestCase(OfflineTestCaseMixin, TestCase):
     """
         Test that templates extending templates with the same name

--- a/compressor/tests/test_offline.py
+++ b/compressor/tests/test_offline.py
@@ -7,8 +7,9 @@ import unittest
 from importlib import import_module
 
 from mock import patch
-from unittest import SkipTest
+from unittest import SkipTest, skipIf
 
+from django import VERSION as DJANGO_VERSION
 from django.core.management.base import CommandError
 from django.template import Template, Context
 from django.test import TestCase
@@ -632,6 +633,7 @@ class OfflineCompressComplexTestCase(OfflineTestCaseMixin, TestCase):
         self.assertEqual(rendered_template, ''.join(result) + '\n')
 
 
+@skipIf(DJANGO_VERSION[0] <= 1 and DJANGO_VERSION[1] < 9, "Needs Django >= 1.9, recursive templates were fixed in Django 1.9")
 class OfflineCompressExtendsRecursionTestCase(OfflineTestCaseMixin, TestCase):
     """
         Test that templates extending templates with the same name

--- a/compressor/tests/test_templates/test_extends_recursion/admin/index.html
+++ b/compressor/tests/test_templates/test_extends_recursion/admin/index.html
@@ -1,0 +1,1 @@
+{% extends "admin/index.html" %}

--- a/compressor/tests/test_templates/test_extends_recursion/test_compressor_offline.html
+++ b/compressor/tests/test_templates/test_extends_recursion/test_compressor_offline.html
@@ -1,0 +1,6 @@
+{% load compress %}
+
+{% compress js%}
+    <script type="text/javascript">alert('test');</script>
+{% endcompress %}
+{# The real error is caused by "admin/index.html" #}

--- a/compressor/tests/test_templates/test_extends_recursion/test_compressor_offline.html
+++ b/compressor/tests/test_templates/test_extends_recursion/test_compressor_offline.html
@@ -3,4 +3,3 @@
 {% compress js%}
     <script type="text/javascript">alert('test');</script>
 {% endcompress %}
-{# The real error is caused by "admin/index.html" #}

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,6 @@ usedevelop = true
 setenv =
     CPPFLAGS=-O0
 whitelist_externals = /usr/bin/make
-downloadcache = {toxworkdir}/_download/
 commands =
     django-admin.py --version
     make test


### PR DESCRIPTION
This fixes #718 and uses tests added in #727.

Passing an empty context for each extended template was breaking django's mechanism to find correct template if the name of the parent template is same as base template by keeping a stack of 'seen' templates. This PR fixes that by using a single context when finding parent templates.