### PR TITLE
Updated CI matrix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,15 +25,6 @@ jobs:
             toxenv: py39-2.2.X
 
           - python: 3.6
-            toxenv: py36-3.0.X
-          - python: 3.7
-            toxenv: py37-3.0.X
-          - python: 3.8
-            toxenv: py38-3.0.X
-          - python: 3.9
-            toxenv: py39-3.0.X
-
-          - python: 3.6
             toxenv: py36-3.1.X
           - python: 3.7
             toxenv: py37-3.1.X

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         versions:
-          - python: 3.5
-            toxenv: py35-2.2.X
           - python: 3.6
             toxenv: py36-2.2.X
           - python: 3.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,15 @@ jobs:
             toxenv: py38-3.2.X
           - python: 3.9
             toxenv: py39-3.2.X
+          - python: "3.10"
+            toxenv: py310-3.2.X
 
           - python: 3.8
             toxenv: py38-4.0.X
           - python: 3.9
             toxenv: py39-4.0.X
-
+          - python: "3.10"
+            toxenv: py310-4.0.X
 
     runs-on: ubuntu-latest
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
 envlist =
-    {py35,py36,py37,py38,py39}-2.2.X
+    {py36,py37,py38,py39}-2.2.X
     {py36,py37,py38,py39}-3.1.X
     {py36,py37,py38,py39}-3.2.X
     {py38,py39}-4.0.X
 [testenv]
 basepython =
-    py35: python3.5
     py36: python3.6
     py37: python3.7
     py38: python3.8

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
     {py35,py36,py37,py38,py39}-2.2.X
-    {py36,py37,py38,py39}-3.0.X
     {py36,py37,py38,py39}-3.1.X
     {py36,py37,py38,py39}-3.2.X
     {py38,py39}-4.0.X
@@ -21,7 +20,6 @@ commands =
     make test
 deps =
     2.2.X: Django>=2.2,<2.3
-    3.0.X: Django>=3.0,<3.1
     3.1.X: Django>=3.1,<3.2
     3.2.X: Django>=3.2,<4.0
     4.0.X: Django>=4.0a1,<5.0

--- a/tox.ini
+++ b/tox.ini
@@ -2,14 +2,15 @@
 envlist =
     {py36,py37,py38,py39}-2.2.X
     {py36,py37,py38,py39}-3.1.X
-    {py36,py37,py38,py39}-3.2.X
-    {py38,py39}-4.0.X
+    {py36,py37,py38,py39,py310}-3.2.X
+    {py38,py39,,py310}-4.0.X
 [testenv]
 basepython =
     py36: python3.6
     py37: python3.7
     py38: python3.8
     py39: python3.9
+    py310: python3.10
 usedevelop = true
 setenv =
     CPPFLAGS=-O0


### PR DESCRIPTION
Django 3.0 was end-of-life in 4/21.

This just simplifies the test matrix. 

Update: 

* Dropped PY35
* Added PY310