### PR TITLE
Allow six to be upgraded

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -144,6 +144,6 @@ setup(
         'django-appconf >= 1.0',
         'rcssmin == 1.0.6',
         'rjsmin == 1.1.0',
-        'six == 1.12.0',
+        'six >= 1.12.0',
     ],
 )


### PR DESCRIPTION
I see there's an ongoing discussion about dropping Python 2 support altogether, so feel free to ignore this PR if that's the way forward.