### PR TITLE
Fix #837 -- Make it much easier to debug `OfflineGenerationError`.

### DIFF
--- a/compressor/templatetags/compress.py
+++ b/compressor/templatetags/compress.py
@@ -61,7 +61,8 @@ class CompressorMixin(object):
         If enabled and in offline mode, and not forced check the offline cache
         and return the result if given
         """
-        key = get_offline_hexdigest(self.get_original_content(context))
+        original_content = self.get_original_content(context)
+        key = get_offline_hexdigest(original_content)
         offline_manifest = get_offline_manifest()
         if key in offline_manifest:
             return offline_manifest[key].replace(
@@ -70,7 +71,8 @@ class CompressorMixin(object):
         else:
             raise OfflineGenerationError('You have offline compression '
                 'enabled but key "%s" is missing from offline manifest. '
-                'You may need to run "python manage.py compress".' % key)
+                'You may need to run "python manage.py compress". Here '
+                'is the original content:\n\n%s' % (key, original_content))
 
     def render_cached(self, compressor, kind, mode):
         """


### PR DESCRIPTION
Previously, we were only including the hex digest key derived from the
original content in the error message. This is useless because:

* The key is missing, so we can't search templates or the cache for it
  and find anything useful.

* We have no idea which template or compress block might have generated
  the key.

Including the original content gives us a very strong clue that will
help us identify the compress block which has some dynamic content that
is causing the error.