### PR TITLE
Md5 to sha256

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ compressor/tests/static/CACHE
 compressor/tests/static/custom
 compressor/tests/static/js/066cd253eada.js
 compressor/tests/static/js/d728fc7f9301.js
+compressor/tests/static/js/74e158ccb432.js
 compressor/tests/static/test.txt*
 
 dist

--- a/compressor/base.py
+++ b/compressor/base.py
@@ -92,12 +92,12 @@ class Compressor(object):
         Returns file path for an output file based on contents.
 
         Returned path is relative to compressor storage's base url, for
-        example "CACHE/css/e41ba2cc6982.css".
+        example "CACHE/css/58a8c0714e59.css".
 
         When `basename` argument is provided then file name (without extension)
         will be used as a part of returned file name, for example:
 
-        get_filepath(content, "my_file.css") -> 'CACHE/css/my_file.e41ba2cc6982.css'
+        get_filepath(content, "my_file.css") -> 'CACHE/css/my_file.58a8c0714e59.css'
         """
         parts = []
         if basename:

--- a/compressor/cache.py
+++ b/compressor/cache.py
@@ -18,7 +18,7 @@ _cachekey_func = None
 
 
 def get_hexdigest(plaintext, length=None):
-    digest = hashlib.md5(smart_bytes(plaintext)).hexdigest()
+    digest = hashlib.sha256(smart_bytes(plaintext)).hexdigest()
     if length:
         return digest[:length]
     return digest

--- a/compressor/tests/test_base.py
+++ b/compressor/tests/test_base.py
@@ -57,10 +57,10 @@ class PrecompilerAndAbsoluteFilterTestCase(SimpleTestCase):
 
     def setUp(self):
         self.html_orig = '<link rel="stylesheet" href="/static/css/relative_url.css" type="text/css" />'
-        self.html_link_to_precompiled_css = '<link rel="stylesheet" href="/static/CACHE/css/relative_url.41a74f6d5864.css" type="text/css" />'
-        self.html_link_to_absolutized_css = '<link rel="stylesheet" href="/static/CACHE/css/relative_url.9b8fd415e521.css" type="text/css" />'
+        self.html_link_to_precompiled_css = '<link rel="stylesheet" href="/static/CACHE/css/relative_url.e8602322bfa6.css" type="text/css" />'
+        self.html_link_to_absolutized_css = '<link rel="stylesheet" href="/static/CACHE/css/relative_url.376db5682982.css" type="text/css" />'
         self.css_orig = "p { background: url('../img/python.png'); }" # content of relative_url.css
-        self.css_absolutized = "p { background: url('/static/img/python.png?c2281c83670e'); }"
+        self.css_absolutized = "p { background: url('/static/img/python.png?ccb38978f900'); }"
 
     def helper(self, enabled, use_precompiler, use_absolute_filter, expected_output):
         precompiler = (('text/css', 'compressor.tests.test_base.PassthroughPrecompiler'),) if use_precompiler else ()
@@ -181,7 +181,7 @@ class CompressorTestCase(SimpleTestCase):
             r"cachekey is returning something that doesn't look like r'\w{12}'")
 
     def test_css_return_if_on(self):
-        output = css_tag('/static/CACHE/css/e41ba2cc6982.css')
+        output = css_tag('/static/CACHE/css/58a8c0714e59.css')
         self.assertEqual(output, self.css_node.output().strip())
 
     def test_js_split(self):
@@ -208,17 +208,17 @@ class CompressorTestCase(SimpleTestCase):
         self.assertEqual(out, list(self.js_node.hunks()))
 
     def test_js_output(self):
-        out = '<script type="text/javascript" src="/static/CACHE/js/d728fc7f9301.js"></script>'
+        out = '<script type="text/javascript" src="/static/CACHE/js/74e158ccb432.js"></script>'
         self.assertEqual(out, self.js_node.output())
 
     def test_js_override_url(self):
         self.js_node.context.update({'url': 'This is not a url, just a text'})
-        out = '<script type="text/javascript" src="/static/CACHE/js/d728fc7f9301.js"></script>'
+        out = '<script type="text/javascript" src="/static/CACHE/js/74e158ccb432.js"></script>'
         self.assertEqual(out, self.js_node.output())
 
     def test_css_override_url(self):
         self.css_node.context.update({'url': 'This is not a url, just a text'})
-        output = css_tag('/static/CACHE/css/e41ba2cc6982.css')
+        output = css_tag('/static/CACHE/css/58a8c0714e59.css')
         self.assertEqual(output, self.css_node.output().strip())
 
     @override_settings(COMPRESS_PRECOMPILERS=(), COMPRESS_ENABLED=False)
@@ -226,22 +226,22 @@ class CompressorTestCase(SimpleTestCase):
         self.assertEqualCollapsed(self.js, self.js_node.output())
 
     def test_js_return_if_on(self):
-        output = '<script type="text/javascript" src="/static/CACHE/js/d728fc7f9301.js"></script>'
+        output = '<script type="text/javascript" src="/static/CACHE/js/74e158ccb432.js"></script>'
         self.assertEqual(output, self.js_node.output())
 
     @override_settings(COMPRESS_OUTPUT_DIR='custom')
     def test_custom_output_dir1(self):
-        output = '<script type="text/javascript" src="/static/custom/js/d728fc7f9301.js"></script>'
+        output = '<script type="text/javascript" src="/static/custom/js/74e158ccb432.js"></script>'
         self.assertEqual(output, JsCompressor(self.js).output())
 
     @override_settings(COMPRESS_OUTPUT_DIR='')
     def test_custom_output_dir2(self):
-        output = '<script type="text/javascript" src="/static/js/d728fc7f9301.js"></script>'
+        output = '<script type="text/javascript" src="/static/js/74e158ccb432.js"></script>'
         self.assertEqual(output, JsCompressor(self.js).output())
 
     @override_settings(COMPRESS_OUTPUT_DIR='/custom/nested/')
     def test_custom_output_dir3(self):
-        output = '<script type="text/javascript" src="/static/custom/nested/js/d728fc7f9301.js"></script>'
+        output = '<script type="text/javascript" src="/static/custom/nested/js/74e158ccb432.js"></script>'
         self.assertEqual(output, JsCompressor(self.js).output())
 
     @override_settings(COMPRESS_PRECOMPILERS=(

--- a/compressor/tests/test_jinja2ext.py
+++ b/compressor/tests/test_jinja2ext.py
@@ -77,7 +77,7 @@ class TestJinja2CompressorExtension(TestCase):
         <link rel="stylesheet" href="{{ STATIC_URL }}css/two.css" type="text/css" charset="utf-8">
         {% endcompress %}""")
         context = {'STATIC_URL': settings.COMPRESS_URL}
