### PR TITLE
added custom sekizai compressors for js and css

### DIFF
--- a/compressor/contrib/sekizai.py
+++ b/compressor/contrib/sekizai.py
@@ -61,3 +61,15 @@ def compress(context, data, name):
         compressable_node.render(context=context),
         deferred_node.get_original_content(context=context),
     ])
+
+def compressjs(context, data, name):
+    """
+    Compress custom sekizai blocks with the 'js' compressor
+    """
+    return compress(context, data, 'js')
+
+def compresscss(context, data, name):
+    """
+    Compress custom sekizai blocks with the 'js' compressor
+    """
+    return compress(context, data, 'css')


### PR DESCRIPTION
Hi guys,
first of all, thanks for the good work.
Now my problem: When used with djangocms, I can't use the normal "js" and "css" sekizai tags because those include the toolbar js, which changes with every request. This - of course - creates a new cache file with every request, which is really bad if several people create content in a djangocms system every day.
To help myself, I created a compressjs and compresscss sekizai postprocessor which override the block name, so it's possible to use a custom block for my js. Might come in handy, at least in my use case. I can confirm that with djangocms 3.8, this is still an issue.