### PR TITLE
Updated jinja2 extension to behave similar to the django tag

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,9 +22,9 @@ Atamert Ölçgen
 Aymeric Augustin
 Bartek Ciszkowski
 Ben Firshman
-Ben Spaulding
 Benjamin Gilbert
 Benjamin Wohlwend
+Ben Spaulding
 Bojan Mihelac
 Boris Shemigon
 Brad Whittington
@@ -65,8 +65,8 @@ Maciek Szczesniak
 Maor Ben-Dayan
 Mark Lavin
 Marsel Mavletkulov
-Matt Schick
 Matthew Tretter
+Matt Schick
 Mehmet S. Catalbas
 Michael van de Waeter
 Mike Yumatov
@@ -80,14 +80,15 @@ Peter Lundberg
 Philipp Bosch
 Philipp Wollermann
 Rich Leland
+Rick van Hattem (wolph)
 Sam Dornan
 Saul Shanabrook
+Sébastien Piquemal
 Selwin Ong
 Shabda Raaj
 Stefano Brentegani
-Sébastien Piquemal
-Thom Linton
 Thomas Schreiber
+Thom Linton
 Tino de Bruijn
 Ulrich Petri
 Ulysses V

--- a/compressor/contrib/jinja2ext.py
+++ b/compressor/contrib/jinja2ext.py
@@ -2,54 +2,85 @@ from jinja2 import nodes
 from jinja2.ext import Extension
 from jinja2.exceptions import TemplateSyntaxError
 
-from compressor.templatetags.compress import OUTPUT_FILE, CompressorMixin
+from compressor.templatetags import compress
 
 
-class CompressorExtension(CompressorMixin, Extension):
+# Allow django like definitions which assume constants instead of variables
+def const(node):
+    if isinstance(node, nodes.Name):
+        return nodes.Const(node.name)
+    else:
+        return node
+
+
+class CompressorExtension(compress.CompressorMixin, Extension):
 
     tags = set(['compress'])
 
     def parse(self, parser):
-        lineno = next(parser.stream).lineno
-        kindarg = parser.parse_expression()
-        # Allow kind to be defined as jinja2 name node
-        if isinstance(kindarg, nodes.Name):
-            kindarg = nodes.Const(kindarg.name)
-        args = [kindarg]
-        if args[0].value not in self.compressors:
-            raise TemplateSyntaxError('compress kind may be one of: %s' %
-                                      (', '.join(self.compressors.keys())),
-                                      lineno)
-        if parser.stream.skip_if('comma'):
-            modearg = parser.parse_expression()
-            # Allow mode to be defined as jinja2 name node
-            if isinstance(modearg, nodes.Name):
-                modearg = nodes.Const(modearg.name)
-                args.append(modearg)
-        else:
-            args.append(nodes.Const('file'))
+        # Store the first lineno for the actual function call
+        lineno = parser.stream.current.lineno
+        next(parser.stream)
+        args = []
 
+        kindarg = const(parser.parse_expression())
+
+        if kindarg.value in self.compressors:
+            args.append(kindarg)
+        else:
+            raise TemplateSyntaxError(
+                'Compress kind may be one of: %r, got: %r' % (
+                    self.compressors.keys(), kindarg.value),
+                parser.stream.current.lineno)
+
+        # For legacy support, allow for a commma but simply ignore it
+        parser.stream.skip_if('comma')
+
+        # Some sane defaults for file output
+        namearg = nodes.Const(None)
+        modearg = nodes.Const('file')
+
+        # If we're not at the "%}" part yet we must have a output mode argument
+        if parser.stream.current.type != 'block_end':
+            modearg = const(parser.parse_expression())
+            args.append(modearg)
+
+            if modearg.value == compress.OUTPUT_FILE:
+                # The file mode optionally accepts a name
+                if parser.stream.current.type != 'block_end':
+                    namearg = const(parser.parse_expression())
+            elif modearg.value == compress.OUTPUT_INLINE:
+                pass
+            else:
+                raise TemplateSyntaxError(
+                    'Compress mode may be one of: %r, got %r' % (
+                        compress.OUTPUT_MODES, modearg.value),
+                    parser.stream.current.lineno)
+
+        # Parse everything between the compress and endcompress tags
         body = parser.parse_statements(['name:endcompress'], drop_needle=True)
 
         # Skip the kind if used in the endblock, by using the kind in the
         # endblock the templates are slightly more readable.
         parser.stream.skip_if('name:' + kindarg.value)
