### PR TITLE
Fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 install:
   - pip install tox
+  - python setup.py install_egg_info
 script:
   - tox
 matrix:


### PR DESCRIPTION
Jenkins is complaining about

```
Traceback (most recent call last):
  File "/home/travis/build/django-compressor/django-compressor/.tox/py37-1.11.X/lib/python3.7/site-packages/pip/_internal/req/req_install.py", line 339, in check_if_exists
    self.satisfied_by = pkg_resources.get_distribution(str(no_marker))
  File "/home/travis/build/django-compressor/django-compressor/.tox/py37-1.11.X/lib/python3.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 476, in get_distribution
    dist = get_provider(dist)
  File "/home/travis/build/django-compressor/django-compressor/.tox/py37-1.11.X/lib/python3.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 352, in get_provider
    return working_set.find(moduleOrReq) or require(str(moduleOrReq))[0]
  File "/home/travis/build/django-compressor/django-compressor/.tox/py37-1.11.X/lib/python3.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 895, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/home/travis/build/django-compressor/django-compressor/.tox/py37-1.11.X/lib/python3.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 786, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pip._vendor.pkg_resources.ContextualVersionConflict: (six 1.13.0 (/home/travis/build/django-compressor/django-compressor/.tox/py37-1.11.X/lib/python3.7/site-packages), Requirement.parse('six==1.12.0'), {'django-compressor'})
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/travis/build/django-compressor/django-compressor/.tox/py37-1.11.X/lib/python3.7/site-packages/pip/_internal/cli/base_command.py", line 143, in main
    status = self.run(options, args)
  File "/home/travis/build/django-compressor/django-compressor/.tox/py37-1.11.X/lib/python3.7/site-packages/pip/_internal/commands/install.py", line 318, in run
    resolver.resolve(requirement_set)
  File "/home/travis/build/django-compressor/django-compressor/.tox/py37-1.11.X/lib/python3.7/site-packages/pip/_internal/resolve.py", line 102, in resolve
    self._resolve_one(requirement_set, req)
  File "/home/travis/build/django-compressor/django-compressor/.tox/py37-1.11.X/lib/python3.7/site-packages/pip/_internal/resolve.py", line 256, in _resolve_one
    abstract_dist = self._get_abstract_dist_for(req_to_install)
  File "/home/travis/build/django-compressor/django-compressor/.tox/py37-1.11.X/lib/python3.7/site-packages/pip/_internal/resolve.py", line 193, in _get_abstract_dist_for
    req, self.require_hashes, self.use_user_site, self.finder,
  File "/home/travis/build/django-compressor/django-compressor/.tox/py37-1.11.X/lib/python3.7/site-packages/pip/_internal/operations/prepare.py", line 329, in prepare_editable_requirement
    req.check_if_exists(use_user_site)
  File "/home/travis/build/django-compressor/django-compressor/.tox/py37-1.11.X/lib/python3.7/site-packages/pip/_internal/req/req_install.py", line 350, in check_if_exists
    self.req.name
  File "/home/travis/build/django-compressor/django-compressor/.tox/py37-1.11.X/lib/python3.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 476, in get_distribution
    dist = get_provider(dist)
  File "/home/travis/build/django-compressor/django-compressor/.tox/py37-1.11.X/lib/python3.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 352, in get_provider
    return working_set.find(moduleOrReq) or require(str(moduleOrReq))[0]
  File "/home/travis/build/django-compressor/django-compressor/.tox/py37-1.11.X/lib/python3.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 895, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/home/travis/build/django-compressor/django-compressor/.tox/py37-1.11.X/lib/python3.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 786, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pip._vendor.pkg_resources.ContextualVersionConflict: (six 1.13.0 (/home/travis/build/django-compressor/django-compressor/.tox/py37-1.11.X/lib/python3.7/site-packages), Requirement.parse('six==1.12.0'), {'django-compressor'})
```

Followed https://github.com/pypa/pip/issues/4537#issuecomment-373386803 to fix tests