### PR TITLE
Seems to fix problem with context dictionary update sequence length

### DIFF
--- a/compressor/base.py
+++ b/compressor/base.py
@@ -339,7 +339,7 @@ class Compressor(object):
 
         self.context['compressed'].update(context or {})
         self.context['compressed'].update(self.extra_context)
-        if hasattr(self.context, 'flatten'):
+        if VERSION < (1, 8) or VERSION > (1, 9):
             # Django 1.8 complains about Context being passed to its
             # Template.render function.
             final_context = self.context.flatten()

--- a/compressor/base.py
+++ b/compressor/base.py
@@ -3,6 +3,7 @@ import os
 import codecs
 from importlib import import_module
 
+from django import VERSION
 from django.core.files.base import ContentFile
 from django.utils.safestring import mark_safe
 from django.utils.six.moves.urllib.request import url2pathname
@@ -342,9 +343,9 @@ class Compressor(object):
         if VERSION < (1, 8) or VERSION > (1, 9):
             # Django 1.8 complains about Context being passed to its
             # Template.render function.
-            final_context = self.context.flatten()
-        else:
             final_context = self.context
+        else:
+            final_context = self.context.flatten()
 
         post_compress.send(sender=self.__class__, type=self.type,
                            mode=mode, context=final_context)


### PR DESCRIPTION
Fix for retreiving final context in base.py/render_output.
Usage of flatten func is not controlled by existence of corresponding function but by django version.
Issue https://github.com/django-compressor/django-compressor/issues/706