### PR TITLE
Abstract away resource types to allow the implementation of new types.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,6 +14,7 @@ Adam "Cezar" Jenkins
 Adrian Holovaty
 Alen Mujezinovic
 Alex Kessinger
+Alexander van Ratingen
 Andreas Pelme
 Antti Hirvonen
 Apostolos Bessas

--- a/compressor/conf.py
+++ b/compressor/conf.py
@@ -32,7 +32,7 @@ class CompressorConf(AppConf):
     URL = None
     ROOT = None
 
-    # These are resolved in configure()
+    # Filters are resolved in configure()
     FILTERS = {}
     CSS_FILTERS = None
     JS_FILTERS = None

--- a/compressor/conf.py
+++ b/compressor/conf.py
@@ -146,7 +146,7 @@ class CompressorConf(AppConf):
         data = self.configured_data
         for kind in {'css', 'js'}:
             setting_name = '%s_FILTERS' % kind.upper()
-            filters = data[setting_name]
+            filters = data.pop(setting_name)
             if filters is not None:
                 # filters for this kind are set using <kind>_FILTERS
                 if kind in data['FILTERS']:
@@ -161,10 +161,7 @@ class CompressorConf(AppConf):
                             main_setting=self._meta.prefixed_name('FILTERS'),
                             kind=kind))
                 data['FILTERS'][kind] = filters
-            elif kind in data['FILTERS']:
-                # filters for this kind are set using FILTERS[<kind>]
-                data[setting_name] = data['FILTERS'][kind]
-            else:
+            elif kind not in data['FILTERS']:
                 # filters are not defined
-                data['FILTERS'][kind] = data[setting_name] = default_filters[kind]
+                data['FILTERS'][kind] = default_filters[kind]
         return data

--- a/compressor/conf.py
+++ b/compressor/conf.py
@@ -7,6 +7,11 @@ from django.template.utils import InvalidTemplateEngineError
 from appconf import AppConf
 
 
+default_filters = dict(
+    css=['compressor.filters.css_default.CssAbsoluteFilter'],
+    js=['compressor.filters.jsmin.JSMinFilter'])
+
+
 class CompressorConf(AppConf):
     # Main switch
     ENABLED = not settings.DEBUG
@@ -19,16 +24,21 @@ class CompressorConf(AppConf):
     OUTPUT_DIR = 'CACHE'
     STORAGE = 'compressor.storage.CompressorFileStorage'
 
-    CSS_COMPRESSOR = 'compressor.css.CssCompressor'
-    JS_COMPRESSOR = 'compressor.js.JsCompressor'
+    COMPRESSORS = dict(
+        css='compressor.css.CssCompressor',
+        js='compressor.js.JsCompressor',
+    )
 
     URL = None
     ROOT = None
 
-    CSS_FILTERS = ['compressor.filters.css_default.CssAbsoluteFilter']
+    # These are resolved in configure()
+    FILTERS = {}
+    CSS_FILTERS = None
+    JS_FILTERS = None
+
     CSS_HASHING_METHOD = 'mtime'
 
-    JS_FILTERS = ['compressor.filters.jsmin.JSMinFilter']
     PRECOMPILERS = (
         # ('text/coffeescript', 'coffee --compile --stdio'),
         # ('text/less', 'lessc {infile} {outfile}'),
@@ -131,3 +141,30 @@ class CompressorConf(AppConf):
                                        "must be a list or tuple. Check for "
                                        "missing commas.")
         return value
+
+    def configure(self):
+        data = self.configured_data
+        for kind in {'css', 'js'}:
+            setting_name = '%s_FILTERS' % kind.upper()
+            filters = data[setting_name]
+            if filters is not None:
+                # filters for this kind are set using <kind>_FILTERS
+                if kind in data['FILTERS']:
+                    raise ImproperlyConfigured(
+                        "The setting {kind_setting} "
+                        "conflicts with {main_setting}['{kind}']. "
+                        "Remove either setting and update the other to "
+                        "the correct list of filters for {kind} resources"
+                        ", we recommend you keep the latter."
+                        .format(
+                            kind_setting=self._meta.prefixed_name(setting_name),
+                            main_setting=self._meta.prefixed_name('FILTERS'),
+                            kind=kind))
+                data['FILTERS'][kind] = filters
+            elif kind in data['FILTERS']:
+                # filters for this kind are set using FILTERS[<kind>]
+                data[setting_name] = data['FILTERS'][kind]
+            else:
+                # filters are not defined
+                data['FILTERS'][kind] = data[setting_name] = default_filters[kind]
+        return data

--- a/compressor/css.py
+++ b/compressor/css.py
@@ -4,9 +4,8 @@ from compressor.conf import settings
 
 class CssCompressor(Compressor):
 
