### PR TITLE
Replace force_text with force_str

### DIFF
--- a/compressor/cache.py
+++ b/compressor/cache.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 from django.core.cache import caches
 from django.core.files.base import ContentFile
-from django.utils.encoding import force_text, smart_bytes
+from django.utils.encoding import force_str, smart_bytes
 from django.utils.functional import SimpleLazyObject
 
 from compressor.conf import settings
@@ -25,11 +25,11 @@ def get_hexdigest(plaintext, length=None):
 
 
 def simple_cachekey(key):
-    return 'django_compressor.%s' % force_text(key)
+    return 'django_compressor.%s' % force_str(key)
 
 
 def socket_cachekey(key):
-    return 'django_compressor.%s.%s' % (socket.gethostname(), force_text(key))
+    return 'django_compressor.%s.%s' % (socket.gethostname(), force_str(key))
 
 
 def get_cachekey(*args, **kwargs):


### PR DESCRIPTION
### Description

This PR fixes the following deprecation warning:
```
RemovedInDjango40Warning: force_text() is deprecated in favor of force_str()
```
`force_text` is deprecated in Django 3 and should be replaced with `force_str` ([release notes of Django 3](https://docs.djangoproject.com/en/dev/releases/3.0/#features-deprecated-in-3-0)).