### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,9 @@ setup(
     name="django_compressor",
     version=find_version("compressor", "__init__.py"),
     url='https://django-compressor.readthedocs.io/en/latest/',
+    project_urls={
+        'Source': 'https://github.com/django-compressor/django-compressor',
+    },
     license='MIT',
     description="Compresses linked and inline JavaScript or CSS into single cached files.",
     long_description=read('README.rst'),


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)