-    def __init__(self, content=None, output_prefix="css", context=None):
-        filters = list(settings.COMPRESS_CSS_FILTERS)
-        super(CssCompressor, self).__init__(content, output_prefix, context, filters)
+    output_prefix = 'css'
+    output_mimetypes = {'text/css'}
 
     def split_contents(self):
         if self.split_content:
@@ -31,8 +30,7 @@ class CssCompressor(Compressor):
                 if append_to_previous and settings.COMPRESS_ENABLED:
                     self.media_nodes[-1][1].split_content.append(data)
                 else:
-                    node = self.__class__(content=self.parser.elem_str(elem),
-                                          context=self.context)
+                    node = self.copy(content=self.parser.elem_str(elem))
                     node.split_content.append(data)
                     self.media_nodes.append((media, node))
         return self.split_content

--- a/compressor/css.py
+++ b/compressor/css.py
@@ -4,7 +4,6 @@ from compressor.conf import settings
 
 class CssCompressor(Compressor):
 
-    output_prefix = 'css'
     output_mimetypes = {'text/css'}
 
     def split_contents(self):

--- a/compressor/filters/base.py
+++ b/compressor/filters/base.py
@@ -40,6 +40,13 @@ class FilterBase(object):
     Subclasses should implement `input` and/or `output` methods which must
     return a string (unicode under python 2) or raise a NotImplementedError.
     """
+
+    # Since precompiling moves files around, it breaks url()
+    # statements in css files. therefore we run the absolute and relative filter
+    # on precompiled css files even if compression is disabled.
+    # This flag allows those filters to do so.
+    run_with_compression_disabled = False
+
     def __init__(self, content, attrs=None, filter_type=None, filename=None,
                  verbose=0, charset=None, **kwargs):
         self.type = filter_type or getattr(self, 'type', None)

--- a/compressor/filters/css_default.py
+++ b/compressor/filters/css_default.py
@@ -20,9 +20,6 @@ SCHEMES = ('http://', 'https://', '/')
 
 class CssAbsoluteFilter(FilterBase):
 
-    # Since precompiling moves files around, it breaks url()
-    # statements in css files. therefore we run the this filter
-    # on precompiled css files even if compression is disabled.
     run_with_compression_disabled = True
 
     def __init__(self, *args, **kwargs):
@@ -130,9 +127,6 @@ class CssRelativeFilter(CssAbsoluteFilter):
     but add a *relative URL prefix* instead of ``settings.COMPRESS_URL``.
     """
 
-    # Since precompiling moves files around, it breaks url()
-    # statements in css files. therefore we run the this filter
-    # on precompiled css files even if compression is disabled.
     run_with_compression_disabled = True
 
     def post_process_url(self, url):

--- a/compressor/filters/css_default.py
+++ b/compressor/filters/css_default.py
@@ -20,6 +20,11 @@ SCHEMES = ('http://', 'https://', '/')
 
 class CssAbsoluteFilter(FilterBase):
 
+    # Since precompiling moves files around, it breaks url()
+    # statements in css files. therefore we run the this filter
+    # on precompiled css files even if compression is disabled.
+    run_with_compression_disabled = True
+
     def __init__(self, *args, **kwargs):
         super(CssAbsoluteFilter, self).__init__(*args, **kwargs)
         self.root = settings.COMPRESS_ROOT
@@ -124,6 +129,12 @@ class CssRelativeFilter(CssAbsoluteFilter):
     Do similar to ``CssAbsoluteFilter`` URL processing
     but add a *relative URL prefix* instead of ``settings.COMPRESS_URL``.
     """
+
+    # Since precompiling moves files around, it breaks url()
+    # statements in css files. therefore we run the this filter
+    # on precompiled css files even if compression is disabled.
+    run_with_compression_disabled = True
+
     def post_process_url(self, url):
         """
         Replace ``settings.COMPRESS_URL`` URL prefix with  '../' * (N + 1)

--- a/compressor/js.py
+++ b/compressor/js.py
@@ -4,9 +4,8 @@ from compressor.base import Compressor, SOURCE_HUNK, SOURCE_FILE
 
 class JsCompressor(Compressor):
 
-    def __init__(self, content=None, output_prefix="js", context=None):
-        filters = list(settings.COMPRESS_JS_FILTERS)
-        super(JsCompressor, self).__init__(content, output_prefix, context, filters)
+    output_prefix = 'js'
+    output_mimetypes = {'text/javascript'}
 
     def split_contents(self):
         if self.split_content:
@@ -33,8 +32,7 @@ class JsCompressor(Compressor):
             if append_to_previous and settings.COMPRESS_ENABLED:
                 self.extra_nodes[-1][1].split_content.append(content)
             else:
-                node = self.__class__(content=self.parser.elem_str(elem),
-                                      context=self.context)
+                node = self.copy(content=self.parser.elem_str(elem))
                 node.split_content.append(content)
                 self.extra_nodes.append((extra, node))
         return self.split_content

