### PR TITLE
#979 - Correctly handle relative paths in "extends" tags.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ compressor/tests/static/custom
 compressor/tests/static/js/066cd253eada.js
 compressor/tests/static/js/d728fc7f9301.js
 compressor/tests/static/js/74e158ccb432.js
+compressor/tests/static/js/8a0fed36c317.js
 compressor/tests/static/test.txt*
 
 dist

--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -127,7 +127,7 @@ class Command(BaseCommand):
 
             for path in paths:
                 for root, dirs, files in os.walk(path, followlinks=follow_links):
-                    templates.update(os.path.join(root, name)
+                    templates.update(os.path.relpath(os.path.join(root, name), path)
                         for name in files if not name.startswith('.') and
                             any(fnmatch(name, "*%s" % glob) for glob in extensions))
         elif engine == 'jinja2':

--- a/compressor/tests/test_templates/test_extends_relative/base.html
+++ b/compressor/tests/test_templates/test_extends_relative/base.html
@@ -1,0 +1,15 @@
+{% spaceless %}
+{% block js %}
+    <script type="text/javascript">
+        alert("test using block.super");
+    </script>
+{% endblock %}
+
+{% block css %}
+    <style type="text/css">
+        body {
+            background: red;
+        }
+    </style>
+{% endblock %}
+{% endspaceless %}

--- a/compressor/tests/test_templates/test_extends_relative/test_compressor_offline.html
+++ b/compressor/tests/test_templates/test_extends_relative/test_compressor_offline.html
@@ -1,0 +1,13 @@
+{% extends "./base.html" %}
+{% load compress %}
+
+{% block js %}{% spaceless %}
+	{% compress js %}
+		{{ block.super }}
+	    <script type="text/javascript">
+	        alert("this alert shouldn't be alone!");
+	    </script>
+	{% endcompress %}
+{% endspaceless %}{% endblock %}
+
+{% block css %}{% endblock %}


### PR DESCRIPTION
For django-compressor/django-compressor#979.

Django 1.10 introduced relative paths for the extends tag, for example `{% extends '../base.html' %}`. These fail to resolve during offline compression and compress catches a `TemplateDoesNotExist` exception.

This commit fixes the issue by passing a relative path to `templates.update`.