-        return nodes.CallBlock(self.call_method('_compress_normal', args), [], [],
-            body).set_lineno(lineno)
 
-    def _compress_forced(self, kind, mode, caller):
-        return self._compress(kind, mode, caller, True)
+        return nodes.CallBlock(
+            self.call_method('_compress_normal', [kindarg, modearg, namearg]),
+            [], [], body).set_lineno(lineno)
 
-    def _compress_normal(self, kind, mode, caller):
-        return self._compress(kind, mode, caller, False)
+    def _compress_forced(self, kind, mode, name, caller):
+        return self._compress(kind, mode, name, caller, True)
 
-    def _compress(self, kind, mode, caller, forced):
-        mode = mode or OUTPUT_FILE
+    def _compress_normal(self, kind, mode, name, caller):
+        return self._compress(kind, mode, name, caller, False)
+
+    def _compress(self, kind, mode, name, caller, forced):
+        mode = mode or compress.OUTPUT_FILE
         original_content = caller()
         context = {
             'original_content': original_content
         }
-        return self.render_compressed(context, kind, mode, forced=forced)
+        return self.render_compressed(context, kind, mode, name, forced=forced)
 
     def get_original_content(self, context):
         return context['original_content']

--- a/compressor/templatetags/compress.py
+++ b/compressor/templatetags/compress.py
@@ -88,7 +88,7 @@ class CompressorMixin(object):
         cache_content = cache_get(cache_key)
         return cache_key, cache_content
 
-    def render_compressed(self, context, kind, mode, forced=False):
+    def render_compressed(self, context, kind, mode, name=None, forced=False):
 
         # See if it has been rendered offline
         if self.is_offline_compression_enabled(forced) and not forced:
@@ -99,7 +99,7 @@ class CompressorMixin(object):
                 not settings.COMPRESS_PRECOMPILERS and not forced):
             return self.get_original_content(context)
 
-        context['compressed'] = {'name': getattr(self, 'name', None)}
+        context['compressed'] = {'name': getattr(self, 'name', name)}
         compressor = self.get_compressor(context, kind)
 
         # Check cache

--- a/compressor/templatetags/compress.py
+++ b/compressor/templatetags/compress.py
@@ -99,7 +99,8 @@ class CompressorMixin(object):
                 not settings.COMPRESS_PRECOMPILERS and not forced):
             return self.get_original_content(context)
 
-        context['compressed'] = {'name': getattr(self, 'name', name)}
+        name = name or getattr(self, 'name', None)
+        context['compressed'] = {'name': name}
         compressor = self.get_compressor(context, kind)
 
         # Check cache
@@ -109,7 +110,7 @@ class CompressorMixin(object):
             if cache_content is not None:
                 return cache_content
 
-        file_basename = getattr(self, 'name', None) or getattr(self, 'basename', None)
+        file_basename = name or getattr(self, 'basename', None)
         if file_basename is None:
             file_basename = 'output'
 

--- a/compressor/tests/test_offline.py
+++ b/compressor/tests/test_offline.py
@@ -331,9 +331,6 @@ class OfflineCompressBasicTestCase(OfflineTestCaseMixin, TestCase):
 class OfflineCompressSkipDuplicatesTestCase(OfflineTestCaseMixin, TestCase):
     templates_dir = 'test_duplicate'
 
-    # We don't need to test multiples engines here.
-    engines = ('django',)
-
     def _test_offline(self, engine):
         count, result = CompressCommand().handle_inner(engines=[engine], verbosity=0)
         # Only one block compressed, the second identical one was skipped.
@@ -346,27 +343,27 @@ class OfflineCompressSkipDuplicatesTestCase(OfflineTestCaseMixin, TestCase):
             rendered_template, self._render_result(result * 2, ''))
 
 
-class OfflineCompressBlockSuperTestCase(OfflineTestCaseMixin, TestCase):
-    templates_dir = 'test_block_super'
-    expected_hash = '68c645740177'
+class SuperMixin:
     # Block.super not supported for Jinja2 yet.
     engines = ('django',)