-        out = css_tag("/static/CACHE/css/e41ba2cc6982.css")
+        out = css_tag("/static/CACHE/css/58a8c0714e59.css")
         self.assertEqual(out, template.render(context))
 
     def test_nonascii_css_tag(self):
@@ -86,7 +86,7 @@ class TestJinja2CompressorExtension(TestCase):
         <style type="text/css">p { border:5px solid green;}</style>
         {% endcompress %}""")
         context = {'STATIC_URL': settings.COMPRESS_URL}
-        out = css_tag("/static/CACHE/css/799f6defe43c.css")
+        out = css_tag("/static/CACHE/css/4263023f49d6.css")
         self.assertEqual(out, template.render(context))
 
     def test_js_tag(self):
@@ -95,7 +95,7 @@ class TestJinja2CompressorExtension(TestCase):
         <script type="text/javascript" charset="utf-8">obj.value = "value";</script>
         {% endcompress %}""")
         context = {'STATIC_URL': settings.COMPRESS_URL}
-        out = '<script type="text/javascript" src="/static/CACHE/js/d728fc7f9301.js"></script>'
+        out = '<script type="text/javascript" src="/static/CACHE/js/74e158ccb432.js"></script>'
         self.assertEqual(out, template.render(context))
 
     def test_nonascii_js_tag(self):
