### PR TITLE
Add sourcemaps on ClosureCompilerFilter

### DIFF
--- a/compressor/base.py
+++ b/compressor/base.py
@@ -289,16 +289,21 @@ class Compressor(object):
         any custom modification. Calls other mode specific methods or simply
         returns the content directly.
         """
-        output = '\n'.join(self.filter_input(forced))
 
-        if not output:
+        outputs = self.filter_input(forced)
+        if settings.COMPRESS_OFFLINE_GROUP_FILES:
+            outputs = ['\n'.join(outputs)]
+
+        if not outputs:
             return ''
 
         if settings.COMPRESS_ENABLED or forced:
-            filtered_output = self.filter_output(output)
-            return self.handle_output(mode, filtered_output, forced)
-
-        return output
+            filtered_outputs = []
+            for output in outputs:
+                filtered_output = self.filter_output(output)
+                filtered_outputs.append(self.handle_output(mode, filtered_output, forced))
+            outputs = filtered_outputs
+        return '\n'.join(outputs)
 
     def handle_output(self, mode, content, forced, basename=None):
         # Then check for the appropriate output method and call it

--- a/compressor/cache.py
+++ b/compressor/cache.py
@@ -133,6 +133,8 @@ def get_precompiler_cachekey(command, contents):
 
 
 def cache_get(key):
+    if settings.COMPRESS_OFFLINE_GROUP_FILES:
+        key = 'G|%s' % key
     packed_val = cache.get(key)
     if packed_val is None:
         return None
@@ -147,6 +149,8 @@ def cache_get(key):
 
 
 def cache_set(key, val, refreshed=False, timeout=None):
+    if settings.COMPRESS_OFFLINE_GROUP_FILES:
+        key = 'G|%s' % key
     if timeout is None:
         timeout = settings.COMPRESS_REBUILD_TIMEOUT
     refresh_time = timeout + time.time()

--- a/compressor/conf.py
+++ b/compressor/conf.py
@@ -71,6 +71,8 @@ class CompressorConf(AppConf):
     OFFLINE_MANIFEST = 'manifest.json'
     # If false the files are not grouped in a single file
     OFFLINE_GROUP_FILES = True
+    # If True, write the Base64 source maps on a separated file
+    OFFLINE_SOURCEMAPS_ON_FILES = False
     # The Context to be used when TemplateFilter is used
     TEMPLATE_FILTER_CONTEXT = {}
     # Placeholder to be used instead of settings.COMPRESS_URL during offline compression.

--- a/compressor/conf.py
+++ b/compressor/conf.py
@@ -39,6 +39,7 @@ class CompressorConf(AppConf):
     CACHEABLE_PRECOMPILERS = ()
     CLOSURE_COMPILER_BINARY = 'java -jar compiler.jar'
     CLOSURE_COMPILER_ARGUMENTS = ''
+    CLOSURE_COMPILER_SOURCEMAPS = False
     YUI_BINARY = 'java -jar yuicompressor.jar'
     YUI_CSS_ARGUMENTS = ''
     YUI_JS_ARGUMENTS = ''

--- a/compressor/conf.py
+++ b/compressor/conf.py
@@ -68,6 +68,8 @@ class CompressorConf(AppConf):
     OFFLINE_CONTEXT = {}
     # The name of the manifest file (e.g. filename.ext)
     OFFLINE_MANIFEST = 'manifest.json'
+    # If false the files are not grouped in a single file
+    OFFLINE_GROUP_FILES = True
     # The Context to be used when TemplateFilter is used
     TEMPLATE_FILTER_CONTEXT = {}
     # Placeholder to be used instead of settings.COMPRESS_URL during offline compression.

--- a/compressor/css.py
+++ b/compressor/css.py
@@ -47,5 +47,5 @@ class CssCompressor(Compressor):
                 for media, subnode in self.media_nodes:
                     subnode.extra_context.update({'media': media})
                     ret.append(subnode.output(*args, **kwargs))
-                return ''.join(ret)
+                return '\n'.join(ret)
         return super(CssCompressor, self).output(*args, **kwargs)

--- a/compressor/filters/closure.py
+++ b/compressor/filters/closure.py
@@ -1,5 +1,11 @@
+import base64
+import json
+import os
+from django.core.files.temp import NamedTemporaryFile
+import io
 from compressor.conf import settings
 from compressor.filters import CompilerFilter
+from compressor.exceptions import FilterError
 
 
 class ClosureCompilerFilter(CompilerFilter):
@@ -8,3 +14,49 @@ class ClosureCompilerFilter(CompilerFilter):
         ("binary", settings.COMPRESS_CLOSURE_COMPILER_BINARY),
         ("args", settings.COMPRESS_CLOSURE_COMPILER_ARGUMENTS),
     )
+    minfile = None
+
+    def __init__(self, content, **kwargs):
+        super(ClosureCompilerFilter, self).__init__(content, **kwargs)
+
+        if settings.COMPRESS_CLOSURE_COMPILER_SOURCEMAPS and not settings.COMPRESS_OFFLINE_GROUP_FILES:
+            self.command = self.command.replace('{args}', '--create_source_map {mapfile} {args}')
+
+    def input(self, **kwargs):
+        encoding = self.default_encoding
+        options = dict(self.options)
+
+        if "{mapfile}" in self.command and "mapfile" not in options:
+            # create temporary mapfile file if needed
+            ext = self.type and ".%s.map" % self.type or ""
+            self.minfile = NamedTemporaryFile(mode='r+', suffix=ext)
+            options["mapfile"] = self.minfile.name
+
+        self.options = options
+
+        filtered = super(ClosureCompilerFilter, self).input(**kwargs)
+
+        try:
+            mapfile_path = options.get('mapfile')
+            if mapfile_path:
+                with io.open(mapfile_path, 'r', encoding=encoding) as file:
+                    map = file.read()
+
+                map_dict = json.loads(map)
+                sources = map_dict['sources']
+                sources[sources.index('stdin')] = kwargs['elem']['attrs_dict']['src']
+                map_dict['file'] = os.path.basename(kwargs['elem']['attrs_dict']['src'])
+                map_dict['sources'] = sources
+                map = json.dumps(map_dict)
+
+                filtered = '%s\n//# sourceMappingURL=data:application/json;base64,%s' % (
+                    filtered,
+                    base64.standard_b64encode(map)
+                )
+        except (IOError, OSError) as e:
+            raise FilterError('Unable add source map %s (%r): %s' %
+                              (self.__class__.__name__, self.command, e))
+        finally:
+            if self.minfile is not None:
+                self.minfile.close()
+        return filtered

--- a/compressor/js.py
+++ b/compressor/js.py
@@ -27,6 +27,8 @@ class JsCompressor(Compressor):
                 extra = ' defer'
             else:
                 extra = ''
+            if 'crossorigin' in attribs:
+                extra += ' crossorigin'
             # Append to the previous node if it had the same attribute
             append_to_previous = (self.extra_nodes and
                                   self.extra_nodes[-1][0] == extra)

--- a/compressor/tests/test_base.py
+++ b/compressor/tests/test_base.py
@@ -390,31 +390,41 @@ class JsAsyncDeferTestCase(SimpleTestCase):
             <script type="text/javascript">obj.value = "value";</script>
             <script src="/static/js/one.js" type="text/javascript" async></script>
             <script src="/static/js/two.js" type="text/javascript" async></script>
+            <script src="/static/js/three.js" type="text/javascript"></script>
+            <script type="text/javascript">obj.value = "value";</script>
+            <script src="/static/js/one.js" type="text/javascript" crossorigin></script>
+            <script src="/static/js/two.js" type="text/javascript" crossorigin></script>
+            <script src="/static/js/three.js" type="text/javascript"></script>
+            <script src="/static/js/one.js" type="text/javascript" crossorigin async></script>
+            <script src="/static/js/two.js" type="text/javascript" crossorigin></script>
             <script src="/static/js/three.js" type="text/javascript"></script>"""
 
