### PR TITLE
Remove delete() call from CompressorFileStorage.get_available_name

### DIFF
--- a/compressor/tests/test_storages.py
+++ b/compressor/tests/test_storages.py
@@ -61,3 +61,9 @@ class StorageTestCase(TestCase):
         context = {'STATIC_URL': settings.COMPRESS_URL}
         out = css_tag("/static/CACHE/css/output.e701f86c6430.css")
         self.assertEqual(out, render(template, context))
+
+    def test_duplicate_save_overwrites_same_file(self):
+        filename1 = self.default_storage.save('test.txt', ContentFile('yeah yeah'))
+        filename2 = self.default_storage.save('test.txt', ContentFile('yeah yeah'))
+        self.assertEqual(filename1, filename2)
+        self.assertNotIn("_", filename2)


### PR DESCRIPTION
This PR is an alternative to #1105 and #1100, and intends to fix #1099. It changes CompressorFileStorage:

* drops the deletion logic in  `CompressorFileStorage.get_available_name()`
* this means that `get_available_name` will sometimes return filenames with an underscore and a random string appended at the end to ensure uniqueness
* overrides the `save()` method to add one additional last step: if the filename contains an underscore then move it into the correct location. 

So, instead of deleting a file and then writing new data in the same filename, compressor would write the data in a temporary file, then move it to the correct place. Python docs say `os.replace` is an atomic operation, so this would avoid the brief moment of file not existing between delete and write.

Notes:

* I didn't add any new test cases. In theory there could be a test case which creates compressed files with clashing filenames, and then tests if the produced files contain any underscores (they shouldn't). But not sure if it's worth testing that.
* `GzipCompressorFileStorage` and `BrotliCompressorFileStorage` override the `save` method again and do some more file IO. I'm not sure if we could run into race conditions there too.

