### PR TITLE
Implemented NoDuplicatesStorageProxy, for use in "compress" command

### DIFF
--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -16,6 +16,8 @@ from django.utils.encoding import smart_str
 from django.template.loader import get_template  # noqa Leave this in to preload template locations
 from django.template import engines
 
+
+from compressor import storage
 from compressor.cache import get_offline_hexdigest, write_offline_manifest, get_offline_manifest
 from compressor.conf import settings
 from compressor.exceptions import (OfflineGenerationError, TemplateSyntaxError,
@@ -191,6 +193,9 @@ class Command(BaseCommand):
         nodes_count = 0
         offline_manifest = OrderedDict()
         errors = []
+        # Replace compressor.storage.default_storage with a proxy object
+        # which will filter out duplicate save() calls
+        storage.default_storage = storage.NoDuplicatesStorageProxy()
 
         for context_dict in contexts:
             compressor_nodes = OrderedDict()

--- a/compressor/tests/test_offline.py
+++ b/compressor/tests/test_offline.py
@@ -362,6 +362,23 @@ class OfflineCompressSkipDuplicatesTestCase(OfflineTestCaseMixin, TestCase):
             rendered_template, self._render_result(result * 2, ''))
 
 
+class OfflineCompressDuplicateOutputTestCase(OfflineTestCaseMixin, TestCase):
+    templates_dir = 'test_duplicate_output'
+
+    def _test_offline(self, engine, verbosity=0):
+        from compressor.storage import CompressorFileStorage
+        with patch.object(CompressorFileStorage, "save") as mock_save:
+            count, result = CompressCommand().handle_inner(
+                engines=[engine], verbosity=verbosity)
+
+            # The template has two {% compress %} tags with different contents,
+            # but they both render the same output.
+            # There should have been two storage.save() calls:
+            # - a single js file,
+            # - and the offline manifest
+            self.assertEqual(mock_save.call_count, 2)
+
+
 class SuperMixin:
     # Block.super not supported for Jinja2 yet.
     engines = ('django',)

--- a/compressor/tests/test_templates/test_duplicate_output/test_compressor_offline.html
+++ b/compressor/tests/test_templates/test_duplicate_output/test_compressor_offline.html
@@ -1,0 +1,11 @@
+{% load compress static %}
+
+{% compress js %}
+    <script type="text/javascript" src="{% static "js/one.js" %}"></script>
+{% endcompress %}
+
+{% compress js %}
+    <script
+        type="text/javascript"
+        src="{% static "js/one.js" %}"></script>
+{% endcompress %}

--- a/compressor/tests/test_templates_jinja2/test_duplicate_output/test_compressor_offline.html
+++ b/compressor/tests/test_templates_jinja2/test_duplicate_output/test_compressor_offline.html
@@ -1,0 +1,9 @@
+{% compress js %}
+    <script type="text/javascript" src="{{ url_for('static', filename="js/one.js") }}"></script>
+{% endcompress %}
+
+{% compress js %}
+    <script
+        type="text/javascript"
+        src="{{ url_for('static', filename="js/one.js") }}"></script>
+{% endcompress %}


### PR DESCRIPTION
This is my second attempt to fix #1099.

I added a `NoDuplicatesStorageProxy`, which delegates all method calls to DefaultStorage, *except* it filters out duplicate `save()` calls.

I updated the `compress` management command to use `NoDuplicatesStorageProxy` by monkey-patching `compressor.storage.default_storage`.

The PR includes a test case which exercises the changes. 
