### PR TITLE
Allow md5 hash to be overridden

### DIFF
--- a/compressor/cache.py
+++ b/compressor/cache.py
@@ -18,7 +18,8 @@ _cachekey_func = None
 
 
 def get_hexdigest(plaintext, length=None):
-    digest = hashlib.md5(smart_bytes(plaintext)).hexdigest()
+    hash_name = getattr(settings, 'COMPRESS_CACHE_HASH', 'md5')
+    digest = getattr(hashlib, hash_name)(smart_bytes(plaintext)).hexdigest()
     if length:
         return digest[:length]
     return digest

--- a/compressor/tests/test_base.py
+++ b/compressor/tests/test_base.py
@@ -211,6 +211,12 @@ class CompressorTestCase(SimpleTestCase):
         out = '<script type="text/javascript" src="/static/CACHE/js/d728fc7f9301.js"></script>'
         self.assertEqual(out, self.js_node.output())
 
+    @override_settings(COMPRESS_CACHE_HASH='sha256')
+    def test_js_output_sha256(self):
+        """ Modify the CACHE_HASH to use sha256 instead of md5 """
+        out = '<script type="text/javascript" src="/static/CACHE/js/74e158ccb432.js"></script>'
+        self.assertEqual(out, self.js_node.output())
+
     def test_js_override_url(self):
         self.js_node.context.update({'url': 'This is not a url, just a text'})
         out = '<script type="text/javascript" src="/static/CACHE/js/d728fc7f9301.js"></script>'


### PR DESCRIPTION
On FIPS[0] enabled systems unsafe cryptographic modules are disabled.
This commit leaves the default of 'md5', but allows one to override
which hashlib library is loaded.

A test for sha256 is included.

AppConf was not used, as it appears the get_hexdigest function is called
too early or in the wrong context to utilize AppConf.

[0] http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140val-all.htm