### PR TITLE
add ldjson to compress

### DIFF
--- a/compressor/conf.py
+++ b/compressor/conf.py
@@ -21,6 +21,7 @@ class CompressorConf(AppConf):
 
     CSS_COMPRESSOR = 'compressor.css.CssCompressor'
     JS_COMPRESSOR = 'compressor.js.JsCompressor'
+    LDJSON_COMPRESSOR = 'compressor.ldjson.LdjsonCompressor'
 
     URL = None
     ROOT = None

--- a/compressor/ldjson.py
+++ b/compressor/ldjson.py
@@ -1,0 +1,8 @@
+from compressor.conf import settings
+from compressor.base import Compressor, SOURCE_HUNK, SOURCE_FILE
+from compressor.js import JsCompressor
+
+class LdjsonCompressor(JsCompressor):
+
+    def __init__(self, content=None, output_prefix="ldjson", context=None):
+        super(LdjsonCompressor, self).__init__(content, output_prefix, context)

--- a/compressor/templates/compressor/ldjson_file.html
+++ b/compressor/templates/compressor/ldjson_file.html
@@ -1,0 +1,1 @@
+<script type="application/ld+json" src="{{ compressed.url }}"{{ compressed.extra }}></script>

--- a/compressor/templates/compressor/ldjson_inline.html
+++ b/compressor/templates/compressor/ldjson_inline.html
@@ -1,0 +1,1 @@
+<script type="application/ld+json">{{ compressed.content|safe }}</script>

--- a/compressor/templatetags/compress.py
+++ b/compressor/templatetags/compress.py
@@ -24,13 +24,14 @@ class CompressorMixin(object):
     def compressors(self):
         return {
             'js': settings.COMPRESS_JS_COMPRESSOR,
+            'ldjson': settings.COMPRESS_LDJSON_COMPRESSOR,
             'css': settings.COMPRESS_CSS_COMPRESSOR,
         }
 
     def compressor_cls(self, kind, *args, **kwargs):
         if kind not in self.compressors.keys():
             raise template.TemplateSyntaxError(
-                "The compress tag's argument must be 'js' or 'css'.")
+                "The compress tag's argument must be 'js' or 'css' pr 'ldjson'.")
         return get_class(self.compressors.get(kind),
                          exception=ImproperlyConfigured)(*args, **kwargs)
 


### PR DESCRIPTION
i add ld-json for schema.org https://developers.google.com/schemas/formats/json-ld

before:
if you use application/ld+json  and put the code inside {%compress js inline%} {%endcompress%} django-compressor change the type "application/ld+json" to "text/javascript"

after:
now you can use  {%compress ldjson inline%} and...  {%compress ldjson %}  