### PR TITLE
Add note to specify `COMPRESS_OFFLINE_MANIFEST_STORAGE`

### DIFF
--- a/docs/remote-storages.txt
+++ b/docs/remote-storages.txt
@@ -70,8 +70,9 @@ apps can be integrated.
             super().save(name, self.local_storage._open(name))
             return name
 
-#. Set your :attr:`~django.conf.settings.COMPRESS_STORAGE` and STATICFILES_STORAGE_
-   settings to the dotted path of your custom cached storage backend, e.g.
+#. Set your :attr:`~django.conf.settings.COMPRESS_STORAGE`, STATICFILES_STORAGE_
+   and :attr:`~django.conf.settings.COMPRESS_OFFLINE_MANIFEST_STORAGE` settings 
+   to the dotted path of your custom cached storage backend, e.g.
    ``'mysite.storage.CachedS3Boto3Storage'``.
 
 #. To have Django correctly render the URLs to your static files, set the
@@ -85,6 +86,7 @@ In the end it might look like this::
     COMPRESS_ROOT = STATIC_ROOT
     STATICFILES_STORAGE = 'mysite.storage.CachedS3BotoStorage'
     COMPRESS_STORAGE = STATICFILES_STORAGE
+    COMPRESS_OFFLINE_MANIFEST_STORAGE = STATICFILES_STORAGE
     STATIC_URL = 'https://compressor-test.s3.amazonaws.com/'
     COMPRESS_URL = STATIC_URL
 


### PR DESCRIPTION
Fixes #1138 to add documentation.

With the addition of `COMPRESS_OFFLINE_MANIFEST_STORAGE` Setting in d70f1d6cc8696386afa8590ba8e6f269658f112d, if you are using boto3 with offline compression, manifest.json may never make it to the remote storage if this setting is not manually specified.

@petewalker had the right answer: Manually set `COMPRESS_OFFLINE_MANIFEST_STORAGE`, or it defaults to `COMPRESS_OUTPUT_DIR`, which is probably not what you want when using remote storages.