### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,5 +80,5 @@ The in-development version of Django Compressor can be installed with
 .. _JSMin: http://www.crockford.com/javascript/jsmin.html
 .. _csscompressor: https://github.com/sprymix/csscompressor
 .. _data URIs: http://en.wikipedia.org/wiki/Data_URI_scheme
-.. _django-compressor.readthedocs.org: http://django-compressor.readthedocs.org/en/latest/
+.. _django-compressor.readthedocs.org: https://django-compressor.readthedocs.io/en/latest/
 .. _github.com/django-compressor/django-compressor: https://github.com/django-compressor/django-compressor

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -326,7 +326,7 @@ v1.0
 - Added :func:`post_compress<compressor.signals.post_compress>` signal.
 
 .. _`Slim It`: http://slimit.org/
-.. _`django-appconf`: http://django-appconf.rtfd.org/
+.. _`django-appconf`: https://django-appconf.readthedocs.io/
 .. _`versiontools`: http://pypi.python.org/pypi/versiontools
 
 v0.9.2
@@ -465,7 +465,7 @@ Major improvements and a lot of bugfixes, some of which are:
 - Added ``mtime_cache`` management command to add and/or remove all mtimes
   from the cache.
 
-- Moved docs to Read The Docs: http://django-compressor.readthedocs.org/en/latest/
+- Moved docs to Read The Docs: https://django-compressor.readthedocs.io/en/latest/
 
 - Added optional ``compressor.storage.GzipCompressorFileStorage`` storage
   backend that gzips of the saved files automatically for easier deployment.

--- a/docs/django-sekizai.txt
+++ b/docs/django-sekizai.txt
@@ -21,4 +21,4 @@ Usage
 
 
 .. _django-sekizai: https://github.com/ojii/django-sekizai
-.. _django-sekizai docs: http://django-sekizai.readthedocs.org/en/latest/
+.. _django-sekizai docs: https://django-sekizai.readthedocs.io/en/latest/

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ def find_package_data(where='.', package='',
 setup(
     name="django_compressor",
     version=find_version("compressor", "__init__.py"),
-    url='http://django-compressor.readthedocs.org/en/latest/',
+    url='https://django-compressor.readthedocs.io/en/latest/',
     license='MIT',
     description="Compresses linked and inline JavaScript or CSS into single cached files.",
     long_description=read('README.rst'),


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.