### PR TITLE
Enhance Sekizai compressor support

### DIFF
--- a/compressor/contrib/sekizai.py
+++ b/compressor/contrib/sekizai.py
@@ -22,14 +22,14 @@ def compress(context, data, name):
     """
     # separate compressable from uncompressable files
     parser = get_class(settings.COMPRESS_PARSER)(data)
-    compressor = Compressor()
+    js_compressor, css_compressor = Compressor('js'), Compressor('css')
     compressable_elements, expanded_elements, deferred_elements = [], [], []
     if name == 'js':
         for elem in parser.js_elems():
             attribs = parser.elem_attribs(elem)
             try:
                 if 'src' in attribs:
-                    compressor.get_basename(attribs['src'])
+                    js_compressor.get_basename(attribs['src'])
             except UncompressableFileError:
                 if 'defer' in attribs:
                     deferred_elements.append(elem)
@@ -42,7 +42,7 @@ def compress(context, data, name):
             attribs = parser.elem_attribs(elem)
             try:
                 if parser.elem_name(elem) == 'link' and attribs['rel'].lower() == 'stylesheet':
-                    compressor.get_basename(attribs['href'])
+                    css_compressor.get_basename(attribs['href'])
             except UncompressableFileError:
                 expanded_elements.append(elem)
             else:

--- a/compressor/contrib/sekizai.py
+++ b/compressor/contrib/sekizai.py
@@ -6,6 +6,11 @@
  and: https://github.com/ojii/django-sekizai.git@0.6 or later
 """
 from compressor.templatetags.compress import CompressorNode
+from compressor.exceptions import UncompressableFileError
+from compressor.base import Compressor
+from compressor.conf import settings
+from compressor.utils import get_class
+
 from django.template.base import TextNode
 
 
@@ -15,4 +20,44 @@ def compress(context, data, name):
     Name is either 'js' or 'css' (the sekizai namespace)
     Basically passes the string through the {% compress 'js' %} template tag
     """
-    return CompressorNode(nodelist=TextNode(data), kind=name, mode='file').render(context=context)
+    # separate compressable from uncompressable files
+    parser = get_class(settings.COMPRESS_PARSER)(data)
+    compressor = Compressor()
+    compressable_elements, expanded_elements, deferred_elements = [], [], []
+    if name == 'js':
+        for elem in parser.js_elems():
+            attribs = parser.elem_attribs(elem)
+            try:
+                if 'src' in attribs:
+                    compressor.get_basename(attribs['src'])
+            except UncompressableFileError:
+                if 'defer' in attribs:
+                    deferred_elements.append(elem)
+                else:
+                    expanded_elements.append(elem)
+            else:
+                compressable_elements.append(elem)
+    elif name == 'css':
+        for elem in parser.css_elems():
+            attribs = parser.elem_attribs(elem)
+            try:
+                if parser.elem_name(elem) == 'link' and attribs['rel'].lower() == 'stylesheet':
+                    compressor.get_basename(attribs['href'])
+            except UncompressableFileError:
+                expanded_elements.append(elem)
+            else:
+                compressable_elements.append(elem)
+
+    # reconcatenate them
+    data = ''.join(parser.elem_str(e) for e in expanded_elements)
+    expanded_node = CompressorNode(nodelist=TextNode(data), kind=name, mode='file')
+    data = ''.join(parser.elem_str(e) for e in compressable_elements)
+    compressable_node = CompressorNode(nodelist=TextNode(data), kind=name, mode='file')
+    data = ''.join(parser.elem_str(e) for e in deferred_elements)
+    deferred_node = CompressorNode(nodelist=TextNode(data), kind=name, mode='file')
+
+    return '\n'.join([
+        expanded_node.get_original_content(context=context),
+        compressable_node.render(context=context),
+        deferred_node.get_original_content(context=context),
+    ])

--- a/compressor/tests/test_sekizai.py
+++ b/compressor/tests/test_sekizai.py
@@ -24,7 +24,7 @@ class TestSekizaiCompressorExtension(TestCase):
         html = template.render(context).strip()
         self.assertEqual(html,
 '''<script src="https://code.jquery.com/jquery-3.3.1.min.js" type="text/javascript"></script>
-<script type="text/javascript" src="/static/CACHE/js/cb5ca6a608a4.js"></script>
+<script type="text/javascript" src="/static/CACHE/js/output.cb5ca6a608a4.js"></script>
 <script async="async" defer="defer" src="https://maps.googleapis.com/maps/api/js?key=XYZ"></script>''')
 
     def test_postprocess_css(self):
@@ -39,4 +39,4 @@ class TestSekizaiCompressorExtension(TestCase):
         html = template.render(context).strip()
         self.assertEqual(html,
 '''<link href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.5/css/select2.min.css" rel="stylesheet" type="text/css" />
-<link rel="stylesheet" href="/static/CACHE/css/20f9b535162f.css" type="text/css" />''')
+<link rel="stylesheet" href="/static/CACHE/css/output.20f9b535162f.css" type="text/css" />''')

--- a/compressor/tests/test_sekizai.py
+++ b/compressor/tests/test_sekizai.py
@@ -1,18 +1,42 @@
 # -*- coding: utf-8 -*-
 from __future__ import with_statement, unicode_literals
 
+from django.template import Template
 from django.test import TestCase
-from django.test.utils import override_settings
-
-from compressor.conf import settings
-from compressor.tests.test_base import css_tag
+from sekizai.context import SekizaiContext
 
 
 class TestSekizaiCompressorExtension(TestCase):
     """
