### PR TITLE
Fix coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,4 +46,6 @@ jobs:
           pip install tox
           python setup.py install_egg_info
       - run: tox -e ${{ matrix.versions.toxenv }}
-      - uses: codecov/codecov-action@v1.3.2
+      - run: |
+          pip install codecov
+          codecov

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,5 +1,5 @@
 flake8==3.7.9
-coverage==4.5.1
+coverage==5.5
 html5lib==1.0.1
 mock==2.0.0
 Jinja2==2.10.1


### PR DESCRIPTION
I noticed in recent GH action build logs that [codecov couldn't find the coverage data](https://github.com/django-compressor/django-compressor/runs/2318689313?check_suite_focus=true#step:6:37). thought I broke this with #1046 but it seems like it was broken already (last data is a year old?).

When I ran it again with the `codecov` python lib, there was another error that seemed to indicate we should update coverage to v5:

> Error running `['/opt/hostedtoolcache/Python/3.5.10/x64/bin/python', '-m', 'coverage', 'xml', '-i']`: returncode=1, output=b"Couldn't use data file '/home/runner/work/django-compressor/django-compressor/.coverage': Looks like a coverage 4.x data file. Are you mixing versions of coverage?\n"

From my testing, it seems like it should do the trick.