### PR TITLE
Minor docs clarification on COMPRESS_OFFLINE.

### DIFF
--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -458,9 +458,9 @@ Offline settings
 
     :Default: ``False``
 
-    Boolean that decides if compression should also be done outside of the
-    request/response loop -- independent from user requests. This allows to
-    pre-compress CSS and JavaScript files and works just like the automatic
+    Boolean that decides if compression should be done outside of the
+    request/response loop. (See :ref:`behind_the_Scenes` for more.) This allows
+    to pre-compress CSS and JavaScript files and works just like the automatic
     compression with the ``{% compress %}`` tag.
 
 .. attribute:: COMPRESS_OFFLINE_TIMEOUT


### PR DESCRIPTION
From #680

> If you have the flag set, does the compression still happens at request time? 

This was a bit confusing due to "also" in the description implying that should offline fail, the full compress flow would be used as fallback. 
Added a link to further info that clarifies this behavior.