### PR TITLE
Fix tox envlist expansion

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ three_two =
 [tox]
 envlist =
     {py27,py32,py33,py34,py35}-{1.8.X}
-    {py27,py34,py35}-{1.{9,10}.X}
+    {py27,py34,py35}-{1.9.X,1.10.X}
 [testenv]
 basepython =
     py27: python2.7


### PR DESCRIPTION
Apparently nested curly brace expansions don't work in tox.ini. Locally, with tox 2.3.1, before:

```
$ tox -l
py27-1.8.X
py32-1.8.X
py33-1.8.X
py34-1.8.X
py35-1.8.X
py27-1.{9.X}
py27-10.X}
py34-1.{9.X}
py34-10.X}
py35-1.{9.X}
py35-10.X}
```

After:

```
$ tox -l
py27-1.8.X
py32-1.8.X
py33-1.8.X
py34-1.8.X
py35-1.8.X
py27-1.9.X
py27-1.10.X
py34-1.9.X
py34-1.10.X
py35-1.9.X
py35-1.10.X
```