### PR TITLE
clarified documentation for COMPRESS_CACHE_BACKEND

### DIFF
--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -370,7 +370,7 @@ Caching settings
 
 .. attribute:: COMPRESS_CACHE_BACKEND
 
-    :Default: ``CACHES["default"]`` or ``CACHE_BACKEND``
+    :Default: ``"default"`` or ``CACHE_BACKEND``
 
     The backend to use for caching, in case you want to use a different cache
     backend for Django Compressor.


### PR DESCRIPTION
When using the "default" ``CACHES["default"]`` as a value for ``COMPRESS_CACHE_BACKEND`` an error would be thrown. The correct way is to use the name of the cache backend.