### PR TITLE
Fix templates regarding w3c validator warnings. Removed type attribut…

### DIFF
--- a/compressor/templates/compressor/css_file.html
+++ b/compressor/templates/compressor/css_file.html
@@ -1,1 +1,1 @@
-<link rel="stylesheet" href="{{ compressed.url }}" type="text/css"{% if compressed.media %} media="{{ compressed.media }}"{% endif %} />
+<link rel="stylesheet" href="{{ compressed.url }}" type="text/css"{% if compressed.media %} media="{{ compressed.media }}"{% endif %}>

--- a/compressor/templates/compressor/js_file.html
+++ b/compressor/templates/compressor/js_file.html
@@ -1,1 +1,1 @@
-<script type="text/javascript" src="{{ compressed.url }}"{{ compressed.extra }}></script>
+<script src="{{ compressed.url }}"{{ compressed.extra }}></script>


### PR DESCRIPTION
Fixed templates regarding w3c validator warnings. Removed type attribute from script element because the type attribute is unnecessary for JavaScript resources.