### PR TITLE
Add log messages to debug missing keys.

### DIFF
--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -235,7 +235,7 @@ class Command(BaseCommand):
                             settings.COMPRESS_URL, settings.COMPRESS_URL_PLACEHOLDER
                         )
                         offline_manifest[key] = result
-                        rendered_map[key] = {'rendered': rendered, 'template_name': template.name}
+                        rendered_map[key] = {'rendered': rendered, 'template_name': template.template_name}
                         context.pop()
                         results.append(result)
                         block_count += 1

--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 # flake8: noqa
 import os
 import sys
+import json
 
 from collections import OrderedDict, defaultdict
 from fnmatch import fnmatch
@@ -186,6 +187,7 @@ class Command(BaseCommand):
         nodes_count = 0
         block_count = 0
         offline_manifest = OrderedDict()
+        rendered_map = OrderedDict()
         results = []
         for context_dict in contexts:
             compressor_nodes = OrderedDict()
@@ -233,6 +235,7 @@ class Command(BaseCommand):
                             settings.COMPRESS_URL, settings.COMPRESS_URL_PLACEHOLDER
                         )
                         offline_manifest[key] = result
+                        rendered_map[key] = {'rendered': rendered, 'template_name': template.name}
                         context.pop()
                         results.append(result)
                         block_count += 1
@@ -246,7 +249,7 @@ class Command(BaseCommand):
         if verbosity >= 1:
             log.write("done\nCompressed %d block(s) from %d template(s) for %d context(s).\n" %
                       (block_count, nodes_count, contexts_count))
-        return offline_manifest, block_count, results
+        return offline_manifest, rendered_map, block_count, results
 
     def handle_extensions(self, extensions=('html',)):
         """
@@ -290,14 +293,23 @@ class Command(BaseCommand):
         engines = [e.strip() for e in options.get("engines", [])] or ["django"]
 
         final_offline_manifest = {}
+        final_rendered_map = {}
         final_block_count = 0
         final_results = []
         for engine in engines:
-            offline_manifest, block_count, results = self.compress(engine, extensions, verbosity, follow_links, log)
+            offline_manifest, rendered_map, block_count, results = self.compress(engine, extensions, verbosity, follow_links, log)
             final_results.extend(results)
             final_block_count += block_count
             final_offline_manifest.update(offline_manifest)
+            final_rendered_map.update(rendered_map)
         write_offline_manifest(final_offline_manifest)
+        if verbosity >= 2:
+            log.write("Rendered strings used to create manifest keys:\n\n")
+            for key in final_rendered_map:
+                log.write("-" * 20)
+                log.write("key: %s" % (key, ))
+                log.write("template name: %s" % (final_rendered_map[key]['template_name'], ))
+                log.write("rendered string: %s" % (final_rendered_map[key]['rendered'], ))
         return final_block_count, final_results
 
 Command.requires_system_checks = False

--- a/compressor/tests/test_offline.py
+++ b/compressor/tests/test_offline.py
@@ -243,7 +243,7 @@ class OfflineCompressBasicTestCase(OfflineTestCaseMixin, TestCase):
 
     @patch.object(CompressCommand, 'compress')
     def test_handle_no_args(self, compress_mock):
-        compress_mock.return_value = {}, 1, []
+        compress_mock.return_value = {}, {}, 1, []
         CompressCommand().handle()
         self.assertEqual(compress_mock.call_count, 1)
 
@@ -263,7 +263,7 @@ class OfflineCompressBasicTestCase(OfflineTestCaseMixin, TestCase):
 
     @patch.object(CompressCommand, 'compress')
     def test_handle_compress_offline_disabled_force(self, compress_mock):
-        compress_mock.return_value = {}, 1, []
+        compress_mock.return_value = {}, {}, 1, []
         with self.settings(COMPRESS_OFFLINE=False):
             CompressCommand().handle(force=True)
         self.assertEqual(compress_mock.call_count, 1)


### PR DESCRIPTION
Debugging `OfflineGeneratorError` is quite difficult.
This PR adds some log messages that will show the strings used to create the offline manifest, hopefully this will give enough information so anybody can debug an `OfflineGeneratorError`.

Most of the time an `OfflineGeneratorError` shows up when compress gets a different string when creating the offline manifest and when a normal request happens. By printing the strings, key and template name that compressor uses and creates when building the offline manifest we give users enough information for them to realize what's the discrepancy between the manifest and a normal request and they can fix the error.