### PR TITLE
Implemented separate storage for the offline manifest, fixes #1112

### DIFF
--- a/compressor/conf.py
+++ b/compressor/conf.py
@@ -75,6 +75,7 @@ class CompressorConf(AppConf):
     OFFLINE_CONTEXT = {}
     # The name of the manifest file (e.g. filename.ext)
     OFFLINE_MANIFEST = 'manifest.json'
+    OFFLINE_MANIFEST_STORAGE = 'compressor.storage.OfflineManifestFileStorage'
     # The Context to be used when TemplateFilter is used
     TEMPLATE_FILTER_CONTEXT = {}
     # Placeholder to be used instead of settings.COMPRESS_URL during offline compression.

--- a/compressor/storage.py
+++ b/compressor/storage.py
@@ -110,3 +110,20 @@ class DefaultStorage(LazyObject):
 
 
 default_storage = DefaultStorage()
+
+
+class OfflineManifestFileStorage(CompressorFileStorage):
+    def __init__(self, location=None, base_url=None, *args, **kwargs):
+        if location is None:
+            location = os.path.join(settings.COMPRESS_ROOT, settings.COMPRESS_OUTPUT_DIR)
+        if base_url is None:
+            base_url = os.path.join(settings.COMPRESS_URL, settings.COMPRESS_OUTPUT_DIR)
+        super().__init__(location, base_url, *args, **kwargs)
+
+
+class DefaultOfflineManifestStorage(LazyObject):
+    def _setup(self):
+        self._wrapped = get_storage_class(settings.COMPRESS_OFFLINE_MANIFEST_STORAGE)()
+
+
+default_offline_manifest_storage = DefaultOfflineManifestStorage()

--- a/compressor/storage.py
+++ b/compressor/storage.py
@@ -2,6 +2,7 @@ import gzip
 import os
 from datetime import datetime
 import time
+from urllib.parse import urljoin
 
 from django.core.files.storage import FileSystemStorage, get_storage_class
 from django.utils.functional import LazyObject, SimpleLazyObject
@@ -117,7 +118,7 @@ class OfflineManifestFileStorage(CompressorFileStorage):
         if location is None:
             location = os.path.join(settings.COMPRESS_ROOT, settings.COMPRESS_OUTPUT_DIR)
         if base_url is None:
-            base_url = os.path.join(settings.COMPRESS_URL, settings.COMPRESS_OUTPUT_DIR)
+            base_url = urljoin(settings.COMPRESS_URL, settings.COMPRESS_OUTPUT_DIR)
         super().__init__(location, base_url, *args, **kwargs)
 
 

--- a/compressor/tests/test_offline.py
+++ b/compressor/tests/test_offline.py
@@ -15,7 +15,7 @@ from django.urls import get_script_prefix, set_script_prefix
 from compressor.cache import flush_offline_manifest, get_offline_manifest
 from compressor.exceptions import OfflineGenerationError
 from compressor.management.commands.compress import Command as CompressCommand
-from compressor.storage import default_storage
+from compressor.storage import default_offline_manifest_storage
 from compressor.utils import get_mod_func
 
 
@@ -154,9 +154,9 @@ class OfflineTestCaseMixin:
     def tearDown(self):
         self.override_settings.__exit__(None, None, None)
 
-        manifest_path = os.path.join('CACHE', 'manifest.json')
-        if default_storage.exists(manifest_path):
-            default_storage.delete(manifest_path)
+        manifest_filename = 'manifest.json'
+        if default_offline_manifest_storage.exists(manifest_filename):
+            default_offline_manifest_storage.delete(manifest_filename)
 
     def _prepare_contexts(self, engine):
         contexts = settings.COMPRESS_OFFLINE_CONTEXT
@@ -311,9 +311,9 @@ class OfflineCompressBasicTestCase(OfflineTestCaseMixin, TestCase):
     def _test_deleting_manifest_does_not_affect_rendering(self, engine):
         count, result = CompressCommand().handle_inner(engines=[engine], verbosity=0)
         get_offline_manifest()