@@ -104,7 +104,7 @@ class TestJinja2CompressorExtension(TestCase):
         <script type="text/javascript" charset="utf-8">var test_value = "\u2014";</script>
         {% endcompress %}""")
         context = {'STATIC_URL': settings.COMPRESS_URL}
-        out = '<script type="text/javascript" src="/static/CACHE/js/d34f30e02e70.js"></script>'
+        out = '<script type="text/javascript" src="/static/CACHE/js/a18195c6ae48.js"></script>'
         self.assertEqual(out, template.render(context))
 
     def test_nonascii_latin1_js_tag(self):
@@ -113,7 +113,7 @@ class TestJinja2CompressorExtension(TestCase):
         <script type="text/javascript">var test_value = "\u2014";</script>
         {% endcompress %}""")
         context = {'STATIC_URL': settings.COMPRESS_URL}
-        out = '<script type="text/javascript" src="/static/CACHE/js/a830bddd3636.js"></script>'
+        out = '<script type="text/javascript" src="/static/CACHE/js/f64debbd8878.js"></script>'
         self.assertEqual(out, template.render(context))
 
     def test_css_inline(self):
@@ -143,6 +143,6 @@ class TestJinja2CompressorExtension(TestCase):
                                             '<style type="text/css">'
                                             '/* русский текст */'
                                             '</style>{% endcompress %}')
-        out = '<link rel="stylesheet" href="/static/CACHE/css/b2cec0f8cb24.css" type="text/css" />'
+        out = '<link rel="stylesheet" href="/static/CACHE/css/c836c9caed5c.css" type="text/css" />'
         context = {'STATIC_URL': settings.COMPRESS_URL}
         self.assertEqual(out, template.render(context))

--- a/compressor/tests/test_mtime_cache.py
+++ b/compressor/tests/test_mtime_cache.py
@@ -8,7 +8,7 @@ class TestMtimeCacheCommand(TestCase):
     # FIXME: add actual tests, improve the existing ones.
 
     exclusion_patterns = [
-        '*CACHE*', '*custom*', '*066cd253eada.js', '*d728fc7f9301.js', 'test.txt*'
+        '*CACHE*', '*custom*', '*066cd253eada.js', '*d728fc7f9301.js', '*74e158ccb432.js', 'test.txt*'
     ]
 
     def default_ignore(self):

--- a/compressor/tests/test_offline.py
+++ b/compressor/tests/test_offline.py
@@ -203,7 +203,7 @@ class OfflineTestCaseMixin(object):
 
 class OfflineCompressBasicTestCase(OfflineTestCaseMixin, TestCase):
     templates_dir = 'basic'
-    expected_hash = 'a2d34b854194'
+    expected_hash = 'a432b6ddb2c4'
 
     @patch.object(CompressCommand, 'compress')
     def test_handle_no_args(self, compress_mock):
@@ -293,7 +293,7 @@ class OfflineCompressSkipDuplicatesTestCase(OfflineTestCaseMixin, TestCase):
         # Only one block compressed, the second identical one was skipped.
         self.assertEqual(1, count)
         # Only 1 <script> block in returned result as well.
