### PR TITLE
Add support for PostCSS

### DIFF
--- a/compressor/filters/postcss.py
+++ b/compressor/filters/postcss.py
@@ -1,0 +1,33 @@
+from compressor.conf import settings
+from compressor.filters import CompilerFilter
+
+
+DEFAULT_BINARY = "postcss"
+DEFAULT_ARGS = " "
+DEFAULT_PLUGINS = ()
+
+
+def fetch_options():
+    def plugins_as_args(plugins):
+        return ''.join(map(lambda plugin: '--use %s ' % plugin, plugins))
+    return (
+        ("binary", getattr(settings, "COMPRESS_POSTCSS_BINARY", DEFAULT_BINARY)),
+        ("args", getattr(settings, "COMPRESS_POSTCSS_ARGS", DEFAULT_ARGS)),
+        ("plugins", plugins_as_args(getattr(settings, "COMPRESS_POSTCSS_PLUGINS", DEFAULT_PLUGINS))),
+    )
+
+
+class PostCSSFilter(CompilerFilter):
+    command = "{binary} {args} {plugins} -o {outfile} {infile}"
+    options = fetch_options()
+
+
+class PostCSSFilterTestable(PostCSSFilter):
+    """
+    This class should inherit from PostCSSFilter. Its sole purpose is to
+    make testing of the superclass easier but can be treated as the superclass
+    itself when testing.
+    """
+    def __init__(self, *args, **kwargs):
+        super(PostCSSFilter, self).__init__(*args, **kwargs)
+        self.options = fetch_options()

--- a/compressor/tests/test_filters.py
+++ b/compressor/tests/test_filters.py
@@ -22,6 +22,7 @@ from compressor.filters.closure import ClosureCompilerFilter
 from compressor.filters.yuglify import YUglifyCSSFilter, YUglifyJSFilter
 from compressor.filters.yui import YUICSSFilter, YUIJSFilter
 from compressor.filters.cleancss import CleanCSSFilter
+from compressor.filters.postcss import PostCSSFilterTestable as PostCSSFilter
 from compressor.tests.test_base import test_dir
 
 
@@ -389,6 +390,24 @@ class CssDataUriTestCase(TestCase):
 .datauri { background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9YGARc5KB0XV+IAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAF1JREFUGNO9zL0NglAAxPEfdLTs4BZM4DIO4C7OwQg2JoQ9LE1exdlYvBBeZ7jqch9//q1uH4TLzw4d6+ErXMMcXuHWxId3KOETnnXXV6MJpcq2MLaI97CER3N0 vr4MkhoXe0rZigAAAABJRU5ErkJggg=="); }
 ''' % datauri_hash]
         self.assertEqual(out, list(self.css_node.hunks()))
+
+
+class PostCSSFilterTestCase(TestCase):
+    """
+    Tests for PostCSS. Ideally we would want to install a few plugins and try
+    with those.
+    """
+
+    @override_settings(COMPRESS_POSTCSS_PLUGINS=('plugin1', 'plugin2'))
+    def test_multiple_plugins(self):
+        filter = PostCSSFilter('test')
+        options = dict(filter.options)
+        self.assertIn('--use plugin1 --use plugin2', options['plugins'])
+
+    def test_no_plugins(self):
+        filter = PostCSSFilter('test')
+        options = dict(filter.options)
+        self.assertNotIn('--use', options['plugins'])
 
 
 class TemplateTestCase(TestCase):

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -144,11 +144,45 @@ Backend settings
 
          The arguments passed to clean-css.
 
+    - ``compressor.filters.PostCSSFilter``
+
+      A filter that passes the CSS content to the `postcss`_ tool. You can
+      specify the plugins you wish to use with :attr:`COMPRESS_POSTCSS_PLUGINS`
+      in your settings (assuming you have postcss and the desired plugins installed).
+
+      Example::
+
+          COMPRESS_POSTCSS_PLUGINS = (
+              'autoprefixer',
+              'postcss-font-magician',
+          )
+
+      .. attribute:: COMPRESS_POSTCSS_PLUGINS
+
+         A tuple with postcss plugins that you want to use. Any plugin you
+         specify here must be installed manually. If no plugins are specified
+         then the CSS will still go through postcss but without any plugins
+         applied and thus no changes to the file will occur.
+
+      .. attribute:: COMPRESS_POSTCSS_BINARY
+
+         Path to the postcss binary in the filesystem. By default ``postcss`` will
+         be used. If postcss is not installed globally or for some other reason
+         you wish to use a different binary you can explicitly state the path to that binary.
+
+      .. attribute:: COMPRESS_POSTCSS_ARGUMENTS
+
+         Extra arguments passed to postcss if desired. By default no extra
+         arguments are required.
+
+
+
 
     .. _`data: URIs`: http://en.wikipedia.org/wiki/Data_URI_scheme
     .. _csscompressor: http://pypi.python.org/pypi/csscompressor/
     .. _rCSSmin: http://opensource.perlig.de/rcssmin/
     .. _`clean-css`: https://github.com/GoalSmashers/clean-css/
+    .. _postcss: https://github.com/postcss/postcss
 
 
     - ``compressor.filters.template.TemplateFilter``


### PR DESCRIPTION
I thought it would be advantageous to be able and use PostCSS with the myriad of plugins it offers like the famous Autoprefixer. I did find [this implementation](https://github.com/dizballanze/django-compressor-autoprefixer) which however is specific to only one plugin.

With the implementation here you can use any number of plugins by specifying the `COMPRESS_POSTCSS_PLUGINS` variable in settings.py.

I did my best to add documentation and tests and follow the guidelines for `django-compressor`. I hope this gets merged since I think it can better the workflow for many people (it sure will for me!).

I tested only with Python2.7 and Python3.5 with no error messages. I also wanted to add tests that make usage of the plugins themselves but that would require using `npm` in the testsuite and since I couldn't find anything like that already there I decided to skip it.

Feel free to comment..