### PR TITLE
Update doc in light of new mangled name avoidance

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -4,6 +4,11 @@ Changelog
 Unreleased
 ----------
 
+- Update the `CachedS3Boto3Storage` example storage subclass in "Remote Storages"
+  to work properly after the v4.0 change to how duplicate file names are handled
+  by `CompressorFileStorage`
+  
+
 v4.1 (2022-08-03)
 -----------------
 
@@ -25,6 +30,12 @@ v4.0 (2022-03-23)
 
 - Fix intermittent No such file or directory errors by changing strategy to
   deal with duplicate filenames in CompressorFileStorage
+  
+  Note: if your project has a custom storage backend following the example of 
+  `CachedS3Boto3Storage` from the "Remote Storages" documentation, it will need
+  to be updated to call `save` instead of `_save` to work properly after this
+  change to `CompressorFileStorage`.
+  
 - Deprecate SlimItFilter, stop testing it with Python 3.7 or higher
 
 

--- a/docs/remote-storages.txt
+++ b/docs/remote-storages.txt
@@ -66,7 +66,7 @@ apps can be integrated.
                 "compressor.storage.CompressorFileStorage")()
 
         def save(self, name, content):
-            self.local_storage._save(name, content)
+            self.local_storage.save(name, content)
             super().save(name, self.local_storage._open(name))
             return name
 


### PR DESCRIPTION
https://github.com/django-compressor/django-compressor/pull/1107 moved file-name-mangling avoidance into a `save` override, but the doc suggests calling `_save` which bypassess the new file-name-mangling-avoidance code. Updating a project to use django-compressor 4.0 that had a storages class which followed this doc resulted in mangled-named files appearing in the file system (and ultimately css changes not getting built/deployed, since the changes were in the mangled-name files while the rest of the process was using the "bare" name).