### PR TITLE
Ensure generated file always contains a base name

### DIFF
--- a/compressor/base.py
+++ b/compressor/base.py
@@ -286,7 +286,7 @@ class Compressor(object):
                 pass
         return content
 
-    def output(self, mode='file', forced=False):
+    def output(self, mode='file', forced=False, basename=None):
         """
         The general output method, override in subclass if you need to do
         any custom modification. Calls other mode specific methods or simply
@@ -299,7 +299,7 @@ class Compressor(object):
 
         if settings.COMPRESS_ENABLED or forced:
             filtered_output = self.filter_output(output)
-            return self.handle_output(mode, filtered_output, forced)
+            return self.handle_output(mode, filtered_output, forced, basename)
 
         return output
 

--- a/compressor/filters/css_default.py
+++ b/compressor/filters/css_default.py
@@ -139,7 +139,7 @@ class CssRelativeFilter(CssAbsoluteFilter):
 
         - original file URL: '/static/my-app/style.css'
         - it has an image link: ``url(images/logo.svg)``
-        - compiled file URL: '/static/CACHE/css/abcdef123456.css'
+        - compiled file URL: '/static/CACHE/css/output.abcdef123456.css'
         - replaced image link URL: ``url(../../my-app/images/logo.svg)``
         """
         old_prefix = self.url

--- a/compressor/templatetags/compress.py
+++ b/compressor/templatetags/compress.py
@@ -104,7 +104,11 @@ class CompressorMixin(object):
             if cache_content is not None:
                 return cache_content
 
-        rendered_output = compressor.output(mode, forced=forced)
+        file_basename = getattr(self, 'name', None) or getattr(self, 'basename', None)
+        if file_basename is None:
+            file_basename = 'output'
+
+        rendered_output = compressor.output(mode, forced=forced, basename=file_basename)
         assert isinstance(rendered_output, six.string_types)
         if cache_key:
             cache_set(cache_key, rendered_output)

--- a/compressor/templatetags/compress.py
+++ b/compressor/templatetags/compress.py
@@ -142,36 +142,14 @@ def compress(parser, token):
 
     Syntax::
 
-        {% compress <js/css> %}
+        {% compress <js/css> [<file/inline> [block_name]] %}
         <html of inline or linked JS/CSS>
         {% endcompress %}
 
     Examples::
 
-        {% compress css %}
-        <link rel="stylesheet" href="/static/css/one.css" type="text/css" charset="utf-8">
-        <style type="text/css">p { border:5px solid green;}</style>
-        <link rel="stylesheet" href="/static/css/two.css" type="text/css" charset="utf-8">
-        {% endcompress %}
+        See docs/usage.rst
 
-    Which would be rendered something like::
-
-        <link rel="stylesheet" href="/static/CACHE/css/f7c661b7a124.css" type="text/css" media="all" charset="utf-8">
-
-    or::
-
-        {% compress js %}
-        <script src="/static/js/one.js" type="text/javascript" charset="utf-8"></script>
-        <script type="text/javascript" charset="utf-8">obj.value = "value";</script>
-        {% endcompress %}
-
-    Which would be rendered something like::
-
-        <script type="text/javascript" src="/static/CACHE/js/3f33b9146e12.js" charset="utf-8"></script>
-
-    Linked files must be on your COMPRESS_URL (which defaults to STATIC_URL).
-    If DEBUG is true off-site files will throw exceptions. If DEBUG is false
-    they will be silently stripped.
     """
 
     nodelist = parser.parse(('endcompress',))

--- a/compressor/tests/test_jinja2ext.py
+++ b/compressor/tests/test_jinja2ext.py
@@ -77,7 +77,7 @@ class TestJinja2CompressorExtension(TestCase):
         <link rel="stylesheet" href="{{ STATIC_URL }}css/two.css" type="text/css" charset="utf-8">
         {% endcompress %}""")
         context = {'STATIC_URL': settings.COMPRESS_URL}
