### PR TITLE
Updating remote storages documentation for CachedS3BotoStorage bug.

### DIFF
--- a/docs/remote-storages.txt
+++ b/docs/remote-storages.txt
@@ -66,8 +66,8 @@ apps can be integrated.
                 "compressor.storage.CompressorFileStorage")()
 
         def save(self, name, content):
-            name = super(CachedS3BotoStorage, self).save(name, content)
             self.local_storage._save(name, content)
+            super(CachedS3BotoStorage, self).save(name, self.local_storage._open(name))
             return name
 
 #. Set your :attr:`~django.conf.settings.COMPRESS_STORAGE` and STATICFILES_STORAGE_


### PR DESCRIPTION
The example in the docs doesn't quite work as the file stored in
the "content" variable is already closed, and ends up spitting out
encoded data to the destination files. It was properly being sent
to S3, but not getting saved locally.

This saves the file locally first, then using local storage, opens
the file once again for the S3BotoStorage save call.