+    def _extract_attr(self, tag):
+        if tag.has_attr('async') and tag.has_attr('crossorigin'):
+            return 'crossorigin async'
+        if tag.has_attr('defer') and tag.has_attr('crossorigin'):
+            return 'crossorigin defer'
+        if tag.has_attr('async'):
+            return 'async'
+        if tag.has_attr('defer'):
+            return 'defer'
+        if tag.has_attr('crossorigin'):
+            return 'crossorigin'
+
     def test_js_output(self):
-        def extract_attr(tag):
-            if tag.has_attr('async'):
-                return 'async'
-            if tag.has_attr('defer'):
-                return 'defer'
         js_node = JsCompressor(self.js)
-        output = [None, 'async', 'defer', None, 'async', None]
+        output = [None, 'async', 'defer', None, 'async', None, 'crossorigin', None, 'crossorigin async', 'crossorigin', None]
         scripts = make_soup(js_node.output()).find_all('script')
-        attrs = [extract_attr(s) for s in scripts]
+        attrs = [self._extract_attr(s) for s in scripts]
         self.assertEqual(output, attrs)
 
     @override_settings(COMPRESS_OFFLINE_GROUP_FILES=False)
     def test_js_output_no_group(self):
-        def extract_attr(tag):
-            if tag.has_attr('async'):
-                return 'async'
-            if tag.has_attr('defer'):
-                return 'defer'
         js_node = JsCompressor(self.js)
