### PR TITLE
Make Django parser's get_nodelist context optional

### DIFF
--- a/compressor/offline/django.py
+++ b/compressor/offline/django.py
@@ -116,7 +116,7 @@ class DjangoParser(object):
     def render_node(self, template, context, node):
         return node.render(context, forced=True)
 
-    def get_nodelist(self, node, original, context):
+    def get_nodelist(self, node, original, context=None):
         if isinstance(node, ExtendsNode):
             try:
                 if context is None:


### PR DESCRIPTION
At [django-sass-processor](https://github.com/jrief/django-sass-processor) we are using Django offline parser from compressor as an API, so [recent change](https://github.com/django-compressor/django-compressor/commit/c0010bf2ae4064c11cfee2387f6e06c3880fc6d3#diff-01dc27e1db84256620f15d8a69b327caL119) (well... it's April 19, but let's call it recent nonetheless) is breaking for us. And we see no better way other than `try`/`except TypeError` to be compatible with _django-compressor_ both pre 2.1 and post 2.1 versions. (issue jrief/django-sass-processor#45)

I see no reason why not make the `context` argument to `compressor.offline.django.DjangoParser.get_nodelist` optional. Method has `if context is None` check anyway.