--- a/compressor/js.py
+++ b/compressor/js.py
@@ -4,7 +4,6 @@ from compressor.base import Compressor, SOURCE_HUNK, SOURCE_FILE
 
 class JsCompressor(Compressor):
 
-    output_prefix = 'js'
     output_mimetypes = {'text/javascript'}
 
     def split_contents(self):

--- a/compressor/templatetags/compress.py
+++ b/compressor/templatetags/compress.py
@@ -22,21 +22,22 @@ class CompressorMixin(object):
 
     @property
     def compressors(self):
-        return {
-            'js': settings.COMPRESS_JS_COMPRESSOR,
-            'css': settings.COMPRESS_CSS_COMPRESSOR,
-        }
+        return settings.COMPRESSORS
 
-    def compressor_cls(self, kind, *args, **kwargs):
+    def compressor_cls(self, kind):
         if kind not in self.compressors.keys():
             raise template.TemplateSyntaxError(
-                "The compress tag's argument must be 'js' or 'css'.")
+                "The compress tag's argument must be one of: %s."
+                % ', '.join(map(repr, self.compressors.keys())))
         return get_class(self.compressors.get(kind),
-                         exception=ImproperlyConfigured)(*args, **kwargs)
+                         exception=ImproperlyConfigured)
 
     def get_compressor(self, context, kind):
-        return self.compressor_cls(kind,
-            content=self.get_original_content(context), context=context)
+        cls = self.compressor_cls(kind)
+        return cls(
+            kind,
+            content=self.get_original_content(context),
+            context=context)
 
     def debug_mode(self, context):
         if settings.COMPRESS_DEBUG_TOGGLE:

--- a/compressor/tests/test_conf.py
+++ b/compressor/tests/test_conf.py
@@ -25,40 +25,40 @@ class ConfTestCase(SimpleTestCase):
     def test_filter_defaults(self):
         # This used the settings from compressor/test_settings.py
         # which contains no values for filers and therefore uses the defaults.
-        self.assertEqual(settings.COMPRESS_CSS_FILTERS, default_css_filters)
-        self.assertEqual(settings.COMPRESS_JS_FILTERS, default_js_filters)
         self.assertEqual(settings.COMPRESS_FILTERS['css'], default_css_filters)
         self.assertEqual(settings.COMPRESS_FILTERS['js'], default_js_filters)
+        self.assertFalse(hasattr(settings, 'COMPRESS_CSS_FILTERS'))
+        self.assertFalse(hasattr(settings, 'COMPRESS_JS_FILTERS'))
 
     @override_settings(COMPRESS_FILTERS=dict(),
                        COMPRESS_CSS_FILTERS=None,
                        COMPRESS_JS_FILTERS=None)
     def test_filters_by_default(self):
         conf = create_conf()
-        self.assertEqual(conf.CSS_FILTERS, default_css_filters)
-        self.assertEqual(conf.JS_FILTERS, default_js_filters)
         self.assertEqual(conf.FILTERS['css'], default_css_filters)
         self.assertEqual(conf.FILTERS['js'], default_js_filters)
+        self.assertFalse(hasattr(conf, 'COMPRESS_CSS_FILTERS'))
+        self.assertFalse(hasattr(conf, 'COMPRESS_JS_FILTERS'))
 
     @override_settings(COMPRESS_FILTERS=dict(),
                        COMPRESS_CSS_FILTERS=['ham'],
                        COMPRESS_JS_FILTERS=['spam'])
     def test_filters_by_specific_settings(self):
         conf = create_conf()
-        self.assertEqual(conf.CSS_FILTERS, ['ham'])
-        self.assertEqual(conf.JS_FILTERS, ['spam'])
         self.assertEqual(conf.FILTERS['css'], ['ham'])
         self.assertEqual(conf.FILTERS['js'], ['spam'])
+        self.assertFalse(hasattr(conf, 'COMPRESS_CSS_FILTERS'))
+        self.assertFalse(hasattr(conf, 'COMPRESS_JS_FILTERS'))
 
     @override_settings(COMPRESS_FILTERS=dict(css=['ham'], js=['spam']),
                        COMPRESS_CSS_FILTERS=None,
                        COMPRESS_JS_FILTERS=None)
     def test_filters_by_main_setting(self):
         conf = create_conf()
-        self.assertEqual(conf.CSS_FILTERS, ['ham'])
-        self.assertEqual(conf.JS_FILTERS, ['spam'])
         self.assertEqual(conf.FILTERS['css'], ['ham'])
         self.assertEqual(conf.FILTERS['js'], ['spam'])
+        self.assertFalse(hasattr(conf, 'COMPRESS_CSS_FILTERS'))
+        self.assertFalse(hasattr(conf, 'COMPRESS_JS_FILTERS'))
 
     @override_settings(COMPRESS_FILTERS=dict(css=['ham']),
                        COMPRESS_CSS_FILTERS=['spam'])

