### PR TITLE
Add multiprocessing option in compress command

### DIFF
--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -249,7 +249,7 @@ class Command(BaseCommand):
             finally:
                 pool.close()
                 pool.join()
-        results = [r for r in results if r]
+        results = [r for r in results if r is not None]
 
         write_offline_manifest(offline_manifest.copy())
 

--- a/compressor/offline/django.py
+++ b/compressor/offline/django.py
@@ -100,14 +100,8 @@ class DjangoParser(object):
         except template.TemplateDoesNotExist as e:
             raise TemplateDoesNotExist(str(e))
 
-    def process_template(self, template, context):
-        return True
-
     def get_init_context(self, offline_context):
         return offline_context
-
-    def process_node(self, template, context, node):
-        pass
 
     def render_nodelist(self, template, context, node):
         context.template = template

--- a/compressor/offline/jinja2.py
+++ b/compressor/offline/jinja2.py
@@ -74,9 +74,6 @@ class Jinja2Parser(object):
 
         return template
 
-    def process_template(self, template, context):
-        return True
-
     def get_init_context(self, offline_context):
         # Don't need to add filters and tests to the context, as Jinja2 will
         # automatically look for them in self.env.filters and self.env.tests.
@@ -87,9 +84,6 @@ class Jinja2Parser(object):
         context.update(offline_context)
 
         return context
-
-    def process_node(self, template, context, node):
-        pass
 
     def _render_nodes(self, template, context, nodes):
         compiled_node = self.env.compile(jinja2.nodes.Template(nodes))


### PR DESCRIPTION
Re-implements #353 using `multiprocessing.Pool` to use fixed number of processes instead of creating a new one for each compress node.
