### PR TITLE
Test against python 3.8 and django 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,6 @@ matrix:
     - python: 3.8
       env: TOXENV=py38-2.2.X
       dist: xenial
-    - python: 3.5
-      env: TOXENV=py35-3.0.X
     - python: 3.6
       env: TOXENV=py36-3.0.X
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ matrix:
     - python: 3.7
       env: TOXENV=py37-1.11.X
       dist: xenial
+    - python: 3.8
+      env: TOXENV=py38-1.11.X
+      dist: xenial
     - python: 3.5
       env: TOXENV=py35-2.1.X
     - python: 3.6
@@ -24,12 +27,28 @@ matrix:
     - python: 3.7
       env: TOXENV=py37-2.1.X
       dist: xenial
+    - python: 3.8
+      env: TOXENV=py38-2.1.X
+      dist: xenial
     - python: 3.5
       env: TOXENV=py35-2.2.X
     - python: 3.6
       env: TOXENV=py36-2.2.X
     - python: 3.7
       env: TOXENV=py37-2.2.X
+      dist: xenial
+    - python: 3.8
+      env: TOXENV=py38-2.2.X
+      dist: xenial
+    - python: 3.5
+      env: TOXENV=py35-3.0.X
+    - python: 3.6
+      env: TOXENV=py36-3.0.X
+    - python: 3.7
+      env: TOXENV=py37-3.0.X
+      dist: xenial
+    - python: 3.8
+      env: TOXENV=py38-3.0.X
       dist: xenial
 
 notifications:

--- a/compressor/offline/jinja2.py
+++ b/compressor/offline/jinja2.py
@@ -48,7 +48,11 @@ def url_for(mod, filename):
     """
     Incomplete emulation of Flask's url_for.
     """
-    from django.contrib.staticfiles.templatetags import staticfiles
+    try:
+        from django.contrib.staticfiles.templatetags import staticfiles
+    except ImportError:
+        # Django 3.0+
+        import django.templatetags.static as staticfiles
 
     if mod == "static":
         return staticfiles.static(filename)

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -5,7 +5,7 @@ mock==2.0.0
 Jinja2==2.10.1
 lxml==4.2.5
 beautifulsoup4==4.6.3
-django-sekizai==0.10.0
+django-sekizai==1.0.0
 csscompressor==0.9.5
 rcssmin==1.0.6
 rjsmin==1.1.0

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -6,6 +6,9 @@ Jinja2==2.10.1
 lxml==4.2.5
 beautifulsoup4==4.6.3
 django-sekizai==1.0.0
+-e git://github.com/mbi/django-classy-tags.git@0ddd19876e8ee6cc3b86c94dd4411fee80eb8dbf#egg=django-classy-tags
+    # django-classy-tags is a dependency of django-sekizai; use https://github.com/divio/django-classy-tags/pull/46 until
+    # the PR gets landed and django-sekizai gets updated to be compatible with django 3.0
 csscompressor==0.9.5
 rcssmin==1.0.6
 rjsmin==1.1.0

--- a/setup.py
+++ b/setup.py
@@ -137,6 +137,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Internet :: WWW/HTTP',
     ],
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     {py27,py34,py35,py36,py37,py38}-1.11.X
     {py35,py36,py37,py38}-2.1.X
     {py35,py36,py37,py38}-2.2.X
+    {py35,py36,py37,py38}-3.0.X
 [testenv]
 basepython =
     py27: python2.7
@@ -22,5 +23,6 @@ deps =
     1.11.X: Django>=1.11,<2.0
     2.1.X: Django>=2.1,<2.2
     2.2.X: Django>=2.2,<2.3
+    3.0.X: Django>=3.0,<3.1
     -r{toxinidir}/requirements/tests.txt
     django-discover-runner

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    {py27,py34,py35,py36,py37}-1.11.X
-    {py35,py36,py37}-2.1.X
-    {py35,py36,py37}-2.2.X
+    {py27,py34,py35,py36,py37,py38}-1.11.X
+    {py35,py36,py37,py38}-2.1.X
+    {py35,py36,py37,py38}-2.2.X
 [testenv]
 basepython =
     py27: python2.7
@@ -10,6 +10,7 @@ basepython =
     py35: python3.5
     py36: python3.6
     py37: python3.7
+    py38: python3.8
 usedevelop = true
 setenv =
     CPPFLAGS=-O0

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     {py27,py34,py35,py36,py37,py38}-1.11.X
     {py35,py36,py37,py38}-2.1.X
     {py35,py36,py37,py38}-2.2.X
-    {py35,py36,py37,py38}-3.0.X
+    {py36,py37,py38}-3.0.X
 [testenv]
 basepython =
     py27: python2.7


### PR DESCRIPTION
This is a subset of #965 that keeps backwards compatibility by only adding support for django 3.0 and python 3.8, instead of removing support for older versions of django and python.  

Add support for python 3.8 - Released October 2019
Add support for django 3.0 - Released December 2019

Prerequisite for #964 