### PR TITLE
silently ignore link tags if missing rel atrribute

### DIFF
--- a/compressor/css.py
+++ b/compressor/css.py
@@ -16,7 +16,7 @@ class CssCompressor(Compressor):
             data = None
             elem_name = self.parser.elem_name(elem)
             elem_attribs = self.parser.elem_attribs(elem)
-            if elem_name == 'link' and elem_attribs['rel'].lower() == 'stylesheet':
+            if elem_name == 'link' and 'rel' in elem_attribs and elem_attribs['rel'].lower() == 'stylesheet':
                 basename = self.get_basename(elem_attribs['href'])
                 filename = self.get_filename(basename)
                 data = (SOURCE_FILE, filename, basename, elem)

--- a/compressor/tests/test_templatetags.py
+++ b/compressor/tests/test_templatetags.py
@@ -48,6 +48,23 @@ class TemplatetagTestCase(TestCase):
         out = css_tag("/static/CACHE/css/e41ba2cc6982.css")
         self.assertEqual(out, render(template, self.context))
 
+    def test_missing_rel_leaves_empty_result(self):
+        template = """{% load compress %}{% compress css %}
+<link href="{{ STATIC_URL }}css/one.css" type="text/css">
+{% endcompress %}"""
+        out = ""
+        self.assertEqual(out, render(template, self.context))
+
+    def test_missing_rel_only_on_one_resource(self):
+        template = """{% load compress %}{% compress css %}
+<link href="{{ STATIC_URL }}css/wontmatter.css" type="text/css">
+<link rel="stylesheet" href="{{ STATIC_URL }}css/one.css" type="text/css">
+<style type="text/css">p { border:5px solid green;}</style>
+<link rel="stylesheet" href="{{ STATIC_URL }}css/two.css" type="text/css">
+{% endcompress %}"""
+        out = css_tag("/static/CACHE/css/e41ba2cc6982.css")
+        self.assertEqual(out, render(template, self.context))
+
     def test_uppercase_rel(self):
         template = """{% load compress %}{% compress css %}
 <link rel="StyleSheet" href="{{ STATIC_URL }}css/one.css" type="text/css">


### PR DESCRIPTION
Stop compress tag from throwing KeyError when link tag is missing rel attribute