### PR TITLE
ref #870 - improves memory management

### DIFF
--- a/compressor/offline/jinja2.py
+++ b/compressor/offline/jinja2.py
@@ -84,7 +84,7 @@ class Jinja2Parser(object):
 
         # Allow offline context to override the globals.
         context = self.env.globals.copy()
-        context.update(offline_context)
+        context.update(flatten_context(offline_context))
 
         return context
 

--- a/compressor/tests/test_offline.py
+++ b/compressor/tests/test_offline.py
@@ -157,7 +157,7 @@ class OfflineTestCaseMixin(object):
         hashes = self.expected_hash
         if not isinstance(hashes, (list, tuple)):
             hashes = [hashes]
-        count, result = CompressCommand().compress(
+        count, result = CompressCommand().handle_inner(
             log=self.log, verbosity=self.verbosity, engine=engine)
         self.assertEqual(len(hashes), count)
         self.assertEqual([self._render_script(h) for h in hashes], result)
@@ -207,27 +207,29 @@ class OfflineCompressBasicTestCase(OfflineTestCaseMixin, TestCase):
 
     @patch.object(CompressCommand, 'compress')
     def test_handle_no_args(self, compress_mock):
-        CompressCommand().handle()
+        compress_mock.return_value = {}, 1, []
+        CompressCommand().handle_inner()
         self.assertEqual(compress_mock.call_count, 1)
 
     @patch.object(CompressCommand, 'compress')
     def test_handle_compress_disabled(self, compress_mock):
         with self.settings(COMPRESS_ENABLED=False):
             with self.assertRaises(CommandError):
-                CompressCommand().handle()
+                CompressCommand().handle_inner()
         self.assertEqual(compress_mock.call_count, 0)
 
     @patch.object(CompressCommand, 'compress')
     def test_handle_compress_offline_disabled(self, compress_mock):
         with self.settings(COMPRESS_OFFLINE=False):
             with self.assertRaises(CommandError):
-                CompressCommand().handle()
+                CompressCommand().handle_inner()
         self.assertEqual(compress_mock.call_count, 0)
 
     @patch.object(CompressCommand, 'compress')
     def test_handle_compress_offline_disabled_force(self, compress_mock):
+        compress_mock.return_value = {}, 1, []
         with self.settings(COMPRESS_OFFLINE=False):
-            CompressCommand().handle(force=True)
+            CompressCommand().handle_inner(force=True)
         self.assertEqual(compress_mock.call_count, 1)
 
     def test_rendering_without_manifest_raises_exception(self):
@@ -243,7 +245,7 @@ class OfflineCompressBasicTestCase(OfflineTestCaseMixin, TestCase):
                           self.template_jinja2.render, {})
 
     def _test_deleting_manifest_does_not_affect_rendering(self, engine):
-        count, result = CompressCommand().compress(
+        count, result = CompressCommand().handle_inner(
             log=self.log, verbosity=self.verbosity, engine=engine)
         get_offline_manifest()
         manifest_path = os.path.join('CACHE', 'manifest.json')
@@ -278,7 +280,7 @@ class OfflineCompressBasicTestCase(OfflineTestCaseMixin, TestCase):
            side_effect=Exception(b"non-ascii character here:\xc3\xa4"))
     def test_non_ascii_exception_messages(self, mock):
         with self.assertRaises(CommandError):
-            CompressCommand().handle()
+            CompressCommand().handle_inner()
 
 
 class OfflineCompressSkipDuplicatesTestCase(OfflineTestCaseMixin, TestCase):
@@ -288,7 +290,7 @@ class OfflineCompressSkipDuplicatesTestCase(OfflineTestCaseMixin, TestCase):
     engines = ('django',)
 
     def _test_offline(self, engine):
