### PR TITLE
New Python and Django

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ env:
   - TOXENV=py34-1.9.X
   - TOXENV=py27-1.10.X
   - TOXENV=py34-1.10.X
+  - TOXENV=py27-1.11.X
+  - TOXENV=py34-1.11.X
 # https://github.com/travis-ci/travis-ci/issues/4794
 matrix:
   include:
@@ -21,6 +23,8 @@ matrix:
       env: TOXENV=py35-1.9.X
     - python: 3.5
       env: TOXENV=py35-1.10.X
+    - python: 3.5
+      env: TOXENV=py35-1.11.X
 notifications:
   irc: "irc.freenode.org#django-compressor"
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: python
 sudo: false
 install:
-  - if [[ $TOXENV == py32-1.8.X ]]; then pip install pip\<8.0.0 virtualenv\<14.0.0; fi
   - pip install tox
 script:
   - tox
 env:
   - TOXENV=py27-1.8.X
-  - TOXENV=py32-1.8.X
   - TOXENV=py33-1.8.X
   - TOXENV=py34-1.8.X
   - TOXENV=py27-1.9.X

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ matrix:
       env: TOXENV=py35-1.10.X
     - python: 3.5
       env: TOXENV=py35-1.11.X
+    - python: 3.6
+      env: TOXENV=py36-1.11.X
 notifications:
   irc: "irc.freenode.org#django-compressor"
 after_success:

--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -144,7 +144,7 @@ class Command(BaseCommand):
                     templates.update(os.path.join(root, name)
                         for name in files if not name.startswith('.') and
                             any(fnmatch(name, "*%s" % glob) for glob in extensions))