+
+
+class OfflineCompressBlockSuperTestCase(
+        SuperMixin, OfflineTestCaseMixin, TestCase):
+    templates_dir = 'test_block_super'
+    expected_hash = '68c645740177'
 
 
 class OfflineCompressBlockSuperMultipleTestCase(
-        OfflineTestCaseMixin, TestCase):
+        SuperMixin, OfflineTestCaseMixin, TestCase):
     templates_dir = 'test_block_super_multiple'
     expected_hash = 'f87403f4d8af'
-    # Block.super not supported for Jinja2 yet.
-    engines = ('django',)
 
 
 class OfflineCompressBlockSuperMultipleCachedLoaderTestCase(
-        OfflineTestCaseMixin, TestCase):
+        SuperMixin, OfflineTestCaseMixin, TestCase):
     templates_dir = 'test_block_super_multiple_cached'
     expected_hash = 'ea860151aa21'
-    # Block.super not supported for Jinja2 yet.
-    engines = ('django',)
     additional_test_settings = {
         'TEMPLATE_LOADERS': (
             ('django.template.loaders.cached.Loader', (
@@ -378,10 +375,8 @@ class OfflineCompressBlockSuperMultipleCachedLoaderTestCase(
 
 
 class OfflineCompressBlockSuperTestCaseWithExtraContent(
-        OfflineTestCaseMixin, TestCase):
+        SuperMixin, OfflineTestCaseMixin, TestCase):
     templates_dir = 'test_block_super_extra'
-    # Block.super not supported for Jinja2 yet.
-    engines = ('django',)
 
     def _test_offline(self, engine):
         count, result = CompressCommand().handle_inner(engines=[engine], verbosity=0)
@@ -418,8 +413,6 @@ class OfflineCompressTemplateTagNamedTestCase(OfflineTestCaseMixin, TestCase):
     templates_dir = 'test_templatetag_named'
     expected_basename = 'output_name'
     expected_hash = 'a432b6ddb2c4'
-    # block naming unsupported in jinga2
-    engines = ('django',)
 
 
 class OfflineCompressTestCaseWithContext(OfflineTestCaseMixin, TestCase):
@@ -432,7 +425,8 @@ class OfflineCompressTestCaseWithContext(OfflineTestCaseMixin, TestCase):
     }
 
 
-class OfflineCompressTestCaseWithContextSuper(OfflineTestCaseMixin, TestCase):
+class OfflineCompressTestCaseWithContextSuper(
+        SuperMixin, OfflineTestCaseMixin, TestCase):
     templates_dir = 'test_with_context_super'
     expected_hash = '9a8b47adfe17'
     additional_test_settings = {
@@ -440,8 +434,6 @@ class OfflineCompressTestCaseWithContextSuper(OfflineTestCaseMixin, TestCase):
             'content': 'OK!',
         }
     }
-    # Block.super not supported for Jinja2 yet.
-    engines = ('django',)
 
 
 class OfflineCompressTestCaseWithContextList(OfflineTestCaseMixin, TestCase):
@@ -460,14 +452,12 @@ class OfflineCompressTestCaseWithContextList(OfflineTestCaseMixin, TestCase):
 
 
 class OfflineCompressTestCaseWithContextListSuper(
-        OfflineCompressTestCaseWithContextList):
+        SuperMixin, OfflineCompressTestCaseWithContextList):
     templates_dir = 'test_with_context_super'
     expected_hash = ['dc68dd60aed4', 'c2e50f475853', '045b48455bee']
     additional_test_settings = {
         'COMPRESS_OFFLINE_CONTEXT': list(offline_context_generator())
     }
-    # Block.super not supported for Jinja2 yet.
-    engines = ('django',)
 
 
 class OfflineCompressTestCaseWithContextGenerator(
@@ -490,15 +480,13 @@ class OfflineCompressTestCaseWithContextGenerator(
 
 
 class OfflineCompressTestCaseWithContextGeneratorSuper(
-        OfflineCompressTestCaseWithContextGenerator):
+        SuperMixin, OfflineCompressTestCaseWithContextGenerator):
     templates_dir = 'test_with_context_super'
     expected_hash = ['dc68dd60aed4', 'c2e50f475853', '045b48455bee']
     additional_test_settings = {
         'COMPRESS_OFFLINE_CONTEXT': 'compressor.tests.test_offline.'
                                     'offline_context_generator'
     }
-    # Block.super not supported for Jinja2 yet.
-    engines = ('django',)
 
 
 class OfflineCompressStaticUrlIndependenceTestCase(
@@ -549,7 +537,7 @@ class OfflineCompressTestCaseWithContextVariableInheritance(
 
 
 class OfflineCompressTestCaseWithContextVariableInheritanceSuper(
-        OfflineTestCaseMixin, TestCase):
+        SuperMixin, OfflineTestCaseMixin, TestCase):
     templates_dir = 'test_with_context_variable_inheritance_super'
     additional_test_settings = {
         'COMPRESS_OFFLINE_CONTEXT': [{
@@ -559,8 +547,6 @@ class OfflineCompressTestCaseWithContextVariableInheritanceSuper(
         }]
     }
     expected_hash = ['6a2f85c623c6', '04b482ba2855']
-    # Block.super not supported for Jinja2 yet.
-    engines = ('django',)
 
 
 class OfflineCompressTestCaseWithContextGeneratorImportError(
@@ -658,7 +644,6 @@ class OfflineCompressEmptyTag(OfflineTestCaseMixin, TestCase):
     """
     templates_dir = 'basic'
     expected_hash = 'a432b6ddb2c4'
-    engines = ('django',)
 
     def _test_offline(self, engine):
         CompressCommand().handle_inner(engines=[engine], verbosity=0)
@@ -758,7 +743,6 @@ class OfflineCompressExtendsRecursionTestCase(OfflineTestCaseMixin, TestCase):
     (e.g. admin/index.html) don't cause an infinite test_extends_recursion
     """
     templates_dir = 'test_extends_recursion'
-    engines = ('django',)
 
     INSTALLED_APPS = [
         'django.contrib.admin',

--- a/compressor/tests/test_templates_jinja2/test_duplicate/test_compressor_offline.html
+++ b/compressor/tests/test_templates_jinja2/test_duplicate/test_compressor_offline.html
@@ -1,0 +1,13 @@
+{% spaceless %}
+
+{% compress js %}
+    <script type="text/javascript">
+        alert("Basic test");
+    </script>
+{% endcompress %}
+{% compress js %}
+    <script type="text/javascript">
+        alert("Basic test");
+    </script>
+{% endcompress %}
+{% endspaceless %}

--- a/compressor/tests/test_templates_jinja2/test_extends_recursion/admin/index.html
+++ b/compressor/tests/test_templates_jinja2/test_extends_recursion/admin/index.html
@@ -1,0 +1,1 @@
+{% extends "admin/index.html" %}

--- a/compressor/tests/test_templates_jinja2/test_extends_recursion/test_compressor_offline.html
+++ b/compressor/tests/test_templates_jinja2/test_extends_recursion/test_compressor_offline.html
@@ -1,0 +1,3 @@
+{% compress js%}
+    <script type="text/javascript">alert('test');</script>
+{% endcompress %}

--- a/compressor/tests/test_templates_jinja2/test_templatetag/test_compressor_offline.html
+++ b/compressor/tests/test_templates_jinja2/test_templatetag/test_compressor_offline.html
@@ -1,7 +1,9 @@
 {% spaceless %}
 
-{% compress js %}
+{% compress 'js' file %}
     <script type="text/javascript">
         alert("{{ "testtemplateTAG"|lower }}");
     </script>
-{% endcompress %}{% endspaceless %}
+{% endcompress %}
+
+{% endspaceless %}

--- a/compressor/tests/test_templates_jinja2/test_templatetag_named/test_compressor_offline.html
+++ b/compressor/tests/test_templates_jinja2/test_templatetag_named/test_compressor_offline.html
@@ -1,0 +1,7 @@
+{% spaceless %}
+
+{% compress js file output_name %}
+    <script type="text/javascript">
+        alert("Basic test");
+    </script>
+{% endcompress %}{% endspaceless %}


### PR DESCRIPTION
There were several inconsistencies between the Django and the Jinja2 tags which made the docs unclear:

1. The jinja2 command required a comma between the kind and mode arguments. This change omits the need (but still supports) the comma.
2. The previous command didn't support a filename, this adds optional support for that