### PR TITLE
Remove django.utils.six

### DIFF
--- a/compressor/tests/test_mtime_cache.py
+++ b/compressor/tests/test_mtime_cache.py
@@ -1,7 +1,7 @@
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
-from django.utils.six import StringIO
+from six import StringIO
 
 
 class TestMtimeCacheCommand(TestCase):


### PR DESCRIPTION
Django 3.0 removed `django.utils.six`.  
Ref: https://docs.djangoproject.com/en/dev/releases/3.0/#removed-private-python-2-compatibility-apis