-        out = css_tag("/static/CACHE/css/58a8c0714e59.css")
+        out = css_tag("/static/CACHE/css/output.58a8c0714e59.css")
         self.assertEqual(out, template.render(context))
 
     def test_nonascii_css_tag(self):
@@ -86,7 +86,7 @@ class TestJinja2CompressorExtension(TestCase):
         <style type="text/css">p { border:5px solid green;}</style>
         {% endcompress %}""")
         context = {'STATIC_URL': settings.COMPRESS_URL}
-        out = css_tag("/static/CACHE/css/4263023f49d6.css")
+        out = css_tag("/static/CACHE/css/output.4263023f49d6.css")
         self.assertEqual(out, template.render(context))
 
     def test_js_tag(self):
@@ -95,7 +95,7 @@ class TestJinja2CompressorExtension(TestCase):
         <script type="text/javascript" charset="utf-8">obj.value = "value";</script>
         {% endcompress %}""")
         context = {'STATIC_URL': settings.COMPRESS_URL}
-        out = '<script type="text/javascript" src="/static/CACHE/js/74e158ccb432.js"></script>'
+        out = '<script type="text/javascript" src="/static/CACHE/js/output.74e158ccb432.js"></script>'
         self.assertEqual(out, template.render(context))
 
     def test_nonascii_js_tag(self):
@@ -104,7 +104,7 @@ class TestJinja2CompressorExtension(TestCase):
         <script type="text/javascript" charset="utf-8">var test_value = "\u2014";</script>
         {% endcompress %}""")
         context = {'STATIC_URL': settings.COMPRESS_URL}
-        out = '<script type="text/javascript" src="/static/CACHE/js/a18195c6ae48.js"></script>'
+        out = '<script type="text/javascript" src="/static/CACHE/js/output.a18195c6ae48.js"></script>'
         self.assertEqual(out, template.render(context))
 
     def test_nonascii_latin1_js_tag(self):
@@ -113,7 +113,7 @@ class TestJinja2CompressorExtension(TestCase):
         <script type="text/javascript">var test_value = "\u2014";</script>
         {% endcompress %}""")
         context = {'STATIC_URL': settings.COMPRESS_URL}
-        out = '<script type="text/javascript" src="/static/CACHE/js/f64debbd8878.js"></script>'
+        out = '<script type="text/javascript" src="/static/CACHE/js/output.f64debbd8878.js"></script>'
         self.assertEqual(out, template.render(context))
 
     def test_css_inline(self):
@@ -143,6 +143,6 @@ class TestJinja2CompressorExtension(TestCase):
                                             '<style type="text/css">'
                                             '/* русский текст */'
                                             '</style>{% endcompress %}')
-        out = '<link rel="stylesheet" href="/static/CACHE/css/c836c9caed5c.css" type="text/css" />'
+        out = '<link rel="stylesheet" href="/static/CACHE/css/output.c836c9caed5c.css" type="text/css" />'
         context = {'STATIC_URL': settings.COMPRESS_URL}
         self.assertEqual(out, template.render(context))

--- a/compressor/tests/test_offline.py
+++ b/compressor/tests/test_offline.py
@@ -47,6 +47,7 @@ class OfflineTestCaseMixin(object):
     verbosity = 0
     # Change this for each test class
     templates_dir = ''
+    expected_basename = 'output'
     expected_hash = ''
     # Engines to test
     engines = ('django', 'jinja2')
@@ -134,17 +135,17 @@ class OfflineTestCaseMixin(object):
 
     def _render_script(self, hash):
         return (
-            '<script type="text/javascript" src="{}CACHE/js/{}.js">'
+            '<script type="text/javascript" src="{}CACHE/js/{}.{}.js">'
             '</script>'.format(
-                settings.COMPRESS_URL_PLACEHOLDER, hash
+                settings.COMPRESS_URL_PLACEHOLDER, self.expected_basename, hash
             )
         )
 
     def _render_link(self, hash):
         return (
-            '<link rel="stylesheet" href="{}CACHE/css/{}.css" '
+            '<link rel="stylesheet" href="{}CACHE/css/{}.{}.css" '
             'type="text/css" />'.format(
-                settings.COMPRESS_URL_PLACEHOLDER, hash
+                settings.COMPRESS_URL_PLACEHOLDER, self.expected_basename, hash
             )
         )
 
