### PR TITLE
Fixing CssAbsoluteFilter changes double quotes to single quotes which causes svg to fail

### DIFF
--- a/compressor/filters/css_default.py
+++ b/compressor/filters/css_default.py
@@ -84,19 +84,23 @@ class CssAbsoluteFilter(FilterBase):
 
     def _converter(self, matchobj, group, template):
         url = matchobj.group(group)
-        url = url.strip(' \'"')
+
+        url = url.strip()
+        wrap = '"' if url[0] == '"' else "'"
+        url = url.strip('\'"')
+
         if url.startswith('#'):
-            return "url('%s')" % url
+            return template % (wrap, url, wrap)
         elif url.startswith(SCHEMES):
-            return "url('%s')" % self.add_suffix(url)
+            return template % (wrap, self.add_suffix(url), wrap)
         full_url = posixpath.normpath('/'.join([str(self.directory_name),
                                                 url]))
         if self.has_scheme:
             full_url = "%s%s" % (self.protocol, full_url)
-        return template % self.add_suffix(full_url)
+        return template % (wrap, self.add_suffix(full_url), wrap)
 
     def url_converter(self, matchobj):
-        return self._converter(matchobj, 1, "url('%s')")
+        return self._converter(matchobj, 1, "url(%s%s%s)")
 
     def src_converter(self, matchobj):
-        return self._converter(matchobj, 2, "src='%s'")
+        return self._converter(matchobj, 2, "src=%s%s%s")

--- a/compressor/tests/test_filters.py
+++ b/compressor/tests/test_filters.py
@@ -287,6 +287,16 @@ class CssAbsolutizingTestCase(TestCase):
             filter = CssAbsoluteFilter(content)
             self.assertEqual(content, filter.input(filename=filename, basename='css/url/test.css'))
 
+    def test_css_absolute_filter_only_url_fragment_wrap_double_quotes(self):
+        filename = os.path.join(settings.COMPRESS_ROOT, 'css/url/test.css')
+        content = 'p { background: url("#foo") }'
+        filter = CssAbsoluteFilter(content)
+        self.assertEqual(content, filter.input(filename=filename, basename='css/url/test.css'))
+
+        with self.settings(COMPRESS_URL='http://media.example.com/'):
+            filter = CssAbsoluteFilter(content)
+            self.assertEqual(content, filter.input(filename=filename, basename='css/url/test.css'))
+
     def test_css_absolute_filter_querystring(self):
         filename = os.path.join(settings.COMPRESS_ROOT, 'css/url/test.css')
         imagefilename = os.path.join(settings.COMPRESS_ROOT, 'img/python.png')


### PR DESCRIPTION
Fixes #738 