### PR TITLE
Update django-appconf

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ setup(
     ],
     zip_safe=False,
     install_requires=[
-        'django-appconf >= 1.0',
+        'django-appconf >= 1.0.3',
         'rcssmin == 1.0.6',
         'rjsmin == 1.1.0',
         'six >= 1.12.0',


### PR DESCRIPTION
Based on @cuu508's comment in https://github.com/django-compressor/django-compressor/issues/963#issuecomment-566916155

`django-appconf >= 1.0.3` is needed for django 3.0 compatibility