@@ -367,6 +368,14 @@ class OfflineCompressTemplateTagTestCase(OfflineTestCaseMixin, TestCase):
 class OfflineCompressStaticTemplateTagTestCase(OfflineTestCaseMixin, TestCase):
     templates_dir = 'test_static_templatetag'
     expected_hash = '2607a2085687'
+
+
+class OfflineCompressTemplateTagNamedTestCase(OfflineTestCaseMixin, TestCase):
+    templates_dir = 'test_templatetag_named'
+    expected_basename = 'output_name'
+    expected_hash = 'a432b6ddb2c4'
+    # block naming unsupported in jinga2
+    engines = ('django',)
 
 
 class OfflineCompressTestCaseWithContext(OfflineTestCaseMixin, TestCase):

--- a/compressor/tests/test_storages.py
+++ b/compressor/tests/test_storages.py
@@ -41,7 +41,7 @@ class StorageTestCase(TestCase):
         {% endcompress %}
         """
         context = {'STATIC_URL': settings.COMPRESS_URL}
-        out = css_tag("/static/CACHE/css/aca9bcd16bee.css")
+        out = css_tag("/static/CACHE/css/output.aca9bcd16bee.css")
         self.assertEqual(out, render(template, context))
 
     def test_race_condition_handling(self):

--- a/compressor/tests/test_templates/test_templatetag_named/test_compressor_offline.html
+++ b/compressor/tests/test_templates/test_templatetag_named/test_compressor_offline.html
@@ -1,0 +1,7 @@
+{% load compress %}{% spaceless %}
+
+{% compress js file output_name %}
+    <script type="text/javascript">
+        alert("Basic test");
+    </script>
+{% endcompress %}{% endspaceless %}

--- a/compressor/tests/test_templatetags.py
+++ b/compressor/tests/test_templatetags.py
@@ -45,7 +45,16 @@ class TemplatetagTestCase(TestCase):
 <style type="text/css">p { border:5px solid green;}</style>
 <link rel="stylesheet" href="{{ STATIC_URL }}css/two.css" type="text/css">
 {% endcompress %}"""
-        out = css_tag("/static/CACHE/css/58a8c0714e59.css")
+        out = css_tag("/static/CACHE/css/output.58a8c0714e59.css")
+        self.assertEqual(out, render(template, self.context))
+
+    def test_css_tag_with_block(self):
+        template = """{% load compress %}{% compress css file block_name %}
+<link rel="stylesheet" href="{{ STATIC_URL }}css/one.css" type="text/css">
+<style type="text/css">p { border:5px solid blue;}</style>
+<link rel="stylesheet" href="{{ STATIC_URL }}css/two.css" type="text/css">
+{% endcompress %}"""
+        out = css_tag("/static/CACHE/css/block_name.393dbcddb48e.css")
         self.assertEqual(out, render(template, self.context))
 
     def test_missing_rel_leaves_empty_result(self):
@@ -62,7 +71,7 @@ class TemplatetagTestCase(TestCase):
 <style type="text/css">p { border:5px solid green;}</style>
 <link rel="stylesheet" href="{{ STATIC_URL }}css/two.css" type="text/css">
 {% endcompress %}"""
-        out = css_tag("/static/CACHE/css/58a8c0714e59.css")
+        out = css_tag("/static/CACHE/css/output.58a8c0714e59.css")
         self.assertEqual(out, render(template, self.context))
 
     def test_uppercase_rel(self):
@@ -71,7 +80,7 @@ class TemplatetagTestCase(TestCase):
 <style type="text/css">p { border:5px solid green;}</style>
 <link rel="StyleSheet" href="{{ STATIC_URL }}css/two.css" type="text/css">
 {% endcompress %}"""