-        self.assertEqual([self._render_script('a2d34b854194')], result)
+        self.assertEqual([self._render_script('a432b6ddb2c4')], result)
         rendered_template = self._render_template(engine)
         # But rendering the template returns both (identical) scripts.
         self.assertEqual(
@@ -302,7 +302,7 @@ class OfflineCompressSkipDuplicatesTestCase(OfflineTestCaseMixin, TestCase):
 
 class OfflineCompressBlockSuperTestCase(OfflineTestCaseMixin, TestCase):
     templates_dir = 'test_block_super'
-    expected_hash = '09424aa0fc45'
+    expected_hash = '68c645740177'
     # Block.super not supported for Jinja2 yet.
     engines = ('django',)
 
@@ -310,7 +310,7 @@ class OfflineCompressBlockSuperTestCase(OfflineTestCaseMixin, TestCase):
 class OfflineCompressBlockSuperMultipleTestCase(
         OfflineTestCaseMixin, TestCase):
     templates_dir = 'test_block_super_multiple'
-    expected_hash = '86520b469e89'
+    expected_hash = 'f87403f4d8af'
     # Block.super not supported for Jinja2 yet.
     engines = ('django',)
 
@@ -318,7 +318,7 @@ class OfflineCompressBlockSuperMultipleTestCase(
 class OfflineCompressBlockSuperMultipleCachedLoaderTestCase(
         OfflineTestCaseMixin, TestCase):
     templates_dir = 'test_block_super_multiple_cached'
-    expected_hash = 'd31f4d9bbd99'
+    expected_hash = 'ea860151aa21'
     # Block.super not supported for Jinja2 yet.
     engines = ('django',)
     additional_test_settings = {
@@ -342,8 +342,8 @@ class OfflineCompressBlockSuperTestCaseWithExtraContent(
             log=self.log, verbosity=self.verbosity, engine=engine)
         self.assertEqual(2, count)
         self.assertEqual([
-            self._render_script('85482ad42724'),
-            self._render_script('09424aa0fc45')
+            self._render_script('9717f9c7e9ff'),
+            self._render_script('68c645740177')
         ], result)
         rendered_template = self._render_template(engine)
         self.assertEqual(rendered_template, self._render_result(result, ''))
@@ -351,7 +351,7 @@ class OfflineCompressBlockSuperTestCaseWithExtraContent(
 
 class OfflineCompressConditionTestCase(OfflineTestCaseMixin, TestCase):
     templates_dir = 'test_condition'
-    expected_hash = '2b3ab9ad7158'
+    expected_hash = '58517669cb7c'
     additional_test_settings = {
         'COMPRESS_OFFLINE_CONTEXT': {
             'condition': 'red',
@@ -361,17 +361,17 @@ class OfflineCompressConditionTestCase(OfflineTestCaseMixin, TestCase):
 
 class OfflineCompressTemplateTagTestCase(OfflineTestCaseMixin, TestCase):
     templates_dir = 'test_templatetag'
-    expected_hash = 'a62a1cfcd3b5'
+    expected_hash = '16f8880b81ab'
 
 
 class OfflineCompressStaticTemplateTagTestCase(OfflineTestCaseMixin, TestCase):
     templates_dir = 'test_static_templatetag'
-    expected_hash = 'c6ecb8d4ce7e'
+    expected_hash = '2607a2085687'
 
 
 class OfflineCompressTestCaseWithContext(OfflineTestCaseMixin, TestCase):
     templates_dir = 'test_with_context'
-    expected_hash = '0b939b10df08'
+    expected_hash = '045b3ad664c8'
     additional_test_settings = {
         'COMPRESS_OFFLINE_CONTEXT': {
             'content': 'OK!',
@@ -381,7 +381,7 @@ class OfflineCompressTestCaseWithContext(OfflineTestCaseMixin, TestCase):
 
 class OfflineCompressTestCaseWithContextSuper(OfflineTestCaseMixin, TestCase):
     templates_dir = 'test_with_context_super'
-    expected_hash = '9fad27eba458'
+    expected_hash = '9a8b47adfe17'
     additional_test_settings = {
         'COMPRESS_OFFLINE_CONTEXT': {
             'content': 'OK!',
@@ -393,7 +393,7 @@ class OfflineCompressTestCaseWithContextSuper(OfflineTestCaseMixin, TestCase):
 
 class OfflineCompressTestCaseWithContextList(OfflineTestCaseMixin, TestCase):
     templates_dir = 'test_with_context'
-    expected_hash = ['a92d67d3304a', '0ad21f77e74e', 'a3598381c14f']
+    expected_hash = ['3b6cd13d4bde', '5aef37564182', 'c6d6c723a18b']
     additional_test_settings = {
         'COMPRESS_OFFLINE_CONTEXT': list(offline_context_generator())
     }
@@ -409,7 +409,7 @@ class OfflineCompressTestCaseWithContextList(OfflineTestCaseMixin, TestCase):
 class OfflineCompressTestCaseWithContextListSuper(
         OfflineCompressTestCaseWithContextList):
     templates_dir = 'test_with_context_super'
-    expected_hash = ['1a40a7565816', 'f91a43f26ad3', 'b6e00dc2000c']
+    expected_hash = ['dc68dd60aed4', 'c2e50f475853', '045b48455bee']
     additional_test_settings = {
         'COMPRESS_OFFLINE_CONTEXT': list(offline_context_generator())
     }
@@ -420,7 +420,7 @@ class OfflineCompressTestCaseWithContextListSuper(
 class OfflineCompressTestCaseWithContextGenerator(
         OfflineTestCaseMixin, TestCase):
     templates_dir = 'test_with_context'
-    expected_hash = ['a92d67d3304a', '0ad21f77e74e', 'a3598381c14f']
+    expected_hash = ['3b6cd13d4bde', '5aef37564182', 'c6d6c723a18b']
     additional_test_settings = {
         'COMPRESS_OFFLINE_CONTEXT': 'compressor.tests.test_offline.'
                                     'offline_context_generator'
@@ -439,7 +439,7 @@ class OfflineCompressTestCaseWithContextGenerator(
 class OfflineCompressTestCaseWithContextGeneratorSuper(
         OfflineCompressTestCaseWithContextGenerator):
     templates_dir = 'test_with_context_super'
-    expected_hash = ['1a40a7565816', 'f91a43f26ad3', 'b6e00dc2000c']
+    expected_hash = ['dc68dd60aed4', 'c2e50f475853', '045b48455bee']
     additional_test_settings = {
         'COMPRESS_OFFLINE_CONTEXT': 'compressor.tests.test_offline.'
                                     'offline_context_generator'
@@ -458,7 +458,7 @@ class OfflineCompressStaticUrlIndependenceTestCase(
     STATIC_URL is not cached when rendering the template.
     """
     templates_dir = 'test_static_url_independence'
-    expected_hash = '12772534f095'
+    expected_hash = '5014de5edcbe'
     additional_test_settings = {
         'STATIC_URL': '/custom/static/url/',
         'COMPRESS_OFFLINE_CONTEXT': (
@@ -485,7 +485,7 @@ class OfflineCompressStaticUrlIndependenceTestCase(
 class OfflineCompressTestCaseWithContextVariableInheritance(
         OfflineTestCaseMixin, TestCase):
     templates_dir = 'test_with_context_variable_inheritance'
-    expected_hash = 'fbf0ed0604e3'
+    expected_hash = '0d88c897f64a'
     additional_test_settings = {
         'COMPRESS_OFFLINE_CONTEXT': {
             'parent_template': 'base.html',
@@ -508,7 +508,7 @@ class OfflineCompressTestCaseWithContextVariableInheritanceSuper(
             'parent_template': 'base2.html',
         }]
     }
-    expected_hash = ['11c0a6708293', '3bb007b509b3']
+    expected_hash = ['6a2f85c623c6', '04b482ba2855']
     # Block.super not supported for Jinja2 yet.
     engines = ('django',)
 
@@ -572,11 +572,11 @@ class OfflineCompressTestCaseErrors(OfflineTestCaseMixin, TestCase):
             # 'compress' nodes are processed correctly.
             self.assertEqual(4, count)
             self.assertEqual(engine, 'jinja2')
-            self.assertIn(self._render_link('78bd7a762e2d'), result)
-            self.assertIn(self._render_link('e31030430724'), result)
+            self.assertIn(self._render_link('7ff52cb38987'), result)
+            self.assertIn(self._render_link('2db2b4d36380'), result)
 
-        self.assertIn(self._render_script('e847d9758dbf'), result)
-        self.assertIn(self._render_script('1c8d9c2db1fb'), result)
+        self.assertIn(self._render_script('3910ce35946a'), result)
+        self.assertIn(self._render_script('244f05154671'), result)
 
 
 class OfflineCompressTestCaseWithError(OfflineTestCaseMixin, TestCase):
@@ -608,7 +608,7 @@ class OfflineCompressEmptyTag(OfflineTestCaseMixin, TestCase):
         compressor encounters such an emptystring in the manifest.
     """
     templates_dir = 'basic'
-    expected_hash = 'a2d34b854194'
+    expected_hash = 'a432b6ddb2c4'
     engines = ('django',)
 
     def _test_offline(self, engine):
@@ -623,8 +623,8 @@ class OfflineCompressBlockSuperBaseCompressed(OfflineTestCaseMixin, TestCase):
     template_names = ['base.html', 'base2.html',
                       'test_compressor_offline.html']
     templates_dir = 'test_block_super_base_compressed'
-    expected_hash_offline = ['e74d9424467d', '9df645ef1c05', '86520b469e89']
-    expected_hash = ['028c3fc42232', '2e9d3f5545a6', '86520b469e89']
+    expected_hash_offline = ['5a2fda9ac8e4', '5b7c5e6473f8', 'f87403f4d8af']
+    expected_hash = ['028c3fc42232', '2e9d3f5545a6', 'f87403f4d8af']
     # Block.super not supported for Jinja2 yet.
     engines = ('django',)
 
@@ -694,9 +694,9 @@ class OfflineCompressComplexTestCase(OfflineTestCaseMixin, TestCase):
             log=self.log, verbosity=self.verbosity, engine=engine)
         self.assertEqual(3, count)
         self.assertEqual([
-            self._render_script('ea8d7c940f0d'),
-            self._render_script('10ae6904bcc6'),
-            self._render_script('8c7c068d5973')
+            self._render_script('2c1f0f85a90d'),
+            self._render_script('8b594c4f7264'),
+            self._render_script('e0e424964c8c')
         ], result)
         rendered_template = self._render_template(engine)
         self.assertEqual(
@@ -751,18 +751,18 @@ class TestCompressCommand(OfflineTestCaseMixin, TestCase):
         call_command('compress', engines=["django"], **opts)
         manifest_django = get_offline_manifest()
         manifest_django_expected = self._build_expected_manifest(
-            {'8464063aa0729700fca0452e009582af': 'f3bfcd635b36'})
+            {'0fed9c02607acba22316a328075a81a74e0983ae79470daa9d3707a337623dc3': '023629c58235'})
         self.assertEqual(manifest_django, manifest_django_expected)
 
         call_command('compress', engines=["jinja2"], **opts)
         manifest_jinja2 = get_offline_manifest()
         manifest_jinja2_expected = self._build_expected_manifest(
-            {'0ec631f01496b28bbecad129c5532db4': '9ddf4527a67d'})
+            {'077408d23d4a829b8f88db2eadcf902b29d71b14f94018d900f38a3f8ed24c94': 'b6695d1aa847'})
         self.assertEqual(manifest_jinja2, manifest_jinja2_expected)
 
         call_command('compress', engines=["django", "jinja2"], **opts)
         manifest_both = get_offline_manifest()
         manifest_both_expected = self._build_expected_manifest(
-            {'8464063aa0729700fca0452e009582af': 'f3bfcd635b36',
-             '0ec631f01496b28bbecad129c5532db4': '9ddf4527a67d'})
+            {'0fed9c02607acba22316a328075a81a74e0983ae79470daa9d3707a337623dc3': '023629c58235',
+             '077408d23d4a829b8f88db2eadcf902b29d71b14f94018d900f38a3f8ed24c94': 'b6695d1aa847'})
         self.assertEqual(manifest_both, manifest_both_expected)

--- a/compressor/tests/test_storages.py
+++ b/compressor/tests/test_storages.py
@@ -41,7 +41,7 @@ class StorageTestCase(TestCase):
         {% endcompress %}
         """
         context = {'STATIC_URL': settings.COMPRESS_URL}
-        out = css_tag("/static/CACHE/css/1d4424458f88.css")
+        out = css_tag("/static/CACHE/css/aca9bcd16bee.css")
         self.assertEqual(out, render(template, context))
 
     def test_race_condition_handling(self):

--- a/compressor/tests/test_templatetags.py
+++ b/compressor/tests/test_templatetags.py
@@ -45,7 +45,7 @@ class TemplatetagTestCase(TestCase):
 <style type="text/css">p { border:5px solid green;}</style>
 <link rel="stylesheet" href="{{ STATIC_URL }}css/two.css" type="text/css">
 {% endcompress %}"""
-        out = css_tag("/static/CACHE/css/e41ba2cc6982.css")
+        out = css_tag("/static/CACHE/css/58a8c0714e59.css")
         self.assertEqual(out, render(template, self.context))
 
     def test_missing_rel_leaves_empty_result(self):
@@ -62,7 +62,7 @@ class TemplatetagTestCase(TestCase):
 <style type="text/css">p { border:5px solid green;}</style>
 <link rel="stylesheet" href="{{ STATIC_URL }}css/two.css" type="text/css">
 {% endcompress %}"""
-        out = css_tag("/static/CACHE/css/e41ba2cc6982.css")
+        out = css_tag("/static/CACHE/css/58a8c0714e59.css")
         self.assertEqual(out, render(template, self.context))
 
     def test_uppercase_rel(self):
@@ -71,7 +71,7 @@ class TemplatetagTestCase(TestCase):
 <style type="text/css">p { border:5px solid green;}</style>
 <link rel="StyleSheet" href="{{ STATIC_URL }}css/two.css" type="text/css">
 {% endcompress %}"""
-        out = css_tag("/static/CACHE/css/e41ba2cc6982.css")
+        out = css_tag("/static/CACHE/css/58a8c0714e59.css")
         self.assertEqual(out, render(template, self.context))
 
     def test_nonascii_css_tag(self):
@@ -80,7 +80,7 @@ class TemplatetagTestCase(TestCase):
         <style type="text/css">p { border:5px solid green;}</style>
         {% endcompress %}
         """
-        out = css_tag("/static/CACHE/css/799f6defe43c.css")
+        out = css_tag("/static/CACHE/css/4263023f49d6.css")
         self.assertEqual(out, render(template, self.context))
 
     def test_js_tag(self):
@@ -89,7 +89,7 @@ class TemplatetagTestCase(TestCase):
         <script type="text/javascript">obj.value = "value";</script>
         {% endcompress %}
         """
-        out = '<script type="text/javascript" src="/static/CACHE/js/d728fc7f9301.js"></script>'
+        out = '<script type="text/javascript" src="/static/CACHE/js/74e158ccb432.js"></script>'
         self.assertEqual(out, render(template, self.context))
 
     def test_nonascii_js_tag(self):
@@ -98,7 +98,7 @@ class TemplatetagTestCase(TestCase):
         <script type="text/javascript">var test_value = "\u2014";</script>
         {% endcompress %}
         """
-        out = '<script type="text/javascript" src="/static/CACHE/js/d34f30e02e70.js"></script>'
+        out = '<script type="text/javascript" src="/static/CACHE/js/a18195c6ae48.js"></script>'
         self.assertEqual(out, render(template, self.context))
 
     def test_nonascii_latin1_js_tag(self):
@@ -107,7 +107,7 @@ class TemplatetagTestCase(TestCase):
         <script type="text/javascript">var test_value = "\u2014";</script>
         {% endcompress %}
         """
-        out = '<script type="text/javascript" src="/static/CACHE/js/a830bddd3636.js"></script>'
+        out = '<script type="text/javascript" src="/static/CACHE/js/f64debbd8878.js"></script>'
         self.assertEqual(out, render(template, self.context))
 
     def test_compress_tag_with_illegal_arguments(self):
@@ -168,11 +168,12 @@ class TemplatetagTestCase(TestCase):
         <script type="text/javascript">var tmpl="{% templatetag openblock %} if x == 3 %}x IS 3{% templatetag openblock %} endif %}"</script>
         {% endaddtoblock %}{% render_block "js" postprocessor "compressor.contrib.sekizai.compress" %}
         """
-        out = '<script type="text/javascript" src="/static/CACHE/js/74e008a57789.js"></script>'
+        out = '<script type="text/javascript" src="/static/CACHE/js/4d88842b99b3.js"></script>'
         self.assertEqual(out, render(template, self.context, SekizaiContext))
 
 
 class PrecompilerTemplatetagTestCase(TestCase):
+
     def setUp(self):
         precompiler = os.path.join(test_dir, 'precompiler.py')
         python = sys.executable
@@ -196,7 +197,7 @@ class PrecompilerTemplatetagTestCase(TestCase):
         template = """{% load compress %}{% compress js %}
             <script type="text/coffeescript"># this is a comment.</script>
             {% endcompress %}"""
-        out = script(src="/static/CACHE/js/82d254e4462a.js")
+        out = script(src="/static/CACHE/js/fb128b610c3e.js")
         self.assertEqual(out, render(template, self.context))
 
     def test_compress_coffeescript_tag_and_javascript_tag(self):
@@ -204,7 +205,7 @@ class PrecompilerTemplatetagTestCase(TestCase):
             <script type="text/coffeescript"># this is a comment.</script>
             <script type="text/javascript"># this too is a comment.</script>
             {% endcompress %}"""
-        out = script(src="/static/CACHE/js/07bc3c26db9a.js")
+        out = script(src="/static/CACHE/js/cf3495aaff6e.js")
         self.assertEqual(out, render(template, self.context))
 
     @override_settings(COMPRESS_ENABLED=False)
@@ -233,7 +234,7 @@ class PrecompilerTemplatetagTestCase(TestCase):
         </script>
         {% endcompress %}"""
 
-        out = script(src="/static/CACHE/js/one.95cfb869eead.js")
+        out = script(src="/static/CACHE/js/one.4b3570601b8c.js")
         self.assertEqual(out, render(template, self.context))
 
     @override_settings(COMPRESS_ENABLED=False)
@@ -247,9 +248,9 @@ class PrecompilerTemplatetagTestCase(TestCase):
         </script>
         {% endcompress %}"""
 
-        out = '\n'.join([script(src="/static/CACHE/js/one.95cfb869eead.js"),
+        out = '\n'.join([script(src="/static/CACHE/js/one.4b3570601b8c.js"),
                          script(scripttype="", src="/static/js/one.js"),
-                         script(src="/static/CACHE/js/one.81a2cd965815.js")])
+                         script(src="/static/CACHE/js/one.8ab93aace8fa.js")])
 
         self.assertEqual(out, render(template, self.context))
 
@@ -279,7 +280,7 @@ class PrecompilerTemplatetagTestCase(TestCase):
 
         out = ''.join(['<link rel="stylesheet" type="text/css" href="/static/css/one.css" />',
                        '<link rel="stylesheet" type="text/css" href="/static/css/two.css" />',
-                       '<link rel="stylesheet" href="/static/CACHE/css/test.5dddc6c2fb5a.css" type="text/css" />'])
+                       '<link rel="stylesheet" href="/static/CACHE/css/test.222f958fb191.css" type="text/css" />'])
         self.assertEqual(out, render(template, self.context))
 
 


### PR DESCRIPTION
On FIPS[0] enabled systems unsafe cryptographic modules are disabled.
This commit changes out the md5 function for sha256, both of hashlib.

[0] http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140val-all.htm