### PR TITLE
Use proper options dict for conversion to tuple in CompilerFilter

### DIFF
--- a/compressor/filters/base.py
+++ b/compressor/filters/base.py
@@ -126,7 +126,7 @@ class CompilerFilter(FilterBase):
         if isinstance(self.options, dict):
             # turn dict into a tuple
             new_options = ()
-            for item in kwargs.items():
+            for item in self.options.items():
                 new_options += (item,)
             self.options = new_options
 

--- a/compressor/tests/test_filters.py
+++ b/compressor/tests/test_filters.py
@@ -41,6 +41,15 @@ class PrecompilerTestCase(TestCase):
         with io.open(self.filename, encoding=settings.FILE_CHARSET) as file:
             self.content = file.read()
 
+    def test_precompiler_dict_options(self):
+        command = "%s %s {option}" % (sys.executable, self.test_precompiler)
+        option = ("option", "option",)
+        CompilerFilter.options = dict([option])
+        compiler = CompilerFilter(
+            content=self.content, filename=self.filename,
+            charset=settings.FILE_CHARSET, command=command)
+        self.assertIn(option, compiler.options)
+
     def test_precompiler_infile_outfile(self):
         command = '%s %s -f {infile} -o {outfile}' % (sys.executable, self.test_precompiler)
         compiler = CompilerFilter(


### PR DESCRIPTION
Fixed convertions of options from dict to tuple.

Previously kwargs were duplicated and proper options were dropped.