### PR TITLE
Css absolute filter improvements

### DIFF
--- a/compressor/filters/css_default.py
+++ b/compressor/filters/css_default.py
@@ -57,51 +57,50 @@ class CssAbsoluteFilter(FilterBase):
 
     def add_suffix(self, url):
         filename = self.guess_filename(url)
+        if not filename:
+            return url
+        if settings.COMPRESS_CSS_HASHING_METHOD is None:
+            return url
+        if not url.startswith(SCHEMES):
+            return url
+
         suffix = None
-        if filename:
-            if settings.COMPRESS_CSS_HASHING_METHOD == "mtime":
-                suffix = get_hashed_mtime(filename)
-            elif settings.COMPRESS_CSS_HASHING_METHOD in ("hash", "content"):
-                suffix = get_hashed_content(filename)
-            elif settings.COMPRESS_CSS_HASHING_METHOD is None:
-                suffix = None
-            else:
-                raise FilterError('COMPRESS_CSS_HASHING_METHOD is configured '
+        if settings.COMPRESS_CSS_HASHING_METHOD == "mtime":
+            suffix = get_hashed_mtime(filename)
+        elif settings.COMPRESS_CSS_HASHING_METHOD in ("hash", "content"):
+            suffix = get_hashed_content(filename)
+        else:
+            raise FilterError('COMPRESS_CSS_HASHING_METHOD is configured '
                                   'with an unknown method (%s).' %
                                   settings.COMPRESS_CSS_HASHING_METHOD)
-        if suffix is None:
-            return url
-        if url.startswith(SCHEMES):
-            fragment = None
-            if "#" in url:
-                url, fragment = url.rsplit("#", 1)
-            if "?" in url:
-                url = "%s&%s" % (url, suffix)
-            else:
-                url = "%s?%s" % (url, suffix)
-            if fragment is not None:
-                url = "%s#%s" % (url, fragment)
+        fragment = None
+        if "#" in url:
+            url, fragment = url.rsplit("#", 1)
+        if "?" in url:
+            url = "%s&%s" % (url, suffix)
+        else:
+            url = "%s?%s" % (url, suffix)
+        if fragment is not None:
+            url = "%s#%s" % (url, fragment)
         return url
 
-    def _converter(self, matchobj, group, template):
-        url = matchobj.group(group)
-
-        url = url.strip()
-        wrap = matchobj.group(1)
-        url = url.strip('\'"')
-
+    def _converter(self, url):
         if url.startswith(('#', 'data:')):
-            return template % (wrap, url, wrap)
+            return url
         elif url.startswith(SCHEMES):
-            return template % (wrap, self.add_suffix(url), wrap)
+            return self.add_suffix(url)
         full_url = posixpath.normpath('/'.join([str(self.directory_name),
                                                 url]))
         if self.has_scheme:
             full_url = "%s%s" % (self.protocol, full_url)
-        return template % (wrap, self.add_suffix(full_url), wrap)
+        return self.add_suffix(full_url)
 
     def url_converter(self, matchobj):
-        return self._converter(matchobj, 2, "url(%s%s%s)")
+        quote = matchobj.group(1)
+        converted_url = self._converter(matchobj.group(2))
+        return "url(%s%s%s)" % (quote, converted_url, quote)
 
     def src_converter(self, matchobj):
-        return self._converter(matchobj, 2, "src=%s%s%s")
+        quote = matchobj.group(1)
+        converted_url = self._converter(matchobj.group(2))
+        return "src=%s%s%s" % (quote, converted_url, quote)

--- a/compressor/filters/css_default.py
+++ b/compressor/filters/css_default.py
@@ -6,7 +6,8 @@ from compressor.cache import get_hashed_mtime, get_hashed_content
 from compressor.conf import settings
 from compressor.filters import FilterBase, FilterError
 
-URL_PATTERN = re.compile(r'url\( *(([\'"]?).+?\2) *\)')
+URL_PATTERN = re.compile(r'url\( *([\'"]?)(.+?)\1 *\)')
+# URL_PATTERN = re.compile(r'url\(([^\)]+)\)')
 SRC_PATTERN = re.compile(r'src=([\'"])(.+?)\1')
 SCHEMES = ('http://', 'https://', '/')
 
@@ -86,7 +87,7 @@ class CssAbsoluteFilter(FilterBase):
         url = matchobj.group(group)
 
         url = url.strip()
-        wrap = '"' if url[0] == '"' else "'"
+        wrap = matchobj.group(1)
         url = url.strip('\'"')
 
         if url.startswith(('#', 'data:')):
@@ -100,7 +101,7 @@ class CssAbsoluteFilter(FilterBase):
         return template % (wrap, self.add_suffix(full_url), wrap)
 
     def url_converter(self, matchobj):
-        return self._converter(matchobj, 1, "url(%s%s%s)")
+        return self._converter(matchobj, 2, "url(%s%s%s)")
 
     def src_converter(self, matchobj):
         return self._converter(matchobj, 2, "src=%s%s%s")

--- a/compressor/filters/css_default.py
+++ b/compressor/filters/css_default.py
@@ -8,7 +8,7 @@ from compressor.filters import FilterBase, FilterError
 
 URL_PATTERN = re.compile(r'url\( *(([\'"]?).+?\2) *\)')
 SRC_PATTERN = re.compile(r'src=([\'"])(.+?)\1')
-SCHEMES = ('http://', 'https://', '/', 'data:')
+SCHEMES = ('http://', 'https://', '/')
 
 
 class CssAbsoluteFilter(FilterBase):
@@ -89,7 +89,7 @@ class CssAbsoluteFilter(FilterBase):
         wrap = '"' if url[0] == '"' else "'"
         url = url.strip('\'"')
 
-        if url.startswith('#'):
+        if url.startswith(('#', 'data:')):
             return template % (wrap, url, wrap)
         elif url.startswith(SCHEMES):
             return template % (wrap, self.add_suffix(url), wrap)

--- a/compressor/filters/css_default.py
+++ b/compressor/filters/css_default.py
@@ -6,9 +6,15 @@ from compressor.cache import get_hashed_mtime, get_hashed_content
 from compressor.conf import settings
 from compressor.filters import FilterBase, FilterError
 
-URL_PATTERN = re.compile(r'url\( *([\'"]?)(.+?)\1 *\)')
-# URL_PATTERN = re.compile(r'url\(([^\)]+)\)')
-SRC_PATTERN = re.compile(r'src=([\'"])(.+?)\1')
+URL_PATTERN = re.compile(r"""
+    url\(
+    \s*      # any amount of whitespace
+    ([\'"]?) # optional quote
+    (.*?)    # any amount of anything, non-greedily (this is the actual url)
+    \1       # matching quote (or nothing if there was none)
+    \s*      # any amount of whitespace
+    \)""", re.VERBOSE)
+SRC_PATTERN = re.compile(r'src=([\'"])(.*?)\1')
 SCHEMES = ('http://', 'https://', '/')
 
 

--- a/compressor/filters/css_default.py
+++ b/compressor/filters/css_default.py
@@ -6,7 +6,7 @@ from compressor.cache import get_hashed_mtime, get_hashed_content
 from compressor.conf import settings
 from compressor.filters import FilterBase, FilterError
 
-URL_PATTERN = re.compile(r'url\(([^\)]+)\)')
+URL_PATTERN = re.compile(r'url\( *(([\'"]?).+?\2) *\)')
 SRC_PATTERN = re.compile(r'src=([\'"])(.+?)\1')
 SCHEMES = ('http://', 'https://', '/', 'data:')
 

--- a/compressor/tests/test_filters.py
+++ b/compressor/tests/test_filters.py
@@ -310,16 +310,16 @@ class CssAbsolutizingTestCase(TestCase):
 
         css1 = """\
 p { background: url('%(compress_url)simg/python.png?%(hash)s'); }
-p { background: url('%(compress_url)simg/python.png?%(hash)s'); }
-p { background: url('%(compress_url)simg/python.png?%(hash)s'); }
+p { background: url(%(compress_url)simg/python.png?%(hash)s); }
+p { background: url(%(compress_url)simg/python.png?%(hash)s); }
 p { background: url('%(compress_url)simg/python.png?%(hash)s'); }
 p { filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(src='%(compress_url)simg/python.png?%(hash)s'); }
 """ % dict(compress_url=settings.COMPRESS_URL, hash=hash_python_png)
 
         css2 = """\
 p { background: url('%(compress_url)simg/add.png?%(hash)s'); }
-p { background: url('%(compress_url)simg/add.png?%(hash)s'); }
-p { background: url('%(compress_url)simg/add.png?%(hash)s'); }
+p { background: url(%(compress_url)simg/add.png?%(hash)s); }
+p { background: url(%(compress_url)simg/add.png?%(hash)s); }
 p { background: url('%(compress_url)simg/add.png?%(hash)s'); }
 p { filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(src='%(compress_url)simg/add.png?%(hash)s'); }
 """ % dict(compress_url=settings.COMPRESS_URL, hash=hash_add_png)
@@ -358,6 +358,14 @@ p { filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(src='%(compress_u
         css = """body { background-image: url("data:image/svg+xml;utf8,<svg><rect fill='url(%23gradient)'/></svg>");}"""
         filter = CssAbsoluteFilter(css, filename="doesntmatter")
         self.assertEqual(css, filter.input(filename="doesntmatter", basename="doesntmatter"))
+
+    def test_does_not_change_quotes_in_src(self):
+        filename = os.path.join(settings.COMPRESS_ROOT, 'css/url/test.css')
+        hash_add_png = self.hashing_func(os.path.join(settings.COMPRESS_ROOT, 'img/add.png'))
+        css = """p { filter: Alpha(src="/img/add.png%(hash)s") }"""
+        filter = CssAbsoluteFilter(css % dict(hash=""))
+        expected = css % dict(hash='?' + hash_add_png)
+        self.assertEqual(expected, filter.input(filename=filename, basename='css/url/test.css'))
 
 
 @override_settings(COMPRESS_URL='http://static.example.com/')


### PR DESCRIPTION
This makes the CssAbsoluteFilter more robust. Fixes #764, fixes #827.

This does not actually handle nested parenthesis at all, it just expects closing quotes if there are opening ones (so `url("data:...stroke='rgba(0, 0, 0, 0.5)` wont match) and, to be safe, data-uris are ignored altogether.

reviewing the individual commits might be easier than the whole diff.