-        output = [None, 'async', 'defer', None, 'async', 'async', None]
+        output = [None, 'async', 'defer', None, 'async', 'async', None, None, 'crossorigin', 'crossorigin', None,
+                  'crossorigin async', 'crossorigin', None]
         scripts = make_soup(js_node.output()).find_all('script')
-        attrs = [extract_attr(s) for s in scripts]
+        attrs = [self._extract_attr(s) for s in scripts]
         self.assertEqual(output, attrs)
 
 

--- a/compressor/tests/test_filters.py
+++ b/compressor/tests/test_filters.py
@@ -408,14 +408,26 @@ class TemplateTestCase(TestCase):
         self.assertEqual(input, TemplateFilter(content).input())
 
 
-class SpecializedFiltersTest(TestCase):
+class ClosureFiltersTest(TestCase):
     """
-    Test to check the Specializations of filters.
+    Test to check the Closure filter.
     """
     def test_closure_filter(self):
         filter = ClosureCompilerFilter('')
+        self.assertEqual(filter.command, '{binary} {args}')
         self.assertEqual(filter.options, (('binary', six.text_type('java -jar compiler.jar')), ('args', six.text_type(''))))
 
+    @override_settings(COMPRESS_CLOSURE_COMPILER_SOURCEMAPS=True, COMPRESS_OFFLINE_GROUP_FILES=False)
+    def test_source_map(self):
+        filter = ClosureCompilerFilter('')
+        self.assertEqual(filter.command, '{binary} --create_source_map {mapfile} {args}')
+        self.assertEqual(filter.options, (('binary', six.text_type('java -jar compiler.jar')), ('args', six.text_type(''))))
+
+
+class YuglifyFiltersTest(TestCase):
+    """
+    Test to check the Yuglify filter.
+    """
     def test_yuglify_filters(self):
         filter = YUglifyCSSFilter('')
         self.assertEqual(filter.command, '{binary} {args} --type=css')
@@ -425,6 +437,11 @@ class SpecializedFiltersTest(TestCase):
         self.assertEqual(filter.command, '{binary} {args} --type=js')
         self.assertEqual(filter.options, (('binary', six.text_type('yuglify')), ('args', six.text_type('--terminal'))))
 
+
+class YuiFiltersTest(TestCase):
+    """
+    Test to check the Yui filter.
+    """
     def test_yui_filters(self):
         filter = YUICSSFilter('')
         self.assertEqual(filter.command, '{binary} {args} --type=css')
@@ -434,6 +451,11 @@ class SpecializedFiltersTest(TestCase):
         self.assertEqual(filter.command, '{binary} {args} --type=js --verbose')
         self.assertEqual(filter.options, (('binary', six.text_type('java -jar yuicompressor.jar')), ('args', six.text_type('')), ('verbose', 1)))
 
+
+class CleanCssFiltersTest(TestCase):
+    """
+    Test to check the CleanCss filter.
+    """
     def test_clean_css_filter(self):
         filter = CleanCSSFilter('')
         self.assertEqual(filter.options, (('binary', six.text_type('cleancss')), ('args', six.text_type(''))))

