### PR TITLE
Update Django/Python support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,6 @@ jobs:
       matrix:
         versions:
           - python: 3.5
-            toxenv: py35-1.11.X
-          - python: 3.6
-            toxenv: py36-1.11.X
-          - python: 3.7
-            toxenv: py37-1.11.X
-          - python: 3.8
-            toxenv: py38-1.11.X
-          - python: 3.5
             toxenv: py35-2.2.X
           - python: 3.6
             toxenv: py36-2.2.X
@@ -29,12 +21,35 @@ jobs:
             toxenv: py37-2.2.X
           - python: 3.8
             toxenv: py38-2.2.X
+          - python: 3.9
+            toxenv: py39-2.2.X
+
           - python: 3.6
             toxenv: py36-3.0.X
           - python: 3.7
             toxenv: py37-3.0.X
           - python: 3.8
             toxenv: py38-3.0.X
+          - python: 3.9
+            toxenv: py39-3.0.X
+
+          - python: 3.6
+            toxenv: py36-3.1.X
+          - python: 3.7
+            toxenv: py37-3.1.X
+          - python: 3.8
+            toxenv: py38-3.1.X
+          - python: 3.9
+            toxenv: py39-3.1.X
+
+          - python: 3.6
+            toxenv: py36-3.2.X
+          - python: 3.7
+            toxenv: py37-3.2.X
+          - python: 3.8
+            toxenv: py38-3.2.X
+          - python: 3.9
+            toxenv: py39-3.2.X
 
     runs-on: ubuntu-latest
     steps:

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -5,10 +5,7 @@ mock==2.0.0
 Jinja2==2.10.1
 lxml==4.6.2
 beautifulsoup4==4.6.3
-django-sekizai==1.0.0
--e git://github.com/mbi/django-classy-tags.git@0ddd19876e8ee6cc3b86c94dd4411fee80eb8dbf#egg=django-classy-tags
-    # django-classy-tags is a dependency of django-sekizai; use https://github.com/divio/django-classy-tags/pull/46 until
-    # the PR gets landed and django-sekizai gets updated to be compatible with django 3.0
+django-sekizai==2.0.0
 csscompressor==0.9.5
 rcssmin==1.0.6
 rjsmin==1.1.0

--- a/setup.py
+++ b/setup.py
@@ -134,6 +134,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Internet :: WWW/HTTP',
     ],
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,16 @@
 [tox]
 envlist =
-    {py35,py36,py37,py38}-1.11.X
-    {py35,py36,py37,py38}-2.2.X
-    {py36,py37,py38}-3.0.X
+    {py35,py36,py37,py38,py39}-2.2.X
+    {py36,py37,py38,py39}-3.0.X
+    {py36,py37,py38,py39}-3.1.X
+    {py36,py37,py38,py39}-3.2.X
 [testenv]
 basepython =
     py35: python3.5
     py36: python3.6
     py37: python3.7
     py38: python3.8
+    py39: python3.9
 usedevelop = true
 setenv =
     CPPFLAGS=-O0
@@ -17,8 +19,9 @@ commands =
     django-admin.py --version
     make test
 deps =
-    1.11.X: Django>=1.11,<2.0
     2.2.X: Django>=2.2,<2.3
     3.0.X: Django>=3.0,<3.1
+    3.1.X: Django>=3.1,<3.2
+    3.2.X: Django>=3.2,<4.0
     -r{toxinidir}/requirements/tests.txt
     django-discover-runner


### PR DESCRIPTION
- Add Python 3.9
- Add Django 3.1 and 3.2

However, to achieve that, we also need to:

- Bump django-sekizai to v2 (earlier versions don't support Django 3.1)
- Drop support for Django 1.11 ([django-sekizai 2 requires Django 2.2 or higher](https://github.com/django-cms/django-sekizai/blob/e12d8159bc1769a36472408e5efe97bbf65de9f9/setup.py#L8))

According to [this page](https://www.djangoproject.com/download/), we've passed the end of extended support for Django 1.11 by more than a year (April 1, 2020), so I think it should be ok to make this breaking change.