### PR TITLE
Create .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,31 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+    # You can also specify other tool versions:
+    # nodejs: "16"
+    # rust: "1.55"
+    # golang: "1.17"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+formats:
+   - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - method: pip
+     path: .
+   - requirements: requirements/tests.txt

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -2,6 +2,7 @@ Changelog
 =========
 
 v3.0 (2021-12-12)
+-----------------
 
 `Full Changelog <https://github.com/django-compressor/django-compressor/compare/2.4.1...3.0>`_
 
@@ -19,7 +20,7 @@ v3.0 (2021-12-12)
 - Fix offline compression race condition, which could result in incomplete manifest
 
 v2.4.1 (2021-04-17)
------------------
+-------------------
 
 `Full Changelog <https://github.com/django-compressor/django-compressor/compare/2.4...2.4.1>`_
 


### PR DESCRIPTION
Congrats on the big 3.0! I noticed the docs weren't building with an Python 2.7 backend error. I've fixed it by configuring it to the Python 3 backend. I've also enabled running doc builds automatically on pull-requests.

This PR helps making configuration in case of build errors easier going forward.

Docs: https://docs.readthedocs.io/en/stable/config-file/v2.html
