### PR TITLE
THREADING: Make template compression threaded to improve performance

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -57,6 +57,7 @@ Jonathan Lukens
 Julian Scheid
 Julien Phalip
 Justin Lilly
+Keith Hackbarth
 Lucas Tan
 Luis Nell
 Lukas Lehner


### PR DESCRIPTION
This is similar to the work done in https://github.com/django-compressor/django-compressor/pull/737. But since the task is I/O bound in most cases, it seemed to make more sense to choose threads over processes.

On our rather large site, using a custom UglifyJS filter and CSSMin, command line compression when from an average 12.38 minutes to an average 6.59 minutes

Note: initially I used locking to prevent a potential race-condition where the same hash could get compressed twice, but in my very non-scientific tests, performance was better without it.