### PR TITLE
added compress_options to sekizai postprocessor

### DIFF
--- a/compressor/contrib/sekizai.py
+++ b/compressor/contrib/sekizai.py
@@ -12,6 +12,7 @@ from compressor.conf import settings
 from compressor.utils import get_class
 
 from django.template.base import TextNode
+import re
 
 
 def compress(context, data, name):
@@ -19,12 +20,26 @@ def compress(context, data, name):
     Data is the string from the template (the list of js files in this case)
     Name is either 'js' or 'css' (the sekizai namespace)
     Basically passes the string through the {% compress 'js' %} template tag
+    Alternatively, if the block can contain a html comment structured like:
+    <!-- compress_options [params] -->
+    params can be: one of ['js','css'] and one or multiple of ['file','preload','inline']
     """
     # separate compressible from uncompressable files
+    options = []
+    kind = name
+    m = re.search('<!-- *compress_options *([a-z ]+?) *-->', data)
+    if m is not None:
+        options_clean = re.sub(' +', ' ', m.groups()[0])
+        options = set(options_clean.split(' '))
+        if 'js' in options and 'css' not in options:
+            kind = 'js'
+        elif 'css' in options and 'js' not in options:
+            kind = 'css'
+
     parser = get_class(settings.COMPRESS_PARSER)(data)
     js_compressor, css_compressor = Compressor('js'), Compressor('css')
     compressable_elements, expanded_elements, deferred_elements = [], [], []
-    if name == 'js':
+    if kind == 'js':
         for elem in parser.js_elems():
             attribs = parser.elem_attribs(elem)
             try:
@@ -37,7 +52,7 @@ def compress(context, data, name):
                     expanded_elements.append(elem)
             else:
                 compressable_elements.append(elem)
-    elif name == 'css':
+    elif kind == 'css':
         for elem in parser.css_elems():
             attribs = parser.elem_attribs(elem)
             try:
@@ -49,15 +64,28 @@ def compress(context, data, name):
                 compressable_elements.append(elem)
 
     # reconcatenate them
+    results = []
     data = ''.join(parser.elem_str(e) for e in expanded_elements)
-    expanded_node = CompressorNode(nodelist=TextNode(data), kind=name, mode='file')
-    data = ''.join(parser.elem_str(e) for e in compressable_elements)
-    compressable_node = CompressorNode(nodelist=TextNode(data), kind=name, mode='file')
-    data = ''.join(parser.elem_str(e) for e in deferred_elements)
-    deferred_node = CompressorNode(nodelist=TextNode(data), kind=name, mode='file')
+    expanded_node = CompressorNode(nodelist=TextNode(data), kind=kind, mode='file')
+    results.append(expanded_node.get_original_content(context=context))
 
-    return '\n'.join([
-        expanded_node.get_original_content(context=context),
-        compressable_node.render(context=context),
-        deferred_node.get_original_content(context=context),
-    ])
+    if 'file' in options or len(options) == 0:
+        data = ''.join(parser.elem_str(e) for e in compressable_elements)
+        compressable_node = CompressorNode(nodelist=TextNode(data), kind=kind, mode='file')
+        results.append(compressable_node.render(context=context))
+
+    if 'preload' in options:
+        data = ''.join(parser.elem_str(e) for e in compressable_elements)
+        compressable_node = CompressorNode(nodelist=TextNode(data), kind=kind, mode='preload')
+        results.append(compressable_node.render(context=context))
+
+    if 'inline' in options:
+        data = ''.join(parser.elem_str(e) for e in compressable_elements)
+        compressable_node = CompressorNode(nodelist=TextNode(data), kind=kind, mode='inline')
+        results.append(compressable_node.render(context=context))
+
+    data = ''.join(parser.elem_str(e) for e in deferred_elements)
+    deferred_node = CompressorNode(nodelist=TextNode(data), kind=kind, mode='file')
+    results.append(deferred_node.get_original_content(context=context))
+
+    return '\n'.join(results)


### PR DESCRIPTION
Hi guys,
after I cancelled my last PR due to missing features, I now added an improved way to configure the sekizai postprocessor. Specifically, I missed a way to

- compress custom-named blocks, since the old postprocessor only supported the names "js" and "css"
- generate preload or inline compress blocks

My idea was that a sekizai block can now contain an html comment &lt;!-- compress_options [params] --&gt;, where [params] can be

- one of "js" or "css"
- one or multiple of "file", "preload" and "inline"

If the comment is missing, the behavior of the postprocessor doesn't change. This way, I can for example include &lt;!-- compress_options css file preload --&gt; in my css sekizai block (with {% addtoblock "css" %}), and the postprocessor generates a compressed file and also the correct preload link.

If I should change anything, let me know.

Best regards!