### PR TITLE
Fix crashing when node attribute is set to None

### DIFF
--- a/compressor/offline/django.py
+++ b/compressor/offline/django.py
@@ -132,7 +132,9 @@ class DjangoParser(object):
         nodelist = []
         if isinstance(node, Node):
             for attr in node.child_nodelists:
-                nodelist += getattr(node, attr, [])
+                attrs = getattr(node, attr, [])
+                if attrs is not None:
+                    nodelist += attrs
         else:
             nodelist = getattr(node, 'nodelist', [])
         return nodelist


### PR DESCRIPTION
The **compress** command was crashing when https://github.com/batiste/django-page-cms was added to project's `INSTALLED_APPS`. This pull requests provides a simple way to avoid such situations.

```(demo) michal@localhost:~/dev/ar/demo/ArabellaDemoApi$ ./manage.py compress --force
/home/michal/dev/ar/demo/lib64/python3.4/importlib/_bootstrap.py:321: RemovedInDjango19Warning: django.utils.importlib will be removed in Django 1.9.
  return f(*args, **kwds)

Traceback (most recent call last):
  File "./manage.py", line 8, in <module>
    execute_from_command_line(sys.argv)
  File "/home/michal/dev/ar/demo/lib/python3.4/site-packages/django/core/management/__init__.py", line 354, in execute_from_command_line
    utility.execute()
  File "/home/michal/dev/ar/demo/lib/python3.4/site-packages/django/core/management/__init__.py", line 346, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/michal/dev/ar/demo/lib/python3.4/site-packages/django/core/management/base.py", line 394, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/michal/dev/ar/demo/lib/python3.4/site-packages/django/core/management/base.py", line 445, in execute
    output = self.handle(*args, **options)
  File "/home/michal/dev/ar/demo/lib/python3.4/site-packages/compressor/management/commands/compress.py", line 291, in handle
    self.compress(sys.stdout, **options)
  File "/home/michal/dev/ar/demo/lib/python3.4/site-packages/compressor/management/commands/compress.py", line 196, in compress
    nodes = list(parser.walk_nodes(template, context=context))
  File "/home/michal/dev/ar/demo/lib/python3.4/site-packages/compressor/offline/django.py", line 148, in walk_nodes
    for node in self.walk_nodes(node, original, context):
  File "/home/michal/dev/ar/demo/lib/python3.4/site-packages/compressor/offline/django.py", line 148, in walk_nodes
    for node in self.walk_nodes(node, original, context):
  File "/home/michal/dev/ar/demo/lib/python3.4/site-packages/compressor/offline/django.py", line 148, in walk_nodes
    for node in self.walk_nodes(node, original, context):
  File "/home/michal/dev/ar/demo/lib/python3.4/site-packages/compressor/offline/django.py", line 143, in walk_nodes
    for node in self.get_nodelist(node, original, context):
  File "/home/michal/dev/ar/demo/lib/python3.4/site-packages/compressor/offline/django.py", line 135, in get_nodelist
    nodelist += getattr(node, attr, [])
TypeError: 'NoneType' object is not iterable```