### PR TITLE
Add more information to error message when importing a class fails

### DIFF
--- a/compressor/tests/test_utils.py
+++ b/compressor/tests/test_utils.py
@@ -5,6 +5,8 @@ import django.contrib.staticfiles.finders
 import django
 
 import compressor.utils.staticfiles
+from compressor.exceptions import FilterError
+from compressor.utils import get_class
 
 from imp import reload
 
@@ -44,3 +46,13 @@ class StaticFilesTestCase(TestCase):
                 self.assertTrue(compressor.utils.staticfiles.finders is None)
         finally:
             reload(compressor.utils.staticfiles)
+
+
+class TestGetClass(TestCase):
+
+    def test_get_class_import_exception(self):
+        with self.assertRaises(FilterError) as context:
+            get_class('common.uglify.JsUglifySourcemapCompressor')
+
+        self.assertTrue(('Failed to import common.uglify.JsUglifySourcemapCompressor. '
+                         'ImportError is: No module named' in str(context.exception)))

--- a/compressor/utils/__init__.py
+++ b/compressor/utils/__init__.py
@@ -15,8 +15,10 @@ def get_class(class_string, exception=FilterError):
             mod_name, class_name = get_mod_func(class_string)
             if class_name:
                 return getattr(__import__(mod_name, {}, {}, [str('')]), class_name)
-        except (ImportError, AttributeError):
-            raise exception('Failed to import %s' % class_string)
+        except AttributeError as e:
+            raise exception('Failed to import %s. AttributeError is: %s' % (class_string, e))
+        except ImportError as e:
+            raise exception('Failed to import %s. ImportError is: %s' % (class_string, e))
 
         raise exception("Invalid class path '%s'" % class_string)
 


### PR DESCRIPTION
Hi,

I was hoping to add this change which adds more information to the error message when the "get_class" method raises an exception. This can be useful when trying to debug why a class is not importing correctly.

In my case, I was trying to create source maps with django-compressor using uglify by adding this file here:
https://github.com/roverdotcom/django-compressor-sourcemaps/blob/master/uglify.py

However I was getting an import error on starting Django as the file in the import line "from compressor.utils.stringformat import FormattableString as fstr" no longer exists. So eventually, I found that I needed to update the uglify.py file code. But it would be nice if the exact reason for the import failure was shown in the log. I think this change will add this detail.

Let me know what you think,
Thanks!