--- a/compressor/tests/test_conf.py
+++ b/compressor/tests/test_conf.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement, unicode_literals
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
 from django.core.exceptions import ImproperlyConfigured

--- a/compressor/tests/test_conf.py
+++ b/compressor/tests/test_conf.py
@@ -1,0 +1,74 @@
+from __future__ import with_statement, unicode_literals
+from django.test import SimpleTestCase
+from django.test.utils import override_settings
+from django.core.exceptions import ImproperlyConfigured
+from compressor.conf import settings
+from compressor.conf import CompressorConf
+
+
+default_css_filters = ['compressor.filters.css_default.CssAbsoluteFilter']
+default_js_filters = ['compressor.filters.jsmin.JSMinFilter']
+
+
+def create_conf(**attrs):
+    # Creating a new appconf.AppConf subclass will cause
+    # its configuration to be resolved.
+    # We use this to force the CompressorConf to be re-resolved,
+    # when we've changed the settings.
+    attrs['__module__'] = None
+    return type(
+        'TestCompressorConf',
+        (CompressorConf, ),
+        attrs)
+
+
+class ConfTestCase(SimpleTestCase):
+    def test_filter_defaults(self):
+        # This used the settings from compressor/test_settings.py
+        # which contains no values for filers and therefore uses the defaults.
+        self.assertEqual(settings.COMPRESS_CSS_FILTERS, default_css_filters)
+        self.assertEqual(settings.COMPRESS_JS_FILTERS, default_js_filters)
+        self.assertEqual(settings.COMPRESS_FILTERS['css'], default_css_filters)
+        self.assertEqual(settings.COMPRESS_FILTERS['js'], default_js_filters)
+
+    @override_settings(COMPRESS_FILTERS=dict(),
+                       COMPRESS_CSS_FILTERS=None,
+                       COMPRESS_JS_FILTERS=None)
+    def test_filters_by_default(self):
+        conf = create_conf()
+        self.assertEqual(conf.CSS_FILTERS, default_css_filters)
+        self.assertEqual(conf.JS_FILTERS, default_js_filters)
+        self.assertEqual(conf.FILTERS['css'], default_css_filters)
+        self.assertEqual(conf.FILTERS['js'], default_js_filters)
+
+    @override_settings(COMPRESS_FILTERS=dict(),
+                       COMPRESS_CSS_FILTERS=['ham'],
+                       COMPRESS_JS_FILTERS=['spam'])
+    def test_filters_by_specific_settings(self):
+        conf = create_conf()
+        self.assertEqual(conf.CSS_FILTERS, ['ham'])
+        self.assertEqual(conf.JS_FILTERS, ['spam'])
+        self.assertEqual(conf.FILTERS['css'], ['ham'])
+        self.assertEqual(conf.FILTERS['js'], ['spam'])
+
+    @override_settings(COMPRESS_FILTERS=dict(css=['ham'], js=['spam']),
+                       COMPRESS_CSS_FILTERS=None,
+                       COMPRESS_JS_FILTERS=None)
+    def test_filters_by_main_setting(self):
+        conf = create_conf()
+        self.assertEqual(conf.CSS_FILTERS, ['ham'])
+        self.assertEqual(conf.JS_FILTERS, ['spam'])
+        self.assertEqual(conf.FILTERS['css'], ['ham'])
+        self.assertEqual(conf.FILTERS['js'], ['spam'])
+
+    @override_settings(COMPRESS_FILTERS=dict(css=['ham']),
+                       COMPRESS_CSS_FILTERS=['spam'])
+    def test_css_filters_conflict(self):
+        with self.assertRaises(ImproperlyConfigured):
+            create_conf()
+
+    @override_settings(COMPRESS_FILTERS=dict(js=['ham']),
+                       COMPRESS_JS_FILTERS=['spam'])
+    def test_js_filters_conflict(self):
+        with self.assertRaises(ImproperlyConfigured):
+            create_conf()

