### PR TITLE
Set cwd as an attribute of CompilerFilter.

### DIFF
--- a/compressor/filters/base.py
+++ b/compressor/filters/base.py
@@ -117,10 +117,10 @@ class CompilerFilter(FilterBase):
         settings.FILE_CHARSET if settings.is_overridden('FILE_CHARSET') else
         'utf-8'
     )
+    cwd = None
 
     def __init__(self, content, command=None, **kwargs):
         super().__init__(content, **kwargs)
-        self.cwd = None
 
         if command:
             self.command = command

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -15,6 +15,7 @@ v3.0 (2021-??-??)
 - Fix various deprecation warnings
 - Add ability to pass a logger to various classes & methods
 - Removed deprecated ``COMPRESS_JS_FILTERS`` and ``COMPRESS_CSS_FILTERS`` settings
+- In class CompilerFilter set cwd as an attribute so that it's easier to override in child classes.
 
 v2.4.1 (2021-04-17)
 -----------------


### PR DESCRIPTION
Currently the `cwd` is set to None in the __init__ of the CompilerFilter class. I have moved it to become an attribute - this makes it a bit more convenient to override in child classes.