-        count, result = CompressCommand().compress(
+        count, result = CompressCommand().handle_inner(
             log=self.log, verbosity=self.verbosity, engine=engine)
         # Only one block compressed, the second identical one was skipped.
         self.assertEqual(1, count)
@@ -338,7 +340,7 @@ class OfflineCompressBlockSuperTestCaseWithExtraContent(
     engines = ('django',)
 
     def _test_offline(self, engine):
-        count, result = CompressCommand().compress(
+        count, result = CompressCommand().handle_inner(
             log=self.log, verbosity=self.verbosity, engine=engine)
         self.assertEqual(2, count)
         self.assertEqual([
@@ -467,7 +469,7 @@ class OfflineCompressStaticUrlIndependenceTestCase(
     }
 
     def _test_offline(self, engine):
-        count, result = CompressCommand().compress(
+        count, result = CompressCommand().handle_inner(
             log=self.log, verbosity=self.verbosity, engine=engine
         )
         self.assertEqual(1, count)
@@ -550,7 +552,7 @@ class OfflineCompressTestCaseWithContextGeneratorImportError(
             # Valid path to generator function -- no ImportError:
 
             try:
-                CompressCommand().compress(engine=engine)
+                CompressCommand().handle_inner(engine=engine)
             except ImportError:
                 self.fail('Valid path to offline context generator must'
                           ' not raise ImportError.')
@@ -560,21 +562,10 @@ class OfflineCompressTestCaseErrors(OfflineTestCaseMixin, TestCase):
     templates_dir = 'test_error_handling'
 
     def _test_offline(self, engine):
-        count, result = CompressCommand().compress(
+        count, result = CompressCommand().handle_inner(
             log=self.log, verbosity=self.verbosity, engine=engine)
 
-        if engine == 'django':
-            self.assertEqual(2, count)
-        else:
-            # Because we use env.parse in Jinja2Parser, the engine does not
-            # actually load the 'extends' and 'includes' templates, and so
-            # it is unable to detect that they are missing. So all the
-            # 'compress' nodes are processed correctly.
-            self.assertEqual(4, count)
-            self.assertEqual(engine, 'jinja2')
-            self.assertIn(self._render_link('7ff52cb38987'), result)
-            self.assertIn(self._render_link('2db2b4d36380'), result)
-
+        self.assertEqual(2, count)
         self.assertIn(self._render_script('3910ce35946a'), result)
         self.assertIn(self._render_script('244f05154671'), result)
 
@@ -612,7 +603,7 @@ class OfflineCompressEmptyTag(OfflineTestCaseMixin, TestCase):
     engines = ('django',)
 
     def _test_offline(self, engine):
-        count, result = CompressCommand().compress(
+        count, result = CompressCommand().handle_inner(
             log=self.log, verbosity=self.verbosity, engine=engine)
         manifest = get_offline_manifest()
         manifest[list(manifest)[0]] = ''
@@ -651,7 +642,7 @@ class OfflineCompressBlockSuperBaseCompressed(OfflineTestCaseMixin, TestCase):
             return None
 
     def _test_offline(self, engine):
-        count, result = CompressCommand().compress(
+        count, result = CompressCommand().handle_inner(
             log=self.log, verbosity=self.verbosity, engine=engine)
         self.assertEqual(len(self.expected_hash), count)
         for expected_hash, template in zip(self.expected_hash_offline, self.templates):
@@ -671,7 +662,7 @@ class OfflineCompressInlineNonAsciiTestCase(OfflineTestCaseMixin, TestCase):
     }
 
     def _test_offline(self, engine):
-        count, result = CompressCommand().compress(
+        count, result = CompressCommand().handle_inner(
             log=self.log, verbosity=self.verbosity, engine=engine)
         rendered_template = self._render_template(engine)
         self.assertEqual(rendered_template, ''.join(result) + '\n')
@@ -690,7 +681,7 @@ class OfflineCompressComplexTestCase(OfflineTestCaseMixin, TestCase):
     }
 
     def _test_offline(self, engine):
-        count, result = CompressCommand().compress(
+        count, result = CompressCommand().handle_inner(
             log=self.log, verbosity=self.verbosity, engine=engine)
         self.assertEqual(3, count)
         self.assertEqual([
@@ -725,7 +716,7 @@ class OfflineCompressExtendsRecursionTestCase(OfflineTestCaseMixin, TestCase):
 
     @override_settings(INSTALLED_APPS=INSTALLED_APPS)
     def _test_offline(self, engine):
-        count, result = CompressCommand().compress(
+        count, result = CompressCommand().handle_inner(
             log=self.log, verbosity=self.verbosity, engine=engine)
         self.assertEqual(count, 1)
 


### PR DESCRIPTION
Multiple imbricated loops are needs to generate the compressed files and manifest, but the way it's currently done is wasteful in memory when we have multiple contexts.

With a few meticulous changes, it can be drastically improved, in my benchmarks it goes from \~2942Mb to \~174Mb in memory consumption with no impact on the execution time (\~ 3'15"). See the attached mprofile files.

[mprofile.zip](https://github.com/django-compressor/django-compressor/files/1228841/mprofile.zip)


