### PR TITLE
Updated required django-appconf version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -141,7 +141,7 @@ setup(
     ],
     zip_safe=False,
     install_requires=[
-        'django-appconf >= 0.4',
+        'django-appconf >= 1.0',
         'rcssmin == 1.0.6',
         'rjsmin == 1.0.12',
     ],


### PR DESCRIPTION
django-appconf version 0.4 is not compatible with Django 1.9. The old package is still used when upgrading a project to Django 1.9, so this requirement breaks 1.9 compatibility. 

Fixed by using the latest version of django-appconf.