-        out = css_tag("/static/CACHE/css/58a8c0714e59.css")
+        out = css_tag("/static/CACHE/css/output.58a8c0714e59.css")
         self.assertEqual(out, render(template, self.context))
 
     def test_nonascii_css_tag(self):
@@ -80,7 +89,7 @@ class TemplatetagTestCase(TestCase):
         <style type="text/css">p { border:5px solid green;}</style>
         {% endcompress %}
         """
-        out = css_tag("/static/CACHE/css/4263023f49d6.css")
+        out = css_tag("/static/CACHE/css/output.4263023f49d6.css")
         self.assertEqual(out, render(template, self.context))
 
     def test_js_tag(self):
@@ -89,7 +98,7 @@ class TemplatetagTestCase(TestCase):
         <script type="text/javascript">obj.value = "value";</script>
         {% endcompress %}
         """
-        out = '<script type="text/javascript" src="/static/CACHE/js/74e158ccb432.js"></script>'
+        out = '<script type="text/javascript" src="/static/CACHE/js/output.74e158ccb432.js"></script>'
         self.assertEqual(out, render(template, self.context))
 
     def test_nonascii_js_tag(self):
@@ -98,7 +107,7 @@ class TemplatetagTestCase(TestCase):
         <script type="text/javascript">var test_value = "\u2014";</script>
         {% endcompress %}
         """
-        out = '<script type="text/javascript" src="/static/CACHE/js/a18195c6ae48.js"></script>'
+        out = '<script type="text/javascript" src="/static/CACHE/js/output.a18195c6ae48.js"></script>'
         self.assertEqual(out, render(template, self.context))
 
     def test_nonascii_latin1_js_tag(self):
@@ -107,7 +116,7 @@ class TemplatetagTestCase(TestCase):
         <script type="text/javascript">var test_value = "\u2014";</script>
         {% endcompress %}
         """
-        out = '<script type="text/javascript" src="/static/CACHE/js/f64debbd8878.js"></script>'
+        out = '<script type="text/javascript" src="/static/CACHE/js/output.f64debbd8878.js"></script>'
         self.assertEqual(out, render(template, self.context))
 
     def test_compress_tag_with_illegal_arguments(self):
@@ -168,7 +177,7 @@ class TemplatetagTestCase(TestCase):
         <script type="text/javascript">var tmpl="{% templatetag openblock %} if x == 3 %}x IS 3{% templatetag openblock %} endif %}"</script>
         {% endaddtoblock %}{% render_block "js" postprocessor "compressor.contrib.sekizai.compress" %}
         """
-        out = '<script type="text/javascript" src="/static/CACHE/js/4d88842b99b3.js"></script>'
+        out = '<script type="text/javascript" src="/static/CACHE/js/output.4d88842b99b3.js"></script>'
         self.assertEqual(out, render(template, self.context, SekizaiContext))
 
 
@@ -197,7 +206,7 @@ class PrecompilerTemplatetagTestCase(TestCase):
         template = """{% load compress %}{% compress js %}
             <script type="text/coffeescript"># this is a comment.</script>
             {% endcompress %}"""
-        out = script(src="/static/CACHE/js/fb128b610c3e.js")
+        out = script(src="/static/CACHE/js/output.fb128b610c3e.js")
         self.assertEqual(out, render(template, self.context))
 
     def test_compress_coffeescript_tag_and_javascript_tag(self):
@@ -205,7 +214,7 @@ class PrecompilerTemplatetagTestCase(TestCase):
             <script type="text/coffeescript"># this is a comment.</script>
             <script type="text/javascript"># this too is a comment.</script>
             {% endcompress %}"""
-        out = script(src="/static/CACHE/js/cf3495aaff6e.js")
+        out = script(src="/static/CACHE/js/output.cf3495aaff6e.js")
         self.assertEqual(out, render(template, self.context))
 
     @override_settings(COMPRESS_ENABLED=False)

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -39,7 +39,7 @@ Base settings
     like this::
 
         <script type="text/javascript" src="/static/js/site-base.js"></script>