-        manifest_path = os.path.join('CACHE', 'manifest.json')
-        if default_storage.exists(manifest_path):
-            default_storage.delete(manifest_path)
+        manifest_filename = 'manifest.json'
+        if default_offline_manifest_storage.exists(manifest_filename):
+            default_offline_manifest_storage.delete(manifest_filename)
         self.assertEqual(1, count)
         self.assertEqual([self._render_script(self.expected_hash)], result)
         rendered_template = self._render_template(engine)

--- a/compressor/tests/test_storages.py
+++ b/compressor/tests/test_storages.py
@@ -67,3 +67,9 @@ class StorageTestCase(TestCase):
         filename2 = self.default_storage.save('test.txt', ContentFile('yeah yeah'))
         self.assertEqual(filename1, filename2)
         self.assertNotIn("_", filename2)
+
+    def test_offline_manifest_storage(self):
+        storage.default_offline_manifest_storage.save('test.txt', ContentFile('yeah yeah'))
+        self.assertTrue(os.path.exists(os.path.join(settings.COMPRESS_ROOT, 'CACHE', 'test.txt')))
+        # Check that the file is stored at the same default location as before the new manifest storage.
+        self.assertTrue(self.default_storage.exists(os.path.join('CACHE', 'test.txt')))

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- New setting ``COMPRESS_OFFLINE_MANIFEST_STORAGE`` to customize the offline manifest's file storage (#1112)
+
+  With this change the function ``compressor.cache.get_offline_manifest_filename()`` has been removed.
+  You can now use the new file storage ``compressor.storage.default_offline_manifest_storage`` to access the
+  location of the manifest.
+
+
 v4.0 (2022-03-23)
 -----------------
 

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -541,3 +541,14 @@ Offline settings
 
     The name of the file to be used for saving the names of the files
     compressed offline.
+
+.. attribute:: COMPRESS_OFFLINE_MANIFEST_STORAGE
+
+    :Default: ``compressor.storage.OfflineManifestFileStorage``
+
+    The dotted path to a Django Storage backend to be used to save the
+    offline manifest.
+
+    By default, the file configured with
+    :attr:`~django.conf.settings.COMPRESS_OFFLINE_MANIFEST` will be stored
+    into :attr:`~django.conf.settings.COMPRESS_OUTPUT_DIR`.

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -552,3 +552,15 @@ Offline settings
     By default, the file configured with
     :attr:`~django.conf.settings.COMPRESS_OFFLINE_MANIFEST` will be stored
     into :attr:`~django.conf.settings.COMPRESS_OUTPUT_DIR`.
+
+    An example to output the manifest into the project's root directory::
+
+        # project/settings.py:
+        COMPRESS_STORAGE = 'project.module.PrivateOfflineManifestFileStorage'
+
+        # project/module.py:
+        from compressor.storage import OfflineManifestFileStorage
+        from django.conf import settings
+        class PrivateOfflineManifestFileStorage(OfflineManifestFileStorage):
+            def __init__(self, *args, **kwargs):
+                super().__init__(settings.BASE_DIR, None, *args, **kwargs)


### PR DESCRIPTION
The new default `compressor.storage.OfflineManifestFileStorage` uses `COMPRESS_ROOT` and `COMPRESS_OUTPUT_DIR` to write the manifest, which results in the same behavior as before (by default `STATIC_ROOT` + `CACHE/manifest.json`).

To store the manifest in a private location, e.g. the project's root directory, one could configure a subclass of the storage:
```python
# settings.py:
COMPRESS_STORAGE = 'mypackage.PrivateOfflineManifestFileStorage'

# mypackge.py
from compressor.storage import OfflineManifestFileStorage
from django.conf import settings


class PrivateOfflineManifestFileStorage(OfflineManifestFileStorage):
    def __init__(self, *args, **kwargs):
        super().__init__(settings.BASE_DIR, None, *args, **kwargs)
```

**TBD:**
* The new manifest storage uses the `COMPRESS_OUTPUT_DIR` as its default location, so I've removed `get_offline_manifest_filename()` which was obsolete now. I haven't found this method in the docs, but this probably requires some notes in the changelog?
* I'm passing the `base_url` in `OfflineManifestFileStorage.__init()__` to be able to query its URL, but actually the manifest really is more a private cache file, so its URL is actually not required. Should we therefore skip this, or even raise an error in the storage's `url()` method for example?
* Maybe place a note which recommends to use a non-public location for the manifest storage?
* Should I place the above example somewhere in the docs?