### PR TITLE
Use Boto3 instead of obsolete Boto in Remote Storages documentation

### DIFF
--- a/docs/remote-storages.txt
+++ b/docs/remote-storages.txt
@@ -16,7 +16,7 @@ that saves the result to a remote service (see
 django-storages
 ^^^^^^^^^^^^^^^
 
-So assuming your CDN is `Amazon S3`_, you can use the boto_ storage backend
+So assuming your CDN is `Amazon S3`_, you can use the boto3_ storage backend
 from the 3rd party app `django-storages`_. Some required settings are::
 
     AWS_ACCESS_KEY_ID = 'XXXXXXXXXXXXXXXXXXXXX'
@@ -34,7 +34,7 @@ files in your templates which you want to compress::
 
 The storage backend to save the compressed files needs to be changed, too::
 
-    COMPRESS_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+    COMPRESS_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 
 Using staticfiles
 ^^^^^^^^^^^^^^^^^
@@ -50,29 +50,29 @@ apps can be integrated.
    when doing their job.
 
 #. You need to create a subclass of the remote storage backend you want
-   to use; below is an example of the boto S3 storage backend from
+   to use; below is an example of the boto3 S3 storage backend from
    django-storages_::
 
     from django.core.files.storage import get_storage_class
-    from storages.backends.s3boto import S3BotoStorage
+    from storages.backends.s3boto3 import S3Boto3Storage
 
-    class CachedS3BotoStorage(S3BotoStorage):
+    class CachedS3Boto3Storage(S3Boto3Storage):
         """
         S3 storage backend that saves the files locally, too.
         """
         def __init__(self, *args, **kwargs):
-            super(CachedS3BotoStorage, self).__init__(*args, **kwargs)
+            super(CachedS3Boto3Storage, self).__init__(*args, **kwargs)
             self.local_storage = get_storage_class(
                 "compressor.storage.CompressorFileStorage")()
 
         def save(self, name, content):
             self.local_storage._save(name, content)
-            super(CachedS3BotoStorage, self).save(name, self.local_storage._open(name))
+            super(CachedS3Boto3Storage, self).save(name, self.local_storage._open(name))
             return name
 
 #. Set your :attr:`~django.conf.settings.COMPRESS_STORAGE` and STATICFILES_STORAGE_
    settings to the dotted path of your custom cached storage backend, e.g.
-   ``'mysite.storage.CachedS3BotoStorage'``.
+   ``'mysite.storage.CachedS3Boto3Storage'``.
 
 #. To have Django correctly render the URLs to your static files, set the
    STATIC_URL_ setting to the same value as
@@ -90,7 +90,7 @@ In the end it might look like this::
 
 .. _CDN: http://en.wikipedia.org/wiki/Content_delivery_network
 .. _Amazon S3: https://s3.amazonaws.com/
-.. _boto: http://boto.cloudhackers.com/
+.. _boto3: http://boto3.readthedocs.io/
 .. _django-storages: http://github.com/jschneier/django-storages
 .. _staticfiles: http://docs.djangoproject.com/en/dev/howto/static-files/
 .. _STATIC_ROOT: http://docs.djangoproject.com/en/dev/ref/settings/#static-root


### PR DESCRIPTION
I updated documentation as I stated in #909.