-        <script type="text/javascript" src="/static/CACHE/js/8dd1a2872443.js" charset="utf-8"></script>
+        <script type="text/javascript" src="/static/CACHE/js/awesome.8dd1a2872443.js" charset="utf-8"></script>
 
 .. attribute:: COMPRESS_URL
 
@@ -301,7 +301,7 @@ Backend settings
 
     This would give you something like this::
 
-        <script type="text/javascript" src="/static/CACHE/js/8dd1a2872443.js" charset="utf-8"></script>
+        <script type="text/javascript" src="/static/CACHE/js/output.8dd1a2872443.js" charset="utf-8"></script>
 
     The same works for less_, too:
 
@@ -322,7 +322,7 @@ Backend settings
 
     Which would be rendered something like::
 
-        <link rel="stylesheet" href="/static/CACHE/css/8ccf8d877f18.css" type="text/css" charset="utf-8">
+        <link rel="stylesheet" href="/static/CACHE/css/output.8ccf8d877f18.css" type="text/css" charset="utf-8">
 
     .. _less: http://lesscss.org/
     .. _CoffeeScript: http://coffeescript.org/

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -27,7 +27,7 @@ Which would be rendered something like:
 
 .. code-block:: django
 
-    <link rel="stylesheet" href="/static/CACHE/css/f7c661b7a124.css" type="text/css" charset="utf-8">
+    <link rel="stylesheet" href="/static/CACHE/css/one.f7c661b7a124.css" type="text/css" charset="utf-8">
 
 or:
 
@@ -35,7 +35,7 @@ or:
 
     {% load compress %}
 
-    {% compress js %}
+    {% compress js file base %}
     <script src="/static/js/one.js" type="text/javascript" charset="utf-8"></script>
     <script type="text/javascript" charset="utf-8">obj.value = "value";</script>
     {% endcompress %}
@@ -44,7 +44,7 @@ Which would be rendered something like:
 
 .. code-block:: django
 
-    <script type="text/javascript" src="/static/CACHE/js/3f33b9146e12.js" charset="utf-8"></script>
+    <script type="text/javascript" src="/static/CACHE/js/base.3f33b9146e12.js" charset="utf-8"></script>
 
 .. note::
 

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -13,38 +13,56 @@ Usage
 Examples
 --------
 
-.. code-block:: django
+Basic example:
 
-    {% load compress %}
+    .. code-block:: django
 
-    {% compress css %}
-    <link rel="stylesheet" href="/static/css/one.css" type="text/css" charset="utf-8">
-    <style type="text/css">p { border:5px solid green;}</style>
-    <link rel="stylesheet" href="/static/css/two.css" type="text/css" charset="utf-8">
-    {% endcompress %}
+        {% compress css %}
+        <link rel="stylesheet" href="/static/css/one.css" type="text/css" charset="utf-8">
+        <style type="text/css">p { border:5px solid green;}</style>
+        <link rel="stylesheet" href="/static/css/two.css" type="text/css" charset="utf-8">
+        {% endcompress %}
 
-Which would be rendered something like:
+Result:
 
-.. code-block:: django
+    .. code-block:: django
 
-    <link rel="stylesheet" href="/static/CACHE/css/one.f7c661b7a124.css" type="text/css" charset="utf-8">
+        <link rel="stylesheet" href="/static/CACHE/css/output.f7c661b7a124.css" type="text/css" charset="utf-8">
 
-or:
+Adding the ``inline`` parameter will put the content directly to the
+rendered page instead of a file:
 
-.. code-block:: django
+    .. code-block:: django
 
-    {% load compress %}
+        {% compress js inline %}
+        <script src="/static/js/one.js" type="text/javascript" charset="utf-8"></script>
+        <script type="text/javascript" charset="utf-8">obj.value = "value";</script>
+        {% endcompress %}
 