-        elif engine == 'jinja2' and django.VERSION >= (1, 8):
+        elif engine == 'jinja2':
             env = settings.COMPRESS_JINJA2_GET_ENVIRONMENT()
             if env and hasattr(env, 'list_templates'):
                 templates |= set([env.loader.get_source(env, template)[1] for template in

--- a/compressor/parser/default_htmlparser.py
+++ b/compressor/parser/default_htmlparser.py
@@ -7,20 +7,10 @@ from compressor.exceptions import ParserError
 from compressor.parser import ParserBase
 
 
-# Starting in Python 3.2, the HTMLParser constructor takes a 'strict'
-# argument which default to True (which we don't want).
-# In Python 3.3, it defaults to False.
-# In Python 3.4, passing it at all raises a deprecation warning.
-# So we only pass it for 3.2.
-# In Python 3.4, it also takes a 'convert_charrefs' argument
-# which raises a warning if we don't pass it.
-major, minor, release = sys.version_info[:3]
-CONSTRUCTOR_TAKES_STRICT = major == 3 and minor == 2
-CONSTRUCTOR_TAKES_CONVERT_CHARREFS = major == 3 and minor >= 4
+# Since Python 3.4, the HTMLParser constructor takes a 'convert_charrefs'
+# argument which raises a warning if we don't pass it.
 HTML_PARSER_ARGS = {}
-if CONSTRUCTOR_TAKES_STRICT:
-    HTML_PARSER_ARGS['strict'] = False
-if CONSTRUCTOR_TAKES_CONVERT_CHARREFS:
+if sys.version_info[:2] >= (3, 4):
     HTML_PARSER_ARGS['convert_charrefs'] = False
 
 

--- a/compressor/tests/test_jinja2ext.py
+++ b/compressor/tests/test_jinja2ext.py
@@ -1,19 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import with_statement, unicode_literals
 
-import sys
-import unittest
-
 from django.test import TestCase
-from django.utils import six
 from django.test.utils import override_settings
 
 from compressor.conf import settings
 from compressor.tests.test_base import css_tag
 
 
-@unittest.skipIf(six.PY3 and sys.version_info[:2] < (3, 3),
-                     'Jinja can only run on Python < 3 and >= 3.3')
 class TestJinja2CompressorExtension(TestCase):
     """
     Test case for jinja2 extension.

--- a/compressor/tests/test_offline.py
+++ b/compressor/tests/test_offline.py
@@ -3,8 +3,6 @@ import copy
 import django
 import io
 import os
-import sys
-import unittest
 from importlib import import_module
 
 from mock import patch
@@ -34,12 +32,6 @@ else:
     except ImportError:
         from StringIO import StringIO
 
-# The Jinja2 tests fail on Python 3.2 due to the following:
-# The line in compressor/management/commands/compress.py:
-#     compressor_nodes.setdefault(template, []).extend(nodes)
-# causes the error 'unhashable type: 'Template''
-_TEST_JINJA2 = not(sys.version_info[0] == 3 and sys.version_info[1] == 2)
-
 
 def offline_context_generator():
     for i in range(1, 4):
@@ -57,10 +49,7 @@ class OfflineTestCaseMixin(object):
     templates_dir = ''
     expected_hash = ''
     # Engines to test
-    if _TEST_JINJA2:
-        engines = ('django', 'jinja2')
-    else:
-        engines = ('django',)
+    engines = ('django', 'jinja2')
     additional_test_settings = None
 
     def setUp(self):
@@ -247,7 +236,6 @@ class OfflineCompressBasicTestCase(OfflineTestCaseMixin, TestCase):
         self.assertRaises(OfflineGenerationError,
                           self.template.render, Context({}))
 
-    @unittest.skipIf(not _TEST_JINJA2, 'No Jinja2 testing')
     def test_rendering_without_manifest_raises_exception_jinja2(self):
         # flush cached manifest
         flush_offline_manifest()
@@ -742,7 +730,6 @@ class OfflineCompressExtendsRecursionTestCase(OfflineTestCaseMixin, TestCase):
         self.assertEqual(count, 1)
 
 
-@skipIf(not _TEST_JINJA2, "Test only run if we are testing Jinja2")
 class TestCompressCommand(OfflineTestCaseMixin, TestCase):
     templates_dir = "test_compress_command"
 

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,5 +1,5 @@
 flake8==2.4.0
-coverage==3.7.1
+coverage==4.4
 html5lib==0.9999999
 mock==1.0.1
 Jinja2==2.7.3

--- a/tox.ini
+++ b/tox.ini
@@ -23,26 +23,13 @@ three =
     csscompressor==0.9.4
     rcssmin==1.0.6
     rjsmin==1.0.12
-three_two =
-    flake8==2.4.0
-    coverage==3.7.1
-    html5lib==0.9999999
-    mock==1.0.1
-    Jinja2==2.6
-    lxml==3.4.2
-    beautifulsoup4==4.4.0
-    django-sekizai==0.9.0
-    csscompressor==0.9.4
-    rcssmin==1.0.6
-    rjsmin==1.0.12
 [tox]
 envlist =
-    {py27,py32,py33,py34,py35}-{1.8.X}
+    {py27,py33,py34,py35}-{1.8.X}
     {py27,py34,py35}-{1.9.X,1.10.X}
 [testenv]
 basepython =
     py27: python2.7
-    py32: python3.2
     py33: python3.3
     py34: python3.4
     py35: python3.5
@@ -58,7 +45,6 @@ deps =
     1.9.X: Django>=1.9,<1.10
     1.10.X: Django>=1.10,<1.11
     py27: {[deps]two}
-    py32: {[deps]three_two}
     py33: {[deps]three}
     py34: {[deps]three}
     py35: {[deps]three}

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [deps]
 two =
     flake8==2.4.0
-    coverage==3.7.1
+    coverage==4.4
     html5lib==0.9999999
     mock==1.0.1
     Jinja2==2.7.3
@@ -13,7 +13,7 @@ two =
     rjsmin==1.0.12
 three =
     flake8==2.4.0
-    coverage==3.7.1
+    coverage==4.4
     html5lib==0.9999999
     mock==1.0.1
     Jinja2==2.7.3
@@ -27,12 +27,14 @@ three =
 envlist =
     {py27,py33,py34,py35}-{1.8.X}
     {py27,py34,py35}-{1.9.X,1.10.X,1.11.X}
+    {py36}-{1.11.X}
 [testenv]
 basepython =
     py27: python2.7
     py33: python3.3
     py34: python3.4
     py35: python3.5
+    py36: python3.6
 usedevelop = true
 setenv =
     CPPFLAGS=-O0
@@ -49,4 +51,5 @@ deps =
     py33: {[deps]three}
     py34: {[deps]three}
     py35: {[deps]three}
+    py36: {[deps]three}
     django-discover-runner

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ three =
 [tox]
 envlist =
     {py27,py33,py34,py35}-{1.8.X}
-    {py27,py34,py35}-{1.9.X,1.10.X}
+    {py27,py34,py35}-{1.9.X,1.10.X,1.11.X}
 [testenv]
 basepython =
     py27: python2.7
@@ -44,6 +44,7 @@ deps =
     1.8.X: Django>=1.8,<1.9
     1.9.X: Django>=1.9,<1.10
     1.10.X: Django>=1.10,<1.11
+    1.11.X: Django>=1.11,<1.12
     py27: {[deps]two}
     py33: {[deps]three}
     py34: {[deps]three}


### PR DESCRIPTION
* drop support for Python 3.2
* test against django 1.11 and python 3.6

it seems like django 1.11 did not need any code changes and also did not introduce any new deprecation warnings...

fixes #849.