--- a/compressor/tests/test_jinja2ext.py
+++ b/compressor/tests/test_jinja2ext.py
@@ -86,6 +86,19 @@ class TestJinja2CompressorExtension(TestCase):
         out = css_tag("/static/CACHE/css/e41ba2cc6982.css")
         self.assertEqual(out, template.render(context))
 
+    @override_settings(COMPRESS_OFFLINE_GROUP_FILES=False)
+    def test_css_tag_no_group(self):
+        template = self.env.from_string("""{% compress css -%}
+        <link rel="stylesheet" href="{{ STATIC_URL }}css/one.css" type="text/css" charset="utf-8">
+        <style type="text/css">p { border:5px solid green;}</style>
+        <link rel="stylesheet" href="{{ STATIC_URL }}css/two.css" type="text/css" charset="utf-8">
+        {% endcompress %}""")
+        context = {'STATIC_URL': settings.COMPRESS_URL}
+        out = '\n'.join([css_tag('/static/CACHE/css/cdd1a7452e1d.css'),
+                         css_tag('/static/CACHE/css/13c6e6521347.css'),
+                         css_tag('/static/CACHE/css/652d0fbfecf5.css')])
+        self.assertEqual(out, template.render(context))
+
     def test_nonascii_css_tag(self):
         template = self.env.from_string("""{% compress css -%}
         <link rel="stylesheet" href="{{ STATIC_URL }}css/nonasc.css" type="text/css" charset="utf-8">
@@ -93,6 +106,17 @@ class TestJinja2CompressorExtension(TestCase):
         {% endcompress %}""")
         context = {'STATIC_URL': settings.COMPRESS_URL}
         out = css_tag("/static/CACHE/css/799f6defe43c.css")
+        self.assertEqual(out, template.render(context))
+
+    @override_settings(COMPRESS_OFFLINE_GROUP_FILES=False)
+    def test_nonascii_css_tag_no_group(self):
+        template = self.env.from_string("""{% compress css -%}
+        <link rel="stylesheet" href="{{ STATIC_URL }}css/nonasc.css" type="text/css" charset="utf-8">
+        <style type="text/css">p { border:5px solid green;}</style>
+        {% endcompress %}""")
+        context = {'STATIC_URL': settings.COMPRESS_URL}
+        out = '\n'.join([css_tag('/static/CACHE/css/e64bd1e74133.css'),
+                         css_tag('/static/CACHE/css/13c6e6521347.css')])
         self.assertEqual(out, template.render(context))
 
     def test_js_tag(self):
@@ -104,6 +128,17 @@ class TestJinja2CompressorExtension(TestCase):
         out = '<script type="text/javascript" src="/static/CACHE/js/d728fc7f9301.js"></script>'
         self.assertEqual(out, template.render(context))
 
