### PR TITLE
Update flake8 to be compatible with newer versions of python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ testenv:
 	pip install Django
 
 flake8:
-	flake8 compressor --ignore=E501,E128,E701,E261,E301,E126,E127,E131,E402
+	flake8 compressor --ignore=E501,E128,E701,E261,E301,E126,E127,E131,E402,W503
 
 runtests:
 	coverage run --branch --source=compressor `which django-admin.py` test --settings=compressor.test_settings compressor

--- a/compressor/conf.py
+++ b/compressor/conf.py
@@ -107,8 +107,8 @@ class CompressorConf(AppConf):
         if value is None:
             value = settings.STATIC_ROOT
         if value is None:
-            raise ImproperlyConfigured('COMPRESS_ROOT defaults to ' +
-                                       'STATIC_ROOT, please define either')
+            raise ImproperlyConfigured('COMPRESS_ROOT defaults to '
+                                       + 'STATIC_ROOT, please define either')
         return os.path.normcase(os.path.abspath(value))
 
     def configure_url(self, value):

--- a/compressor/css.py
+++ b/compressor/css.py
@@ -35,8 +35,8 @@ class CssCompressor(Compressor):
         return self.split_content
 
     def output(self, *args, **kwargs):
-        if (settings.COMPRESS_ENABLED or settings.COMPRESS_PRECOMPILERS or
-                kwargs.get('forced', False)):
+        if (settings.COMPRESS_ENABLED or settings.COMPRESS_PRECOMPILERS
+                or kwargs.get('forced', False)):
             # Populate self.split_content
             self.split_contents()
             if hasattr(self, 'media_nodes'):

--- a/compressor/js.py
+++ b/compressor/js.py
@@ -26,8 +26,8 @@ class JsCompressor(Compressor):
             else:
                 extra = ''
             # Append to the previous node if it had the same attribute
-            append_to_previous = (self.extra_nodes and
-                                  self.extra_nodes[-1][0] == extra)
+            append_to_previous = (self.extra_nodes
+                                  and self.extra_nodes[-1][0] == extra)
             if append_to_previous and settings.COMPRESS_ENABLED:
                 self.extra_nodes[-1][1].split_content.append(content)
             else:
@@ -37,8 +37,8 @@ class JsCompressor(Compressor):
         return self.split_content
 
     def output(self, *args, **kwargs):
-        if (settings.COMPRESS_ENABLED or settings.COMPRESS_PRECOMPILERS or
-                kwargs.get('forced', False)):
+        if (settings.COMPRESS_ENABLED or settings.COMPRESS_PRECOMPILERS
+                or kwargs.get('forced', False)):
             self.split_contents()
             if hasattr(self, 'extra_nodes'):
                 ret = []

--- a/compressor/management/commands/mtime_cache.py
+++ b/compressor/management/commands/mtime_cache.py
@@ -51,8 +51,8 @@ class Command(BaseCommand):
             options['ignore_patterns'] = ignore_patterns
         self.ignore_patterns = ignore_patterns
 
-        if ((options['add'] and options['clean']) or
-                (not options['add'] and not options['clean'])):
+        if ((options['add'] and options['clean'])
+                or (not options['add'] and not options['clean'])):
             raise CommandError('Please specify either "--add" or "--clean"')
 
         if not settings.COMPRESS_MTIME_DELAY:

--- a/compressor/offline/jinja2.py
+++ b/compressor/offline/jinja2.py
@@ -114,10 +114,10 @@ class Jinja2Parser(object):
 
     def walk_nodes(self, node, block_name=None, context=None):
         for node in self.get_nodelist(node):
-            if (isinstance(node, CallBlock) and
-              isinstance(node.call, Call) and
-              isinstance(node.call.node, ExtensionAttribute) and
-              node.call.node.identifier == self.COMPRESSOR_ID):
+            if (isinstance(node, CallBlock)
+              and isinstance(node.call, Call)
+              and isinstance(node.call.node, ExtensionAttribute)
+              and node.call.node.identifier == self.COMPRESSOR_ID):
                 node.call.node.name = '_compress_forced'
                 yield node
             else:

