### PR TITLE
Remove deprecated providing_args in signals

### DIFF
--- a/compressor/signals.py
+++ b/compressor/signals.py
@@ -1,4 +1,4 @@
 import django.dispatch
 
 
-post_compress = django.dispatch.Signal(providing_args=['type', 'mode', 'context'])
+post_compress = django.dispatch.Signal()


### PR DESCRIPTION
Ref: https://docs.djangoproject.com/en/dev/internals/deprecation/