### PR TITLE
update rjsmin to version 1.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -147,6 +147,6 @@ setup(
     install_requires=[
         'django-appconf >= 1.0.3',
         'rcssmin == 1.0.6',
-        'rjsmin == 1.1.0',
+        'rjsmin == 1.2.0',
     ],
 )


### PR DESCRIPTION
rjsmin is updated to 1.2.0 to [fix a bug that incorrectly compresses some (mostly minified) `.js` files](https://github.com/ndparker/rjsmin/issues/17). 