### PR TITLE
Update classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,10 +127,10 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Framework :: Django',
-        'Framework :: Django:: 1.11',
         'Framework :: Django:: 2.2',
         'Framework :: Django:: 3.0',
         'Framework :: Django:: 3.1',
+        'Framework :: Django:: 3.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',


### PR DESCRIPTION
As far as I can tell django-compressor isn't tested on 1.11 anymore, but it is tested on Django 3.2