### PR TITLE
Fix example for COMPRESS_OFFLINE_MANIFEST_STORAGE in docs

### DIFF
--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -556,7 +556,7 @@ Offline settings
     An example to output the manifest into the project's root directory::
 
         # project/settings.py:
-        COMPRESS_STORAGE = 'project.module.PrivateOfflineManifestFileStorage'
+        COMPRESS_OFFLINE_MANIFEST_STORAGE = 'project.module.PrivateOfflineManifestFileStorage'
 
         # project/module.py:
         from compressor.storage import OfflineManifestFileStorage


### PR DESCRIPTION
Just run into my own faulty docs submitted with #1113.

#1160 is a bit related, as it also improves the docs around the new offline manifest storage.