--- a/compressor/parser/lxml.py
+++ b/compressor/parser/lxml.py
@@ -28,7 +28,7 @@ class LxmlParser(ParserBase):
             # soupparser uses Beautiful Soup 3 which does not run on python 3.x
             try:
                 from lxml.html import soupparser
-            except ImportError as err:
+            except ImportError:
                 soupparser = None
             except Exception as err:
                 raise ParserError("Error while initializing parser: %s" % err)

--- a/compressor/templatetags/compress.py
+++ b/compressor/templatetags/compress.py
@@ -55,8 +55,8 @@ class CompressorMixin(object):
         but can be overridden to completely disable compression for
         a subclass, for instance.
         """
-        return (settings.COMPRESS_ENABLED and
-                settings.COMPRESS_OFFLINE) or forced
+        return (settings.COMPRESS_ENABLED
+                and settings.COMPRESS_OFFLINE) or forced
 
     def render_offline(self, context):
         """
@@ -97,8 +97,8 @@ class CompressorMixin(object):
             return self.render_offline(context)
 
         # Take a shortcut if we really don't have anything to do
-        if (not settings.COMPRESS_ENABLED and
-                not settings.COMPRESS_PRECOMPILERS and not forced):
+        if (not settings.COMPRESS_ENABLED
+                and not settings.COMPRESS_PRECOMPILERS and not forced):
             return self.get_original_content(context)
 
         name = name or getattr(self, 'name', None)

--- a/compressor/tests/test_parsers.py
+++ b/compressor/tests/test_parsers.py
@@ -58,8 +58,8 @@ class Html5LibParserTests(ParserTestCase, CompressorTestCase):
             None,
             '<style type="text/css">p { border:5px solid green;}</style>',
         )
-        self.assertEqual(out1, split[1][:3] +
-                         (self.css_node.parser.elem_str(split[1][3]),))
+        self.assertEqual(out1, split[1][:3]
+                         + (self.css_node.parser.elem_str(split[1][3]),))
         out2 = (
             SOURCE_FILE,
             os.path.join(settings.COMPRESS_ROOT, 'css', 'two.css'),
@@ -133,8 +133,8 @@ class BeautifulSoupParserTests(ParserTestCase, CompressorTestCase):
             None,
             '<style type="text/css">p { border:5px solid green;}</style>',
         )
-        self.assertEqual(out1, split[1][:3] +
-                         (self.css_node.parser.elem_str(split[1][3]),))
+        self.assertEqual(out1, split[1][:3]
+                         + (self.css_node.parser.elem_str(split[1][3]),))
         out2 = (
             SOURCE_FILE,
             os.path.join(settings.COMPRESS_ROOT, 'css', 'two.css'),

--- a/compressor/tests/test_templatetags.py
+++ b/compressor/tests/test_templatetags.py
@@ -223,8 +223,8 @@ class PrecompilerTemplatetagTestCase(TestCase):
             <script type="text/coffeescript"># this is a comment.</script>
             <script type="text/javascript"># this too is a comment.</script>
             {% endcompress %}"""
-        out = (script('# this is a comment.\n') + '\n' +
-               script('# this too is a comment.', scripttype="text/javascript"))
+        out = (script('# this is a comment.\n') + '\n'
+               + script('# this too is a comment.', scripttype="text/javascript"))
         self.assertEqual(out, render(template, self.context))
 
     @override_settings(COMPRESS_ENABLED=False)

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,4 +1,4 @@
-flake8==3.5.0
+flake8==3.7.9
 coverage==4.5.1
 html5lib==1.0.1
 mock==2.0.0


### PR DESCRIPTION
This is a requirement for #967.  Python 3.8 breaks flake8 3.5.0, so upgrading flake8 to 3.7.9 makes testing compatible with python 3.8, but it drags along a bunch of new flake issues, particularly the fun style flip-flop from https://lintlyci.github.io/Flake8Rules/rules/W503.html.