### PR TITLE
Release v2.4

### DIFF
--- a/compressor/__init__.py
+++ b/compressor/__init__.py
@@ -1,2 +1,2 @@
 # following PEP 386
-__version__ = "2.3"
+__version__ = "2.4"

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -6,12 +6,13 @@ v2.4 (2019-12-02)
 
 `Full Changelog <https://github.com/django-compressor/django-compressor/compare/2.3...2.4>`_
 
-- Add support for Django 3.0
-- Remove usage of deprecated `django.utils.six` (#950)
+- Add support for Django 3.0 (#950, #967)
+- Officially support Python 3.8 (#967)
 - Add better support for JS strict mode and validation (#952)
 - Add support for rel=preload (#951)
-- Make jinja2 extension not break on OUTPUT_PRELOAD (#951)
 - Add support for Calmjs (#957)
+
+Note: in 2.3, a new setting ``COMPRESS_FILTERS`` has been introduced that combines the existing ``COMPRESS_CSS_FILTERS`` and ``COMPRESS_JS_FILTERS``. The latter are now deprecated. See `the docs <https://django-compressor.readthedocs.io/en/stable/settings/#django.conf.settings.COMPRESS_FILTERS>`_ on how to use the new setting, the conversion is straightforward.
 
 v2.3 (2019-05-31)
 -----------------
@@ -21,7 +22,7 @@ v2.3 (2019-05-31)
 - Drop support for Django 1.8, 1.9 and 1.10
 - Add support for Django 2.1 and 2.2, as well as Python 3.7
 - Update all dependencies. This required minor code changes, you might need to update some optional dependencies if you use any
-- Allow the mixed use of JS/CSS in Sekizai's templatetags `{% addtoblock "js" %}` and `{% addtoblock "css" %}` (#891)
+- Allow the mixed use of JS/CSS in Sekizai's templatetags ``{% addtoblock "js" %}`` and ``{% addtoblock "css" %}`` (#891)
 - Allow the implementation of new types other than css and js. (#900)
 - Update jinja2 extension to behave similar to the django tag (#899)
 - Fix crash in offline compression when child nodelist is None, again (#605)

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+v2.4 (2019-12-02)
+-----------------
+
+`Full Changelog <https://github.com/django-compressor/django-compressor/compare/2.3...2.4>`_
+
+- Add support for Django 3.0
+- Remove usage of deprecated `django.utils.six` (#950)
+- Add better support for JS strict mode and validation (#952)
+- Add support for rel=preload (#951)
+- Make jinja2 extension not break on OUTPUT_PRELOAD (#951)
+- Add support for Calmjs (#957)
+
 v2.3 (2019-05-31)
 -----------------
 


### PR DESCRIPTION
For #963  .  Depends on #966.

 I took a stab at the changelog too.  Feel free to modify before merging.

I was a bit confused with #957 because it pulls in several commits:
```
| * ca7b4c3 - Merge (7 weeks ago) <Alexander van Ratingen>
| * 9040dbc - Update mention in documentation of old filter setting to new form. (1 year, 8 months ago) <Alexander van Ratingen>
| * 0ff2cff - Document new COMPRESS_FILTERS setting. (1 year, 8 months ago) <Alexander van Ratingen>
| * f3cb088 - Remove old COMPRESS_FILTER_CSS/JS settings from configuration after converting them into the new COMPRESS_FILTERS[css/js] form. (1 year, 8 months ago) <Alexander van Ratingen>
| * 0a3b5b5 - Process review comments (1 year, 9 months ago) <Alexander van Ratingen>
| * 2a8ab45 - Fix failing test on Python 2. (1 year, 9 months ago) <Alexander van Ratingen>
| * eca31d1 - Abstract away resource types to allow the implementation of new types. (1 year, 9 months ago) <Alexander van Ratingen>
```
But the changes in these commits seem to have been reverted before merging back on the `develop` branch.  

After this is merged, someone with permissions will still need to `python setup.py sdist bdist_wheel` and upload to pypi.