--- a/compressor/tests/test_filters.py
+++ b/compressor/tests/test_filters.py
@@ -333,7 +333,7 @@ p { filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(src='%(compress_u
         <link rel="stylesheet" href="/static/css/url/url1.css" type="text/css">
         <link rel="stylesheet" href="/static/css/url/2/url2.css" type="text/css">
         """
-        css_node = CssCompressor(css)
+        css_node = CssCompressor('css', css)
 
         self.assertEqual([css1, css2], list(css_node.hunks()))
 
@@ -386,7 +386,7 @@ class CssAbsolutizingTestCaseWithHash(CssAbsolutizingTestCase):
 @override_settings(
     COMPRESS_ENABLED=True,
     COMPRESS_URL='/static/',
-    COMPRESS_CSS_FILTERS=['compressor.filters.css_default.CssRelativeFilter']
+    COMPRESS_FILTERS={'css': ['compressor.filters.css_default.CssRelativeFilter']}
 )
 class CssRelativizingTestCase(CssAbsolutizingTestCase):
     filter_class = CssRelativeFilter
@@ -410,10 +410,10 @@ class CssRelativizingTestCase(CssAbsolutizingTestCase):
 
 @override_settings(
     COMPRESS_ENABLED=True,
-    COMPRESS_CSS_FILTERS=[
+    COMPRESS_FILTERS={'css': [
         'compressor.filters.css_default.CssAbsoluteFilter',
         'compressor.filters.datauri.CssDataUriFilter',
-    ],
+    ]},
     COMPRESS_URL='/static/',
     COMPRESS_CSS_HASHING_METHOD='mtime'
 )
@@ -422,7 +422,7 @@ class CssDataUriTestCase(TestCase):
         self.css = """
         <link rel="stylesheet" href="/static/css/datauri.css" type="text/css">
         """
-        self.css_node = CssCompressor(self.css)
+        self.css_node = CssCompressor('css', self.css)
 
     def test_data_uris(self):
         datauri_hash = get_hashed_mtime(os.path.join(settings.COMPRESS_ROOT, 'img/python.png'))

--- a/compressor/tests/test_signals.py
+++ b/compressor/tests/test_signals.py
@@ -19,12 +19,12 @@ class PostCompressSignalTestCase(TestCase):
 <link rel="stylesheet" href="/static/css/one.css" type="text/css" />
 <style type="text/css">p { border:5px solid green;}</style>
 <link rel="stylesheet" href="/static/css/two.css" type="text/css" />"""
-        self.css_node = CssCompressor(self.css)
+        self.css_node = CssCompressor('css', self.css)
 
         self.js = """\
 <script src="/static/js/one.js" type="text/javascript"></script>
 <script type="text/javascript">obj.value = "value";</script>"""
-        self.js_node = JsCompressor(self.js)
+        self.js_node = JsCompressor('js', self.js)
 
     def tearDown(self):
         post_compress.disconnect()
@@ -60,7 +60,7 @@ class PostCompressSignalTestCase(TestCase):
 <link rel="stylesheet" href="/static/css/one.css" media="handheld" type="text/css" />
 <style type="text/css" media="print">p { border:5px solid green;}</style>
 <link rel="stylesheet" href="/static/css/two.css" type="text/css" />"""
-        css_node = CssCompressor(css)
+        css_node = CssCompressor('css', css)
 
         def listener(sender, **kwargs):
             pass

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -67,183 +67,209 @@ Base settings
 Backend settings
 ----------------
 
+.. attribute:: COMPRESS_FILTERS
+
+    :default: ``{'css': ['compressor.filters.css_default.CssAbsoluteFilter'], 'js': ['compressor.filters.jsmin.JSMinFilter']}``
+
+    A mapping of resource kinds to the list of filters to apply.
+    The key is used to refer to this resource type in templates
+    when using the `{% compress [resource_kind] %}` template tag.
+    The value is a list of filters to apply in the given order
+    for that resource.
+
+    This library currently includes filters for CSS and Javascript.
+
+    - CSS Filters
+
+      :default: ``['compressor.filters.css_default.CssAbsoluteFilter']``
+
+      A list of filters that will be applied to CSS.
+
+      Possible options for CSS filters are (including their settings):
+
+      - ``compressor.filters.css_default.CssAbsoluteFilter``
+
+        A filter that normalizes the URLs used in ``url()`` CSS statements. This
+        is necessary since the output css files produced by Django Compressor
+        are in a different location than the source files and relative paths
+        might have become invalid. The filter also appends a hash as query string
+        to the normalized URLs to help with cache busting.
+
+        .. attribute:: COMPRESS_CSS_HASHING_METHOD
+
+           The method to use when calculating the query string.  Either ``None``,
+           ``'mtime'`` (default) or ``'content'``. Use the ``None`` if you want
+           to completely disable that feature, and the ``'content'`` in case
+           you're using multiple servers to serve your content.
+
+      - ``compressor.filters.css_default.CssRelativeFilter``
+
+        An alternative to ``CssAbsoluteFilter``. It uses a relative instead of an
+        absolute path to prefix URLs. Specifically, the prefix will be  ``'../' * (N + 1)``
+        where ``N`` is the *depth* of ``settings.COMPRESS_OUTPUT_DIR`` folder
+        (i.e. ``1`` for ``'CACHE'``, or ``2``for ``CACHE/data`` etc). This can be
+        useful if you don't want to hard-code :attr:`~django.conf.settings.COMPRESS_URL`
+        into CSS code.
+
+      - ``compressor.filters.datauri.CssDataUriFilter``
+
+        A filter for embedding media as `data: URIs`_ in the CSS.
+
+        .. attribute:: COMPRESS_DATA_URI_MAX_SIZE
+
+           Only files that are smaller than this in bytes value will be embedded.
+
+      - ``compressor.filters.yui.YUICSSFilter``
+
+        A filter that passes the CSS content to the `YUI compressor`_.
+
+        .. attribute:: COMPRESS_YUI_BINARY
+
+           The YUI compressor filesystem path. Make sure to also prepend this
+           setting with ``java -jar`` if you use that kind of distribution.
+
+        .. attribute:: COMPRESS_YUI_CSS_ARGUMENTS
+
+           The arguments passed to the compressor.
+
+      - ``compressor.filters.yuglify.YUglifyCSSFilter``
+
+        A filter that passes the CSS content to the `yUglify compressor`_.
+
+        .. attribute:: COMPRESS_YUGLIFY_BINARY
+
+           The yUglify compressor filesystem path.
+
+        .. attribute:: COMPRESS_YUGLIFY_CSS_ARGUMENTS
+
+           The arguments passed to the compressor. Defaults to --terminal.
+
+      .. _csscompressor_filter:
+
+      - ``compressor.filters.cssmin.CSSCompressorFilter``
+
+        A filter that uses Yury Selivanov's Python port of the YUI CSS compression
+        algorithm csscompressor_.
+
+      - ``compressor.filters.cssmin.rCSSMinFilter``
+
+        A filter that uses the cssmin implementation rCSSmin_ to compress CSS
+        (installed by default).
+
+      - ``compressor.filters.cleancss.CleanCSSFilter``
+
+        A filter that passes the CSS content to the `clean-css`_ tool.
+
+        .. attribute:: COMPRESS_CLEAN_CSS_BINARY
+
+           The clean-css binary filesystem path.
+
+        .. attribute:: COMPRESS_CLEAN_CSS_ARGUMENTS
+
+           The arguments passed to clean-css.
+
+
+      .. _`data: URIs`: http://en.wikipedia.org/wiki/Data_URI_scheme
+      .. _csscompressor: http://pypi.python.org/pypi/csscompressor/
+      .. _rCSSmin: http://opensource.perlig.de/rcssmin/
+      .. _`clean-css`: https://github.com/GoalSmashers/clean-css/
+
+
+      - ``compressor.filters.template.TemplateFilter``
+
+        A filter that renders the CSS content with Django templating system.
+
+        .. attribute:: COMPRESS_TEMPLATE_FILTER_CONTEXT
+
+           The context to render your css files with.
+
+
+    - Javascript Filters
+
+      .. _compress_js_filters:
+
+      :Default: ``['compressor.filters.jsmin.JSMinFilter']``
+
+      A list of filters that will be applied to javascript.
+
+      Possible options are:
+
+      - ``compressor.filters.jsmin.JSMinFilter``
+
+        A filter that uses the jsmin implementation rJSmin_ to compress
+        JavaScript code (installed by default).
+
+      .. _slimit_filter:
+
+      - ``compressor.filters.jsmin.SlimItFilter``
+
+        A filter that uses the jsmin implementation `Slim It`_ to compress
+        JavaScript code.
+
+      - ``compressor.filters.closure.ClosureCompilerFilter``
+
+        A filter that uses `Google Closure compiler`_.
+
+        .. attribute:: COMPRESS_CLOSURE_COMPILER_BINARY
+
+           The Closure compiler filesystem path. Make sure to also prepend
+           this setting with ``java -jar`` if you use that kind of distribution.
+
+        .. attribute:: COMPRESS_CLOSURE_COMPILER_ARGUMENTS
+
+           The arguments passed to the compiler.
+
+      - ``compressor.filters.yui.YUIJSFilter``
+
+        A filter that passes the JavaScript code to the `YUI compressor`_.
+
+        .. attribute:: COMPRESS_YUI_BINARY
+
+           The YUI compressor filesystem path.
+
+        .. attribute:: COMPRESS_YUI_JS_ARGUMENTS
+
+           The arguments passed to the compressor.
+
+      - ``compressor.filters.yuglify.YUglifyJSFilter``
+
+        A filter that passes the JavaScript code to the `yUglify compressor`_.
+
+        .. attribute:: COMPRESS_YUGLIFY_BINARY
+
+           The yUglify compressor filesystem path.
+
+        .. attribute:: COMPRESS_YUGLIFY_JS_ARGUMENTS
+
+           The arguments passed to the compressor.
+
+      - ``compressor.filters.template.TemplateFilter``
+
+        A filter that renders the JavaScript code with Django templating system.
+
+        .. attribute:: COMPRESS_TEMPLATE_FILTER_CONTEXT
+
+           The context to render your JavaScript code with.
+
+      .. _rJSmin: http://opensource.perlig.de/rjsmin/
+      .. _`Google Closure compiler`: http://code.google.com/closure/compiler/
+      .. _`YUI compressor`: http://developer.yahoo.com/yui/compressor/
+      .. _`yUglify compressor`: https://github.com/yui/yuglify
+      .. _`Slim It`: https://github.com/rspivak/slimit
+
 .. attribute:: COMPRESS_CSS_FILTERS
 
-    :default: ``['compressor.filters.css_default.CssAbsoluteFilter']``
-
-    A list of filters that will be applied to CSS.
-
-    Possible options are (including their settings):
-
-    - ``compressor.filters.css_default.CssAbsoluteFilter``
-
-      A filter that normalizes the URLs used in ``url()`` CSS statements. This
-      is necessary since the output css files produced by Django Compressor
-      are in a different location than the source files and relative paths
-      might have become invalid. The filter also appends a hash as query string
-      to the normalized URLs to help with cache busting.
-
-      .. attribute:: COMPRESS_CSS_HASHING_METHOD
-
-         The method to use when calculating the query string.  Either ``None``,
-         ``'mtime'`` (default) or ``'content'``. Use the ``None`` if you want
-         to completely disable that feature, and the ``'content'`` in case
-         you're using multiple servers to serve your content.
-
-    - ``compressor.filters.css_default.CssRelativeFilter``
-
-      An alternative to ``CssAbsoluteFilter``. It uses a relative instead of an
-      absolute path to prefix URLs. Specifically, the prefix will be  ``'../' * (N + 1)``
-      where ``N`` is the *depth* of ``settings.COMPRESS_OUTPUT_DIR`` folder
-      (i.e. ``1`` for ``'CACHE'``, or ``2``for ``CACHE/data`` etc). This can be
-      useful if you don't want to hard-code :attr:`~django.conf.settings.COMPRESS_URL`
-      into CSS code.
-
-    - ``compressor.filters.datauri.CssDataUriFilter``
-
-      A filter for embedding media as `data: URIs`_ in the CSS.
-
-      .. attribute:: COMPRESS_DATA_URI_MAX_SIZE
-
-         Only files that are smaller than this in bytes value will be embedded.
-
-    - ``compressor.filters.yui.YUICSSFilter``
-
-      A filter that passes the CSS content to the `YUI compressor`_.
-
-      .. attribute:: COMPRESS_YUI_BINARY
-
-         The YUI compressor filesystem path. Make sure to also prepend this
-         setting with ``java -jar`` if you use that kind of distribution.
-
-      .. attribute:: COMPRESS_YUI_CSS_ARGUMENTS
-
-         The arguments passed to the compressor.
-
-    - ``compressor.filters.yuglify.YUglifyCSSFilter``
-
-      A filter that passes the CSS content to the `yUglify compressor`_.
-
-      .. attribute:: COMPRESS_YUGLIFY_BINARY
-
-         The yUglify compressor filesystem path.
-
-      .. attribute:: COMPRESS_YUGLIFY_CSS_ARGUMENTS
-
-         The arguments passed to the compressor. Defaults to --terminal.
-
-    .. _csscompressor_filter:
-
-    - ``compressor.filters.cssmin.CSSCompressorFilter``
-
-      A filter that uses Yury Selivanov's Python port of the YUI CSS compression
-      algorithm csscompressor_.
-
-    - ``compressor.filters.cssmin.rCSSMinFilter``
-
-      A filter that uses the cssmin implementation rCSSmin_ to compress CSS
-      (installed by default).
-
-    - ``compressor.filters.cleancss.CleanCSSFilter``
-
-      A filter that passes the CSS content to the `clean-css`_ tool.
-
-      .. attribute:: COMPRESS_CLEAN_CSS_BINARY
-
-         The clean-css binary filesystem path.
-
-      .. attribute:: COMPRESS_CLEAN_CSS_ARGUMENTS
-
-         The arguments passed to clean-css.
-
-
-    .. _`data: URIs`: http://en.wikipedia.org/wiki/Data_URI_scheme
-    .. _csscompressor: http://pypi.python.org/pypi/csscompressor/
-    .. _rCSSmin: http://opensource.perlig.de/rcssmin/
-    .. _`clean-css`: https://github.com/GoalSmashers/clean-css/
-
-
-    - ``compressor.filters.template.TemplateFilter``
-
-      A filter that renders the CSS content with Django templating system.
-
-      .. attribute:: COMPRESS_TEMPLATE_FILTER_CONTEXT
-
-         The context to render your css files with.
-
-
-.. _compress_js_filters:
+    Backwards-compatible alias for the ``'css'`` key of
+    :attr:`~django.conf.settings.COMPRESS_FILTERS`.
+    If you haven't defined that key you can still continue
+    using this setting, although we encourage you to convert it to the new form.
 
 .. attribute:: COMPRESS_JS_FILTERS
 
-    :Default: ``['compressor.filters.jsmin.JSMinFilter']``
-
-    A list of filters that will be applied to javascript.
-
-    Possible options are:
-
-    - ``compressor.filters.jsmin.JSMinFilter``
-
-      A filter that uses the jsmin implementation rJSmin_ to compress
-      JavaScript code (installed by default).
-
-    .. _slimit_filter:
-
-    - ``compressor.filters.jsmin.SlimItFilter``
-
-      A filter that uses the jsmin implementation `Slim It`_ to compress
-      JavaScript code.
-
-    - ``compressor.filters.closure.ClosureCompilerFilter``
-
-      A filter that uses `Google Closure compiler`_.
-
-      .. attribute:: COMPRESS_CLOSURE_COMPILER_BINARY
-
-         The Closure compiler filesystem path. Make sure to also prepend
-         this setting with ``java -jar`` if you use that kind of distribution.
-
-      .. attribute:: COMPRESS_CLOSURE_COMPILER_ARGUMENTS
-
-         The arguments passed to the compiler.
-
-    - ``compressor.filters.yui.YUIJSFilter``
-
-      A filter that passes the JavaScript code to the `YUI compressor`_.
-
-      .. attribute:: COMPRESS_YUI_BINARY
-
-         The YUI compressor filesystem path.
-
-      .. attribute:: COMPRESS_YUI_JS_ARGUMENTS
-
-         The arguments passed to the compressor.
-
-    - ``compressor.filters.yuglify.YUglifyJSFilter``
-
-      A filter that passes the JavaScript code to the `yUglify compressor`_.
-
-      .. attribute:: COMPRESS_YUGLIFY_BINARY
-
-         The yUglify compressor filesystem path.
-
-      .. attribute:: COMPRESS_YUGLIFY_JS_ARGUMENTS
-
-         The arguments passed to the compressor.
-
-    - ``compressor.filters.template.TemplateFilter``
-
-      A filter that renders the JavaScript code with Django templating system.
-
-      .. attribute:: COMPRESS_TEMPLATE_FILTER_CONTEXT
-
-         The context to render your JavaScript code with.
-
-    .. _rJSmin: http://opensource.perlig.de/rjsmin/
-    .. _`Google Closure compiler`: http://code.google.com/closure/compiler/
-    .. _`YUI compressor`: http://developer.yahoo.com/yui/compressor/
-    .. _`yUglify compressor`: https://github.com/yui/yuglify
-    .. _`Slim It`: https://github.com/rspivak/slimit
+    Backwards-compatible alias for the ``'js'`` key of
+    :attr:`~django.conf.settings.COMPRESS_FILTERS`.
+    If you haven't defined that key you can still continue
+    using this setting, although we encourage you to convert it to the new form.
 
 .. attribute:: COMPRESS_PRECOMPILERS
 

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -81,6 +81,8 @@ Backend settings
 
     - CSS Filters
 
+      .. _compress_css_filters:
+
       :default: ``['compressor.filters.css_default.CssAbsoluteFilter']``
 
       A list of filters that will be applied to CSS.

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -78,11 +78,10 @@ and simply returns exactly what it was given.
 .. note::
 
     If you've configured any
-    :attr:`precompilers <django.conf.settings.COMPRESS_PRECOMPILERS>`
-    setting, :attr:`~django.conf.settings.COMPRESS_ENABLED` to ``False`` won't
+    :attr:`precompilers <django.conf.settings.COMPRESS_PRECOMPILERS>`,
+    setting :attr:`~django.conf.settings.COMPRESS_ENABLED` to ``False`` won't
     affect the processing of those files. Only the
-    :attr:`CSS <django.conf.settings.COMPRESS_CSS_FILTERS>` and
-    :attr:`JavaScript filters <django.conf.settings.COMPRESS_JS_FILTERS>`
+    :attr:`~django.conf.settings.COMPRESS_FILTERS`
     will be disabled.
 
 If both DEBUG and :attr:`~django.conf.settings.COMPRESS_ENABLED` are set to


### PR DESCRIPTION
This change makes it possible to compress other resources besides css and js, such as svg, jpeg, fonts etc.

It introduces a new setting for filters ``COMPRESS_FILTERS`` that combines the existing ``COMPRESS_CSS_FILTERS`` and ``COMPRESS_JS_FILTERS``. The existing settings are still supported, but can optionally be replaced by the new one. This change is fully backwards-compatible and tested.

The undocumented setting ``CSS/JS_COMPRESSORS`` are combined into ``COMPRESSORS``. This is not backwards-compatible nor tested.

You can now add your own compressors.
In the example below, compressor now knows the ``jpeg`` resource type. Of course, the third party jpeg compressor still has to implement it.
```
# settings.py
COMPRESSORS = dict(
    css='compressor.css.CssCompressor',
    js='compressor.js.JsCompressor',
    jpeg='third.party.jpeg.JpegCompressor',
    ...
)
FILTERS = dict(
    jpeg=['third.party.jpeg.JpegOptimizerFilter'],
)

# page.html
<body>
  {% compress jpeg %}
    <img src="/path/to/image.jpeg" />
  {% endcompress %}
</body>
```