### PR TITLE
Used raw STATIC_URL value in get_offline_hexdigest().

### DIFF
--- a/compressor/cache.py
+++ b/compressor/cache.py
@@ -52,13 +52,7 @@ def get_mtime_cachekey(filename):
 def get_offline_hexdigest(render_template_string):
     return get_hexdigest(
         # Make the hexdigest determination independent of STATIC_URL
-        render_template_string.replace(
-            # Cast ``settings.STATIC_URL`` to a string to allow it to be
-            # a string-alike object to e.g. add ``SCRIPT_NAME`` WSGI param
-            # as a *path prefix* to the output URL.
-            # See https://code.djangoproject.com/ticket/25598.
-            str(settings.STATIC_URL), ''
-        )
+        render_template_string.replace(settings.STATIC_URL, '')
     )
 
 


### PR DESCRIPTION
When script prefix was set replacement in the original content was incorrect.

e.g. looking for `/app/prefix/static/`, which is not present, rather than
`/static/` which is.


This is a look at fixing the two CI errors revealed in #1072.

Without this change the [subsequent loops through the test case with a script prefix](https://github.com/django-compressor/django-compressor/blob/b855c686e5a463802a7b4a6d323a33ec42fed8a9/compressor/tests/test_offline.py#L829) generated the [wrong key in `compress`](https://github.com/django-compressor/django-compressor/blob/b855c686e5a463802a7b4a6d323a33ec42fed8a9/compressor/templatetags/compress.py#L69). 

I'm not 100% sure of what's led to the change in behaviour but the [linked Django ticket was fixed](https://code.djangoproject.com/ticket/25598) since this code was implemented, and likely it's just been revealed by updating the CI matrix. 🤔 (It was only part of Django 3.1 though, so that doesn't account for 2.2 and 3.0) 

Anyhow, passes locally; let's see what it says... 🤞😜