+    @override_settings(COMPRESS_OFFLINE_GROUP_FILES=False)
+    def test_js_tag_no_group(self):
+        template = self.env.from_string("""{% compress js -%}
+        <script src="{{ STATIC_URL }}js/one.js" type="text/javascript" charset="utf-8"></script>
+        <script type="text/javascript" charset="utf-8">obj.value = "value";</script>
+        {% endcompress %}""")
+        context = {'STATIC_URL': settings.COMPRESS_URL}
+        out = '\n'.join(['<script type="text/javascript" src="/static/CACHE/js/153fcbd56af1.js"></script>',
+                         '<script type="text/javascript" src="/static/CACHE/js/188074e83ceb.js"></script>'])
+        self.assertEqual(out, template.render(context))
+
     def test_nonascii_js_tag(self):
         template = self.env.from_string("""{% compress js -%}
         <script src="{{ STATIC_URL }}js/nonasc.js" type="text/javascript" charset="utf-8"></script>
@@ -113,6 +148,17 @@ class TestJinja2CompressorExtension(TestCase):
         out = '<script type="text/javascript" src="/static/CACHE/js/d34f30e02e70.js"></script>'
         self.assertEqual(out, template.render(context))
 
+    @override_settings(COMPRESS_OFFLINE_GROUP_FILES=False)
+    def test_nonascii_js_tag_no_group(self):
+        template = self.env.from_string("""{% compress js -%}
+        <script src="{{ STATIC_URL }}js/nonasc.js" type="text/javascript" charset="utf-8"></script>
+        <script type="text/javascript" charset="utf-8">var test_value = "\u2014";</script>
+        {% endcompress %}""")
+        context = {'STATIC_URL': settings.COMPRESS_URL}
+        out = '\n'.join(['<script type="text/javascript" src="/static/CACHE/js/67b8ab34d456.js"></script>',
+                         '<script type="text/javascript" src="/static/CACHE/js/67b8ab34d456.js"></script>'])
+        self.assertEqual(out, template.render(context))
+
     def test_nonascii_latin1_js_tag(self):
         template = self.env.from_string("""{% compress js -%}
         <script src="{{ STATIC_URL }}js/nonasc-latin1.js" type="text/javascript" charset="latin-1"></script>
@@ -120,6 +166,17 @@ class TestJinja2CompressorExtension(TestCase):
         {% endcompress %}""")
         context = {'STATIC_URL': settings.COMPRESS_URL}
         out = '<script type="text/javascript" src="/static/CACHE/js/a830bddd3636.js"></script>'
+        self.assertEqual(out, template.render(context))
+
+    @override_settings(COMPRESS_OFFLINE_GROUP_FILES=False)
+    def test_nonascii_latin1_js_tag_no_group(self):
+        template = self.env.from_string("""{% compress js -%}
+        <script src="{{ STATIC_URL }}js/nonasc-latin1.js" type="text/javascript" charset="latin-1"></script>
+        <script type="text/javascript">var test_value = "\u2014";</script>
+        {% endcompress %}""")
+        context = {'STATIC_URL': settings.COMPRESS_URL}
+        out = '\n'.join(['<script type="text/javascript" src="/static/CACHE/js/78573a09aa12.js"></script>',
+                         '<script type="text/javascript" src="/static/CACHE/js/67b8ab34d456.js"></script>'])
         self.assertEqual(out, template.render(context))
 
     def test_css_inline(self):
@@ -134,6 +191,18 @@ class TestJinja2CompressorExtension(TestCase):
         ])
         self.assertEqual(out, template.render(context))
 
+    @override_settings(COMPRESS_OFFLINE_GROUP_FILES=False)
+    def test_css_inline_no_group(self):
+        template = self.env.from_string("""{% compress css, inline -%}
+        <link rel="stylesheet" href="{{ STATIC_URL }}css/one.css" type="text/css" charset="utf-8">
+        <style type="text/css">p { border:5px solid green;}</style>
+        {% endcompress %}""")
+        context = {'STATIC_URL': settings.COMPRESS_URL}
+        out = '\n'.join([
+            '<style type="text/css">body { background:#990; }</style>',
+            '<style type="text/css">p { border:5px solid green;}</style>'])
+        self.assertEqual(out, template.render(context))
+
     def test_js_inline(self):
         template = self.env.from_string("""{% compress js, inline -%}
         <script src="{{ STATIC_URL }}js/one.js" type="text/css" type="text/javascript" charset="utf-8"></script>
@@ -141,6 +210,17 @@ class TestJinja2CompressorExtension(TestCase):
         {% endcompress %}""")
         context = {'STATIC_URL': settings.COMPRESS_URL}
         out = '<script type="text/javascript">;obj={};;obj.value="value";</script>'
+        self.assertEqual(out, template.render(context))
+
+    @override_settings(COMPRESS_OFFLINE_GROUP_FILES=False)
+    def test_js_inline_no_group(self):
+        template = self.env.from_string("""{% compress js, inline -%}
+        <script src="{{ STATIC_URL }}js/one.js" type="text/css" type="text/javascript" charset="utf-8"></script>
+        <script type="text/javascript" charset="utf-8">obj.value = "value";</script>
+        {% endcompress %}""")
+        context = {'STATIC_URL': settings.COMPRESS_URL}
+        out = '\n'.join(['<script type="text/javascript">;obj={};</script>',
+                         '<script type="text/javascript">;obj.value="value";</script>'])
         self.assertEqual(out, template.render(context))
 
     def test_nonascii_inline_css(self):

--- a/compressor/tests/test_storages.py
+++ b/compressor/tests/test_storages.py
@@ -44,6 +44,20 @@ class StorageTestCase(TestCase):
         out = css_tag("/static/CACHE/css/1d4424458f88.css")
         self.assertEqual(out, render(template, context))
 
+    @override_settings(COMPRESS_OFFLINE_GROUP_FILES=False)
+    def test_css_tag_with_storage_no_group(self):
+        template = """{% load compress %}{% compress css %}
+        <link rel="stylesheet" href="{{ STATIC_URL }}css/one.css" type="text/css">
+        <style type="text/css">p { border:5px solid white;}</style>
+        <link rel="stylesheet" href="{{ STATIC_URL }}css/two.css" type="text/css">
+        {% endcompress %}
+        """
+        context = {'STATIC_URL': settings.COMPRESS_URL}
+        out = '\n'.join([css_tag('/static/CACHE/css/cdd1a7452e1d.css'),
+                         css_tag('/static/CACHE/css/bec939b6c3b6.css'),
+                         css_tag('/static/CACHE/css/652d0fbfecf5.css')])
+        self.assertEqual(out, render(template, context))
+
     def test_race_condition_handling(self):
         # Hold on to original os.remove
         original_remove = os.remove

--- a/compressor/tests/test_templatetags.py
+++ b/compressor/tests/test_templatetags.py
@@ -48,6 +48,18 @@ class TemplatetagTestCase(TestCase):
         out = css_tag("/static/CACHE/css/e41ba2cc6982.css")
         self.assertEqual(out, render(template, self.context))
 
+    @override_settings(COMPRESS_OFFLINE_GROUP_FILES=False)
+    def test_css_tag_no_group(self):
+        template = """{% load compress %}{% compress css %}
+<link rel="stylesheet" href="{{ STATIC_URL }}css/one.css" type="text/css">
+<style type="text/css">p { border:5px solid green;}</style>
+<link rel="stylesheet" href="{{ STATIC_URL }}css/two.css" type="text/css">
+{% endcompress %}"""
+        out = '\n'.join([css_tag('/static/CACHE/css/cdd1a7452e1d.css'),
+                         css_tag('/static/CACHE/css/13c6e6521347.css'),
+                         css_tag('/static/CACHE/css/652d0fbfecf5.css')])
+        self.assertEqual(out, render(template, self.context))
+
     def test_missing_rel_leaves_empty_result(self):
         template = """{% load compress %}{% compress css %}
 <link href="{{ STATIC_URL }}css/one.css" type="text/css">
@@ -65,6 +77,19 @@ class TemplatetagTestCase(TestCase):
         out = css_tag("/static/CACHE/css/e41ba2cc6982.css")
         self.assertEqual(out, render(template, self.context))
 
+    @override_settings(COMPRESS_OFFLINE_GROUP_FILES=False)
+    def test_missing_rel_only_on_one_resource_no_group(self):
+        template = """{% load compress %}{% compress css %}
+<link href="{{ STATIC_URL }}css/wontmatter.css" type="text/css">
+<link rel="stylesheet" href="{{ STATIC_URL }}css/one.css" type="text/css">
+<style type="text/css">p { border:5px solid green;}</style>
+<link rel="stylesheet" href="{{ STATIC_URL }}css/two.css" type="text/css">
+{% endcompress %}"""
+        out = '\n'.join([css_tag('/static/CACHE/css/cdd1a7452e1d.css'),
+                         css_tag('/static/CACHE/css/13c6e6521347.css'),
+                         css_tag('/static/CACHE/css/652d0fbfecf5.css')])
+        self.assertEqual(out, render(template, self.context))
+
     def test_uppercase_rel(self):
         template = """{% load compress %}{% compress css %}
 <link rel="StyleSheet" href="{{ STATIC_URL }}css/one.css" type="text/css">
@@ -72,6 +97,18 @@ class TemplatetagTestCase(TestCase):
 <link rel="StyleSheet" href="{{ STATIC_URL }}css/two.css" type="text/css">
 {% endcompress %}"""
         out = css_tag("/static/CACHE/css/e41ba2cc6982.css")
+        self.assertEqual(out, render(template, self.context))
+
+    @override_settings(COMPRESS_OFFLINE_GROUP_FILES=False)
+    def test_uppercase_rel_no_group(self):
+        template = """{% load compress %}{% compress css %}
+        <link rel="StyleSheet" href="{{ STATIC_URL }}css/one.css" type="text/css">
+        <style type="text/css">p { border:5px solid green;}</style>
+        <link rel="StyleSheet" href="{{ STATIC_URL }}css/two.css" type="text/css">
+        {% endcompress %}"""
+        out = '\n'.join([css_tag('/static/CACHE/css/cdd1a7452e1d.css'),
+                         css_tag('/static/CACHE/css/13c6e6521347.css'),
+                         css_tag('/static/CACHE/css/652d0fbfecf5.css')])
         self.assertEqual(out, render(template, self.context))
 
     def test_nonascii_css_tag(self):
@@ -83,6 +120,17 @@ class TemplatetagTestCase(TestCase):
         out = css_tag("/static/CACHE/css/799f6defe43c.css")
         self.assertEqual(out, render(template, self.context))
 
+    @override_settings(COMPRESS_OFFLINE_GROUP_FILES=False)
+    def test_nonascii_css_tag_no_group(self):
+        template = """{% load compress %}{% compress css %}
+        <link rel="stylesheet" href="{{ STATIC_URL }}css/nonasc.css" type="text/css">
+        <style type="text/css">p { border:5px solid green;}</style>
+        {% endcompress %}
+        """
+        out = '\n'.join([css_tag('/static/CACHE/css/e64bd1e74133.css'),
+                         css_tag('/static/CACHE/css/13c6e6521347.css')])
+        self.assertEqual(out, render(template, self.context))
+
     def test_js_tag(self):
         template = """{% load compress %}{% compress js %}
         <script src="{{ STATIC_URL }}js/one.js" type="text/javascript"></script>
@@ -90,6 +138,17 @@ class TemplatetagTestCase(TestCase):
         {% endcompress %}
         """
         out = '<script type="text/javascript" src="/static/CACHE/js/d728fc7f9301.js"></script>'
+        self.assertEqual(out, render(template, self.context))
+
+    @override_settings(COMPRESS_OFFLINE_GROUP_FILES=False)
+    def test_js_tag_no_group(self):
+        template = """{% load compress %}{% compress js %}
+        <script src="{{ STATIC_URL }}js/one.js" type="text/javascript"></script>
+        <script type="text/javascript">obj.value = "value";</script>
+        {% endcompress %}
+        """
+        out = '\n'.join(['<script type="text/javascript" src="/static/CACHE/js/153fcbd56af1.js"></script>',
+                         '<script type="text/javascript" src="/static/CACHE/js/188074e83ceb.js"></script>'])
         self.assertEqual(out, render(template, self.context))
 
     def test_nonascii_js_tag(self):
@@ -101,6 +160,17 @@ class TemplatetagTestCase(TestCase):
         out = '<script type="text/javascript" src="/static/CACHE/js/d34f30e02e70.js"></script>'
         self.assertEqual(out, render(template, self.context))
 
+    @override_settings(COMPRESS_OFFLINE_GROUP_FILES=False)
+    def test_nonascii_js_tag_no_group(self):
+        template = """{% load compress %}{% compress js %}
+        <script src="{{ STATIC_URL }}js/nonasc.js" type="text/javascript"></script>
+        <script type="text/javascript">var test_value = "\u2014";</script>
+        {% endcompress %}
+        """
+        out = '\n'.join(['<script type="text/javascript" src="/static/CACHE/js/67b8ab34d456.js"></script>',
+                         '<script type="text/javascript" src="/static/CACHE/js/67b8ab34d456.js"></script>'])
+        self.assertEqual(out, render(template, self.context))
+
     def test_nonascii_latin1_js_tag(self):
         template = """{% load compress %}{% compress js %}
         <script src="{{ STATIC_URL }}js/nonasc-latin1.js" type="text/javascript" charset="latin-1"></script>
@@ -108,6 +178,17 @@ class TemplatetagTestCase(TestCase):
         {% endcompress %}
         """
         out = '<script type="text/javascript" src="/static/CACHE/js/a830bddd3636.js"></script>'
+        self.assertEqual(out, render(template, self.context))
+
+    @override_settings(COMPRESS_OFFLINE_GROUP_FILES=False)
+    def test_nonascii_latin1_js_tag_no_group(self):
+        template = """{% load compress %}{% compress js %}
+        <script src="{{ STATIC_URL }}js/nonasc-latin1.js" type="text/javascript" charset="latin-1"></script>
+        <script type="text/javascript">var test_value = "\u2014";</script>
+        {% endcompress %}
+        """
+        out = '\n'.join(['<script type="text/javascript" src="/static/CACHE/js/78573a09aa12.js"></script>',
+                         '<script type="text/javascript" src="/static/CACHE/js/67b8ab34d456.js"></script>'])
         self.assertEqual(out, render(template, self.context))
 
     def test_compress_tag_with_illegal_arguments(self):
@@ -191,6 +272,16 @@ class PrecompilerTemplatetagTestCase(TestCase):
         out = script(src="/static/CACHE/js/07bc3c26db9a.js")
         self.assertEqual(out, render(template, self.context))
 
+    @override_settings(COMPRESS_OFFLINE_GROUP_FILES=False)
+    def test_compress_coffeescript_tag_and_javascript_tag_no_group(self):
+        template = """{% load compress %}{% compress js %}
+            <script type="text/coffeescript"># this is a comment.</script>
+            <script type="text/javascript"># this too is a comment.</script>
+            {% endcompress %}"""
+        out = '\n'.join([script(src="/static/CACHE/js/82d254e4462a.js"),
+                         script(src="/static/CACHE/js/8480dcc457ec.js")])
+        self.assertEqual(out, render(template, self.context))
+
     @override_settings(COMPRESS_ENABLED=False)
     def test_coffeescript_and_js_tag_with_compress_enabled_equals_false(self):
         template = """{% load compress %}{% compress js %}
@@ -246,7 +337,7 @@ class PrecompilerTemplatetagTestCase(TestCase):
         <link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}css/two.css"></link>
         {% endcompress %}"""
 
-        out = ''.join(['<link rel="stylesheet" type="text/css" href="/static/css/one.css" />',
+        out = '\n'.join(['<link rel="stylesheet" type="text/css" href="/static/css/one.css" />',
                        '<link rel="stylesheet" type="text/css" href="/static/css/two.css" />'])
 
         self.assertEqual(out, render(template, self.context))
@@ -261,7 +352,7 @@ class PrecompilerTemplatetagTestCase(TestCase):
         <link rel="stylesheet" type="text/less" href="{{ STATIC_URL }}css/url/test.css"/>
         {% endcompress %}"""
 
-        out = ''.join(['<link rel="stylesheet" type="text/css" href="/static/css/one.css" />',
+        out = '\n'.join(['<link rel="stylesheet" type="text/css" href="/static/css/one.css" />',
                        '<link rel="stylesheet" type="text/css" href="/static/css/two.css" />',
                        '<link rel="stylesheet" href="/static/CACHE/css/test.5dddc6c2fb5a.css" type="text/css" />'])
         self.assertEqual(out, render(template, self.context))

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -516,3 +516,9 @@ Offline settings
 
     The name of the file to be used for saving the names of the files
     compressed offline.
+
+.. attribute:: COMPRESS_OFFLINE_GROUP_FILES
+
+    :Default: ``True``
+
+    If false the files are not grouped in a single file.

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -528,3 +528,9 @@ Offline settings
     :Default: ``True``
 
     If false the files are not grouped in a single file.
+
+.. attribute:: COMPRESS_OFFLINE_SOURCEMAPS_ON_FILES
+
+    :Default: ``False``
+
+    If True, write the Base64 source maps on a separated file

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -195,6 +195,12 @@ Backend settings
 
          The arguments passed to the compiler.
 
+      .. attribute:: COMPRESS_CLOSURE_COMPILER_SOURCEMAPS
+
+        :Default: ``False``
+
+        If True add the source map in base64 at the end of file.
+
     - ``compressor.filters.yui.YUIJSFilter``
 
       A filter that passes the JavaScript code to the `YUI compressor`_.


### PR DESCRIPTION
In order to use [opbeat-plain-JS](https://github.com/opbeat/opbeat-plain-js) to track JavaScript errors, I added a few features for sourcemaps files creation using the ClosureCompilerFilter.

I also add some test for this part.