-    {% compress js file base %}
-    <script src="/static/js/one.js" type="text/javascript" charset="utf-8"></script>
-    <script type="text/javascript" charset="utf-8">obj.value = "value";</script>
-    {% endcompress %}
+Result:
 
-Which would be rendered something like:
+    .. code-block:: django
 
-.. code-block:: django
+        <script type="text/javascript" charset="utf-8">
+        obj = {};
+        obj.value = "value";
+        </script>
 
-    <script type="text/javascript" src="/static/CACHE/js/base.3f33b9146e12.js" charset="utf-8"></script>
+Specifying a ``block_name`` will change the output filename. It can also be
+accessed in the :ref:`post_compress signal <signals>` in the ``context`` parameter.
+
+    .. code-block:: django
+
+        {% compress js file base %}
+        <script src="/static/js/one.js" type="text/javascript" charset="utf-8"></script>
+        <script type="text/javascript" charset="utf-8">obj.value = "value";</script>
+        {% endcompress %}
+
+Result:
+
+    .. code-block:: django
+
+        <script type="text/javascript" src="/static/CACHE/js/base.3f33b9146e12.js" charset="utf-8"></script>
 
 .. note::
 
@@ -61,7 +79,7 @@ and simply returns exactly what it was given.
 
     If you've configured any
     :attr:`precompilers <django.conf.settings.COMPRESS_PRECOMPILERS>`
-    setting :attr:`~django.conf.settings.COMPRESS_ENABLED` to ``False`` won't
+    setting, :attr:`~django.conf.settings.COMPRESS_ENABLED` to ``False`` won't
     affect the processing of those files. Only the
     :attr:`CSS <django.conf.settings.COMPRESS_CSS_FILTERS>` and
     :attr:`JavaScript filters <django.conf.settings.COMPRESS_JS_FILTERS>`
@@ -79,31 +97,6 @@ exception. If DEBUG is ``False`` these files will be silently stripped.
     :attr:`~django.conf.settings.COMPRESS_CACHE_BACKEND` and
     Django's `caching documentation`_).
 
-The compress template tag supports a second argument specifying the output
-mode and defaults to saving the result in a file. Alternatively you can
-pass '``inline``' to the template tag to return the content directly to the
-rendered page, e.g.:
-
-.. code-block:: django
-
-    {% load compress %}
-
-    {% compress js inline %}
-    <script src="/static/js/one.js" type="text/javascript" charset="utf-8"></script>
-    <script type="text/javascript" charset="utf-8">obj.value = "value";</script>
-    {% endcompress %}
-
-would be rendered something like::
-
-    <script type="text/javascript" charset="utf-8">
-    obj = {};
-    obj.value = "value";
-    </script>
-
-The compress template tag also supports a third argument for naming the output
-of that particular compress tag.  This is then added to the context so you can
-access it in the `post_compress signal <signals>`.
-
 .. _memcached: http://memcached.org/
 .. _caching documentation: https://docs.djangoproject.com/en/1.8/topics/cache/#memcached
 
@@ -111,7 +104,7 @@ access it in the `post_compress signal <signals>`.
 .. _offline_compression:
 
 Offline Compression
----------------
+-------------------
 
 Django Compressor has the ability to run the compression "offline",
 i.e. outside of the request/response loop -- independent from user requests.


### PR DESCRIPTION
This changes the default output filename from [hash].[ext] to [name].[hash].[ext] in all cases.

This makes the output naming consistent with Whitenoise in all cases.  This is because only files named as <name>.<hash>.<ext> will be considered immutable, all other files will have the default 10 sec age set.

In addition, the user can customise the name using the block_name attribute.

* The default name is set to output.  
* Use the block_name as the name if it's provided in the template tag.
* When using single or multiple js/css files with no filters defined the basename of one of those files will still be used for the name (this is the existing behaviour).
* Tests added and updated to support the name change.

This change was originally to solve #775, but this only changes the output naming convention.