### PR TITLE
#674 Support inheritance in offline compression using a variable

### DIFF
--- a/compressor/offline/jinja2.py
+++ b/compressor/offline/jinja2.py
@@ -112,7 +112,7 @@ class Jinja2Parser(object):
 
         return body
 
-    def walk_nodes(self, node, block_name=None):
+    def walk_nodes(self, node, block_name=None, context=None):
         for node in self.get_nodelist(node):
             if (isinstance(node, CallBlock) and
               isinstance(node.call, Call) and

--- a/compressor/tests/test_templates/test_with_context_variable_inheritance/base.html
+++ b/compressor/tests/test_templates/test_with_context_variable_inheritance/base.html
@@ -1,0 +1,8 @@
+{% load compress %}
+{% spaceless %}
+    {% compress js %}
+    <script type="text/javascript">
+        alert("test using template extension passed in variable parent=base.html");
+    </script>
+    {% endcompress %}
+{% endspaceless %}

--- a/compressor/tests/test_templates/test_with_context_variable_inheritance/test_compressor_offline.html
+++ b/compressor/tests/test_templates/test_with_context_variable_inheritance/test_compressor_offline.html
@@ -1,0 +1,1 @@
+{% extends parent_template %}

--- a/compressor/tests/test_templates/test_with_context_variable_inheritance_super/base1.html
+++ b/compressor/tests/test_templates/test_with_context_variable_inheritance_super/base1.html
@@ -1,0 +1,7 @@
+{% spaceless %}
+{% block js %}
+    <script type="text/javascript">
+        alert("test using template extension passed in variable parent=base1.html");
+    </script>
+{% endblock %}
+{% endspaceless %}

--- a/compressor/tests/test_templates/test_with_context_variable_inheritance_super/base2.html
+++ b/compressor/tests/test_templates/test_with_context_variable_inheritance_super/base2.html
@@ -1,0 +1,7 @@
+{% spaceless %}
+{% block js %}
+    <script type="text/javascript">
+        alert("test using template extension passed in variable parent=base2.html");
+    </script>
+{% endblock %}
+{% endspaceless %}

--- a/compressor/tests/test_templates/test_with_context_variable_inheritance_super/test_compressor_offline.html
+++ b/compressor/tests/test_templates/test_with_context_variable_inheritance_super/test_compressor_offline.html
@@ -1,0 +1,8 @@
+{% extends parent_template %}
+{% load compress %}
+
+{% block js %}{% spaceless %}
+    {% compress js %}
+        {{ block.super }}
+    {% endcompress %}
+{% endspaceless %}{% endblock %}

--- a/compressor/tests/test_templates_jinja2/test_with_context_variable_inheritance/base.html
+++ b/compressor/tests/test_templates_jinja2/test_with_context_variable_inheritance/base.html
@@ -1,0 +1,8 @@
+
+{% spaceless %}
+    {% compress js %}
+    <script type="text/javascript">
+        alert("test using template extension passed in variable parent=base.html");
+    </script>
+    {% endcompress %}
+{% endspaceless %}

--- a/compressor/tests/test_templates_jinja2/test_with_context_variable_inheritance/test_compressor_offline.html
+++ b/compressor/tests/test_templates_jinja2/test_with_context_variable_inheritance/test_compressor_offline.html
@@ -1,0 +1,1 @@
+{% extends parent_template %}


### PR DESCRIPTION
Added support for template inheritance with variable from context in offline compression ([#674](https://github.com/django-compressor/django-compressor/issues/674)).

This required some refactoring:
- `walk_nodes` from `DjangoParser` and `Jinja2Parser` now take additional named parameter - `context`,
- `get_nodelist` from `DjangoParser` takes `context` as parameter,
- offline contexts are now evaluated before nodes discovery in templates,
- node discovery in templates is done for all offline contexts,
- for each compress node found in there is a list of contexts for which the node was present,
- each node is then processed only with relevant contexts.

This change allows for usage of parametrised inheritance of templates:
- directly by passing parent template name in context (test case added),
- indirectly through custom extends tag by passing mocked request in context (no test case provided as it is a special case of the above).