### PR TITLE
Python 3.12 compatability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,9 @@ jobs:
           - python: "3.10"
             toxenv: py310-4.2.X
           - python: "3.11"
-            toxenv: py311-4.2.X    
+            toxenv: py311-4.2.X
+          - python: "3.12"
+            toxenv: py312-4.2.X
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           python-version: ${{ matrix.versions.python }}
       - run: |
-          pip install tox
+          pip install tox setuptools
           python setup.py install_egg_info
       - run: tox -e ${{ matrix.versions.toxenv }}
       - run: |

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -3,7 +3,7 @@ Changelog
 
 To be released
 -------------------
-- Officially support Python 3.12
+- Officially support Python 3.12 (requires lxml 4.9.3 or higher)
 
 v4.4 (2023-06-28)
 -------------------

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+To be released
+-------------------
+- Officially support Python 3.12
+
 v4.4 (2023-06-28)
 -------------------
 

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -7,7 +7,7 @@ csscompressor==0.9.5
 django-sekizai==4.0.0
 flake8==6.0.0
 html5lib==1.1
-lxml==4.9.2
+lxml==4.9.3
 rcssmin==1.1.1
 rjsmin==1.2.1
 slimit==0.8.1

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ import ast
 import codecs
 import os
 import sys
-from distutils.util import convert_path
 from fnmatch import fnmatchcase
+from pathlib import Path
 
 from setuptools import find_packages, setup
 
@@ -84,7 +84,7 @@ def find_package_data(
     """
 
     out = {}
-    stack = [(convert_path(where), "", package, only_in_packages)]
+    stack = [(str(Path(where)), "", package, only_in_packages)]
     while stack:
         where, prefix, package, only_in_packages = stack.pop(0)
         for name in os.listdir(where):

--- a/setup.py
+++ b/setup.py
@@ -159,6 +159,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Internet :: WWW/HTTP",
     ],
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ basepython =
     py39: python3.9
     py310: python3.10
     py311: python3.11
+    py312: python3.12
 usedevelop = true
 setenv =
     CPPFLAGS=-O0


### PR DESCRIPTION
This PR adds compatibility with Python 3.12 by

- Installing setuptools 
- Pinning lxml to 4.9.3
- Replace distutils.convert_path function with custom function 