### PR TITLE
Add Read The Docs configuration file.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,15 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
Copied from https://docs.readthedocs.io/en/stable/config-file/v2.html

Switched to Python 3.11, since the project doesn't explicitly use 3.12 yet.