### PR TITLE
adding a setting to choose the hashlib

### DIFF
--- a/compressor/cache.py
+++ b/compressor/cache.py
@@ -19,7 +19,9 @@ _cachekey_func = None
 
 
 def get_hexdigest(plaintext, length=None):
-    digest = hashlib.sha256(smart_bytes(plaintext)).hexdigest()
+    hashlib_function_name = getattr(settings, 'COMPRESS_CACHE_HASHLIB_FUNCTION', 'sha256')
+    hashlib_function = getattr(hashlib, hashlib_function_name)
+    digest = hashlib_function(smart_bytes(plaintext)).hexdigest()
     if length:
         return digest[:length]
     return digest

--- a/compressor/tests/test_base.py
+++ b/compressor/tests/test_base.py
@@ -390,6 +390,17 @@ class CacheTestCase(SimpleTestCase):
         except TypeError:
             self.fail("get_precompiler_cachekey raised TypeError unexpectedly")
 
+    def test_get_hexdigest_default(self):
+        css_filename = os.path.join(settings.COMPRESS_ROOT, "css", "one.css")
+        with open(css_filename, 'rb') as fh:
+            self.assertEqual(get_hexdigest(fh.read(), 12), '64f74be417da')
+
+    @override_settings(COMPRESS_CACHE_HASHLIB_FUNCTION='md5')
+    def test_get_hexdigest_md5(self):
+        css_filename = os.path.join(settings.COMPRESS_ROOT, "css", "one.css")
+        with open(css_filename, 'rb') as fh:
+            self.assertEqual(get_hexdigest(fh.read(), 12), 'cdd1a7452e1d')
+
 
 class CompressorInDebugModeTestCase(SimpleTestCase):
 

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -393,6 +393,12 @@ Caching settings
     The cache to use by Django Compressor. Must be a cache alias specified in
     your ``CACHES`` setting.
 
+.. attribute:: COMPRESS_CACHE_HASHLIB_FUNCTION
+
+    :Default: ``"sha256"``
+
+    The name of the hashlib function to use by Django Compressor. 
+
 .. attribute:: COMPRESS_REBUILD_TIMEOUT
 
     :Default: ``2592000`` (30 days in seconds)


### PR DESCRIPTION
Here at ORM, we have a custom compressor filter to find the names of files created when collectstatic is run. Our filter uses the get_hashed_content function, which consequently broke when 
Django-compressor changed from md5, which Django's ManifestStaticFilesStorage uses, to sha256.
We would love if Django-compressor allowed the user to choose which hashlib function to use.