-    Test case for Sekizai extension. Pilvered from test_jinja2.
-    WORK in PROGRESS
+    Test case for Sekizai extension.
     """
-    def assertStrippedEqual(self, result, expected):
-        self.assertEqual(result.strip(), expected.strip(), "%r != %r" % (
-            result.strip(), expected.strip()))
+    def test_postprocess_js(self):
+        template_string = '''
+{% load static compress sekizai_tags %}
+{% addtoblock "js" %}<script src="{% static 'js/one.js' %}" type="text/javascript"></script>{% endaddtoblock %}
+{% addtoblock "js" %}<script async="async" defer="defer" src="https://maps.googleapis.com/maps/api/js?key={{ apiKey }}"></script>{% endaddtoblock %}
+{% addtoblock "js" %}<script src="{% static 'js/two.js' %}" type="text/javascript"></script>{% endaddtoblock %}
+{% addtoblock "js" %}<script src="https://code.jquery.com/jquery-3.3.1.min.js" type="text/javascript"></script>{% endaddtoblock %}
+{% addtoblock "js" %}<script src="{% static 'js/three.js' %}" type="text/javascript"></script>{% endaddtoblock %}
+{% render_block "js" postprocessor "compressor.contrib.sekizai.compress" %}'''
+        template = Template(template_string)
+        context = SekizaiContext({'apiKey': 'XYZ'})
+        html = template.render(context).strip()
+        self.assertEqual(html,
+'''<script src="https://code.jquery.com/jquery-3.3.1.min.js" type="text/javascript"></script>
+<script type="text/javascript" src="/static/CACHE/js/cb5ca6a608a4.js"></script>
+<script async="async" defer="defer" src="https://maps.googleapis.com/maps/api/js?key=XYZ"></script>''')
+
+    def test_postprocess_css(self):
+        template_string = '''
+{% load static compress sekizai_tags %}
+{% addtoblock "css" %}<link href="{% static 'css/one.css' %}" rel="stylesheet" type="text/css" />{% endaddtoblock %}
+{% addtoblock "css" %}<link href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.5/css/select2.min.css" rel="stylesheet" type="text/css" />{% endaddtoblock %}
+{% addtoblock "css" %}<link href="{% static 'css/two.css' %}" rel="stylesheet" type="text/css" />{% endaddtoblock %}
+{% render_block "css" postprocessor "compressor.contrib.sekizai.compress" %}'''
+        template = Template(template_string)
+        context = SekizaiContext()
+        html = template.render(context).strip()
+        self.assertEqual(html,
+'''<link href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.5/css/select2.min.css" rel="stylesheet" type="text/css" />
+<link rel="stylesheet" href="/static/CACHE/css/20f9b535162f.css" type="text/css" />''')

--- a/compressor/tests/test_sekizai.py
+++ b/compressor/tests/test_sekizai.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import with_statement, unicode_literals
+
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from compressor.conf import settings
+from compressor.tests.test_base import css_tag
+
+
+class TestSekizaiCompressorExtension(TestCase):
+    """
+    Test case for Sekizai extension. Pilvered from test_jinja2.
+    WORK in PROGRESS
+    """
+    def assertStrippedEqual(self, result, expected):
+        self.assertEqual(result.strip(), expected.strip(), "%r != %r" % (
+            result.strip(), expected.strip()))

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+v2.2.x (develop)
+----------------
+
+- Allow the mixed use of JS/CSS in Sekizai's templatetags `{% addtoblock "js" %}` and `{% addtoblock "css" %}`.
+
+
 v2.2 (2017-08-16)
 -------------------
 

--- a/docs/django-sekizai.txt
+++ b/docs/django-sekizai.txt
@@ -34,7 +34,7 @@ use any of these directives to import Stylesheets and JavaScript files:
     {% addtoblock "js" %}<script async="async" defer="defer" src="https://maps.googleapis.com/maps/api/js?key={{ config.apiKey }}&callback=initMap"></script>{% endaddtoblock %}
 
 Note that some files are loaded by the browser directly from a CDN and thus can not be compressed
-by django-compressor. Therefore the Sekizai compressor checks whether is a file is compressable, and
+by django-compressor. Therefore the Sekizai compressor checks whether a file is compressable, and
 only if so, concatenates its payload.
 
 .. code-block:: django

--- a/docs/django-sekizai.txt
+++ b/docs/django-sekizai.txt
@@ -14,11 +14,47 @@ for how to use ``render_block``
 Usage
 -----
 
+In templates which either extend base templates or are included by other templates,
+use any of these directives to import Stylesheets and JavaScript files:
+
+
+.. code-block:: django
+
+    {% load static sekizai_tags %}
+
+    {% addtoblock "css" %}<link href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.5/css/select2.min.css" rel="stylesheet" />{% endaddtoblock %}
+    {% addtoblock "css" %}<link href="{% static 'app/css/mystyle.css' %}" rel="stylesheet" type="text/css" />{% endaddtoblock %}
+
+    {% addtoblock "js" %}<script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.5/js/select2.min.js"></script>{% endaddtoblock %}
+    {% addtoblock "js" %}<script src="{% static 'js/js/myapp.js' %}" type="text/javascript"></script>{% endaddtoblock %}
+    {% addtoblock "js" %}<script async="async" defer="defer" src="https://maps.googleapis.com/maps/api/js?key={{ config.apiKey }}&callback=initMap"></script>{% endaddtoblock %}
+
+Note that some files are loaded by the browser directly from a CDN and thus can not be compressed
+by django-compressor. Therefore the Sekizai compressor checks whether is a file is compressable, and
+only if so, concatenates its payload.
+
 .. code-block:: django
 
     {% load sekizai_tags %}
-    {% render_block "<js/css>" postprocessor "compressor.contrib.sekizai.compress" %}
 
+    <html>
+      <head>
+      ...
+      {% render_block "css" postprocessor "compressor.contrib.sekizai.compress" %}
+      </head>
+
+      <body>
+      ...
+      {% render_block "js" postprocessor "compressor.contrib.sekizai.compress" %}
+      </body>
+    </html>
+
+In the above example, we render StyleSheets inside the ``<head>`` element and JavaScript files
+just before closing the ``</body>`` tag.
+
+Here, we first render some references to CSS and JavaScript files, served from external
+sources. Afterwards all local files are concatenated and optionally minified. In the last
+step all references to deferred files are rendered.
 
 .. _django-sekizai: https://github.com/ojii/django-sekizai
 .. _django-sekizai docs: https://django-sekizai.readthedocs.io/en/latest/


### PR DESCRIPTION
**django-compressor**'s Sekizai plugin, currently is not able to handle files from external sources such as CDNs. Therefore one would have to use another prefix, say ``{% addtoblock "ext-css" %}`` and ``{% addtoblock "ext-js" %}`` when adding these references. This however causes inconsistencies and other issues.

I therefore enhanced the Sekizai processor, so that it only concatenates files available locally. External sources are just served using a reference.