### PR TITLE
#750 CompilerFilter fails with UnicodeDecodeError when cache is used

### DIFF
--- a/compressor/filters/base.py
+++ b/compressor/filters/base.py
@@ -221,7 +221,7 @@ class CachedCompilerFilter(CompilerFilter):
             key = self.get_cache_key()
             data = cache.get(key)
             if data is not None:
-                return data
+                return smart_text(data)
             filtered = super(CachedCompilerFilter, self).input(**kwargs)
             cache.set(key, filtered, settings.COMPRESS_REBUILD_TIMEOUT)
             return filtered


### PR DESCRIPTION
Fix bug #750.
