### PR TITLE
Fix bug in offline compression for Django template engine

### DIFF
--- a/compressor/offline/django.py
+++ b/compressor/offline/django.py
@@ -132,7 +132,9 @@ class DjangoParser(object):
         nodelist = []
         if isinstance(node, Node):
             for attr in node.child_nodelists:
-                nodelist += getattr(node, attr, [])
+                # see https://github.com/django-compressor/django-compressor/pull/825
+                # and linked issues/PRs for a discussion on the `None) or []` part
+                nodelist += getattr(node, attr, None) or []
         else:
             nodelist = getattr(node, 'nodelist', [])
         return nodelist


### PR DESCRIPTION
If a Node had an attribute set to None present in child_nodelist, nodelist collection would fail. The change here is simply coding a bit more defensively.

This fixes #605 (which is closed, but not fixed). Related to https://github.com/jazzband/sorl-thumbnail/issues/470.