### PR TITLE
Fixed typo in behind-the-scenes.txt

### DIFF
--- a/docs/behind-the-scenes.txt
+++ b/docs/behind-the-scenes.txt
@@ -34,7 +34,7 @@ First step: parsing and file list
 A compressor instance is created, which in turns instantiates the HTML parser.
 The parser is used to determine a file or code hunk list. Each file mtime is
 checked, first in cache and then on disk/storage, and this is used to
-determine an unique cache key.
+determine a unique cache key.
 
 Second step: Checking the "main" cache
 --------------------------------------


### PR DESCRIPTION
Whilst `an` usually goes with a vowel, such as `an umbrella`, when it makes the long (name of the letter) sound `a` is used, such as `a university`. `unique` is the latter case.