### PR TITLE
add support for type=module & attr nomodule

### DIFF
--- a/compressor/base.py
+++ b/compressor/base.py
@@ -365,6 +365,12 @@ class Compressor:
         """
         return self.output_file(mode, content, forced, basename)
 
+    def output_module(self, mode, content, forced=False, basename=None):
+        """
+        The output method that returns <script> with type="module"
+        """
+        return self.output_file(mode, content, forced, basename)
+
     def render_output(self, mode, context=None):
         """
         Renders the compressor output with the appropriate template for

--- a/compressor/js.py
+++ b/compressor/js.py
@@ -19,12 +19,19 @@ class JsCompressor(Compressor):
             else:
                 content = (SOURCE_HUNK, self.parser.elem_content(elem), None, elem)
             self.split_content.append(content)
+
+            # one or the other with these 2
             if 'async' in attribs:
                 extra = ' async'
             elif 'defer' in attribs:
                 extra = ' defer'
             else:
                 extra = ''
+
+            # optional additional valid script attribute
+            if 'nomodule' in attribs:
+                extra += ' nomodule'
+
             # Append to the previous node if it had the same attribute
             append_to_previous = (self.extra_nodes
                                   and self.extra_nodes[-1][0] == extra)

--- a/compressor/templates/compressor/css_module.html
+++ b/compressor/templates/compressor/css_module.html
@@ -1,0 +1,1 @@
+<link rel="stylesheet" href="{{ compressed.url }}" type="text/css"{% if compressed.media %} media="{{ compressed.media }}"{% endif %}>

--- a/compressor/templates/compressor/js_module.html
+++ b/compressor/templates/compressor/js_module.html
@@ -1,0 +1,1 @@
+<script type="module" src="{{ compressed.url }}"{{ compressed.extra }}></script>

--- a/compressor/templatetags/compress.py
+++ b/compressor/templatetags/compress.py
@@ -12,7 +12,8 @@ register = template.Library()
 OUTPUT_FILE = 'file'
 OUTPUT_INLINE = 'inline'
 OUTPUT_PRELOAD = 'preload'
-OUTPUT_MODES = (OUTPUT_FILE, OUTPUT_INLINE, OUTPUT_PRELOAD)
+OUTPUT_MODULE = 'module'
+OUTPUT_MODES = (OUTPUT_FILE, OUTPUT_INLINE, OUTPUT_PRELOAD, OUTPUT_MODULE)
 
 
 class CompressorMixin:
@@ -158,7 +159,7 @@ def compress(parser, token):
 
     Syntax::
 
-        {% compress <js/css> [<file/inline> [block_name]] %}
+        {% compress <js/css> [<file/inline/preload/module> [block_name]] %}
         <html of inline or linked JS/CSS>
         {% endcompress %}
 
@@ -183,8 +184,8 @@ def compress(parser, token):
         mode = args[2]
         if mode not in OUTPUT_MODES:
             raise template.TemplateSyntaxError(
-                "%r's second argument must be '%s' or '%s'." %
-                (args[0], OUTPUT_FILE, OUTPUT_INLINE))
+                "%r's second argument must be '%s', '%s', '%s' or '%s'." %
+                (args[0], OUTPUT_FILE, OUTPUT_INLINE, OUTPUT_PRELOAD, OUTPUT_MODULE))
     else:
         mode = OUTPUT_FILE
     if len(args) == 4:

--- a/compressor/tests/test_base.py
+++ b/compressor/tests/test_base.py
@@ -226,6 +226,11 @@ class CompressorTestCase(SimpleTestCase):
         out = '<link rel="preload" href="/static/CACHE/js/8a0fed36c317.js" as="script" />'
         self.assertEqual(out, self.js_node.output(mode="preload"))
 
+    def test_js_module_output(self):
+        # this needs to have the same hash as in the test above
+        out = '<script type="module" src="/static/CACHE/js/8a0fed36c317.js"></script>'
+        self.assertEqual(out, self.js_node.output(mode="module"))
+
     def test_js_override_url(self):
         self.js_node.context.update({'url': 'This is not a url, just a text'})
         out = '<script src="/static/CACHE/js/8a0fed36c317.js"></script>'
@@ -347,7 +352,7 @@ class CacheBackendTestCase(CompressorTestCase):
 class JsAsyncDeferTestCase(SimpleTestCase):
     def setUp(self):
         self.js = """\
-            <script src="/static/js/one.js" type="text/javascript"></script>
+            <script nomodule src="/static/js/one.js" type="text/javascript"></script>
             <script src="/static/js/two.js" type="text/javascript" async></script>
             <script src="/static/js/three.js" type="text/javascript" defer></script>
             <script type="text/javascript">obj.value = "value";</script>
@@ -361,8 +366,10 @@ class JsAsyncDeferTestCase(SimpleTestCase):
                 return 'async'
             if tag.has_attr('defer'):
                 return 'defer'
+            if tag.has_attr('nomodule'):
+                return 'nomodule'
         js_node = JsCompressor('js', self.js)
-        output = [None, 'async', 'defer', None, 'async', None]
+        output = ['nomodule', 'async', 'defer', None, 'async', None]
         scripts = make_soup(js_node.output()).find_all('script')
         attrs = [extract_attr(s) for s in scripts]
         self.assertEqual(output, attrs)

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -6,7 +6,7 @@ Usage
 .. code-block:: django
 
     {% load compress %}
-    {% compress <js/css> [<file/inline/preload> [block_name]] %}
+    {% compress <js/css> [<file/inline/preload/nomodule> [block_name]] %}
     <html of inline or linked JS/CSS>
     {% endcompress %}
 
@@ -61,6 +61,33 @@ Result:
     .. code-block:: django
 
         <link rel="preload" href="/static/CACHE/js/d01466eb4fc6.js" as="script" />
+
+
+
+ES5 nomodule & ES6 type="module"
+
+Adding the ``nomodule`` attribute will generate be passed attribute to the script tag for the compressed resource in the template.
+Adding the ``module`` parameter will generate the script tag with type="module" for the compressed resource in the template:
+
+    .. code-block:: django
+
+    {% compress js %}
+        <!-- ES5 must be in separate compress (split types) -->
+        <script nomodule async src="static/js/es5.js"></script>
+    {% endcompress %}
+
+    {% compress js module %}
+        <!-- ES6 and above JS -->
+        <script async src="static/js/es6.js"></script>
+    {% endcompress %} 
+
+Result:
+
+    .. code-block:: django
+
+        <script nomodule async src="/static/CACHE/js/d01466eb4fc6.js"></script>
+	<script type="module" async src="/static/CACHE/js/d0246230b4fc6.js"></script>
+
 
 
 Specifying a ``block_name`` will change the output filename. It can also be


### PR DESCRIPTION
Add support for the attribute 'nomodule' on `<script>` tags inside `JsCompressor`
Add support for  output mode 'module' for script tag with `<script type="module">` in `base.py` and supporting HTML Template files
Fix error message for 'preload' output mode and add new 'module' output mode
Add test for module output mode
Add to attributes test for nomodule attribute

potentially closes:
https://github.com/django-compressor/django-compressor/issues/1001