### PR TITLE
Added mako template support in contrib

### DIFF
--- a/compressor/contrib/mako.py
+++ b/compressor/contrib/mako.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from mako.runtime import supports_caller
+from compressor.templatetags.compress import compress as compressor
+
+
+class NodeMock(object):
+    def __init__(self, content, *args, **kwargs):
+        self.content = content
+
+    def render(self, *args, **kwargs):
+        return self.content
+
+
+class ParserMock(object):
+    def __init__(self, body, *args, **kwargs):
+        self.body = body
+
+    def parse(self, *args, **kwargs):
+        return NodeMock(self.body)
+
+    def delete_first_token(self, *args, **kwargs):
+        pass
+
+
+class TokenMock(object):
+    def __init__(self, *args, **kwargs):
+        self.args = args
+
+    def split_contents(self, *args, **kwargs):
+        return self.args
+
+
+@supports_caller
+def compress(context, **kwargs):
+    try:
+        # Those arguments are mandatory to parse template fragment
+        # and should be provided by mako
+        capture = context['capture']
+        caller = context['caller']
+    except KeyError:
+        return ''
+
+    parser = ParserMock(capture(caller.body))
+
+    # `kind` is mandatory for django-compressor. but `kwargs.get` will return
+    # None if not provided, so `django-compressor` can handle the error
+    args = ['compress', kwargs.get('kind')]
+
+    if 'mode' in kwargs:
+        args.append(kwargs['mode'])
+        if 'name' in kwargs:
+            args.append(kwargs['name'])
+
+    token = TokenMock(*args)
+    return compressor(parser, token).render({})
+
+
+@supports_caller
+def css(context, **kwargs):
+    kwargs['kind'] = 'css'
+    return compress(context, **kwargs)
+
+
+@supports_caller
+def js(context, **kwargs):
+    kwargs['kind'] = 'js'
+    return compress(context, **kwargs)

--- a/docs/mako.txt
+++ b/docs/mako.txt
@@ -1,0 +1,47 @@
+.. _mako_template_support:
+
+Mako Template Support
+=====================
+
+Django Compressor comes with `mako template`_ support via an extension.
+
+Usage
+=====
+
+All you need to do is to import extension namespace and using it with mako
+syntax:
+
+.. code-block:: mako
+
+    <%namespace name="compress" module="compressor.contrib.mako"/>
+
+    <%compress:compress kind="css">
+    <link rel="stylesheet" href="/static/css/style.css" type="text/css" />
+    </%compress:compress>
+
+All django-compressor arguments are supported but must be explicitly named:
+
+* ``kind``: mandatory, "css" or "js".
+* ``mode``: optional, compressor mode, "file" or "inline".
+* ``name``: optional but requires ``mode``, output file name.
+
+Shorter functions
+=================
+
+Additionally two shorter functions are provided, ``css`` and ``js``, same
+arguments can be passed except ``kind`` which is set by default depending on
+which one is used, eg.:
+
+.. code-block:: mako
+
+    <%namespace name="compress" module="compressor.contrib.mako"/>
+
+    <%compress:css>
+    <link rel="stylesheet" href="/static/css/style.css" type="text/css" />
+    </%compress:css>
+
+    <%compress:js>
+    <script type="text/javascript" src="/static/js/script.js">
+    </%compress:js>
+
+.. _mako template: http://www.makotemplates.org/


### PR DESCRIPTION
## Usage

All you need to do is to import extension namespace and using it with mako syntax:

```mako
<%namespace name="compressor" module="compressor.contrib.mako"/>

<%compressor:compress kind="css">
<link rel="stylesheet" href="/static/css/style.css" type="text/css" />
</%compressor:compress>
```

All django-compressor arguments are supported but must be explicitly named:

* ``kind``: mandatory, "css" or "js".
* ``mode``: optional, compressor mode, "file" or "inline".
* ``name``: optional but requires ``mode``, output file name.
