### PR TITLE
Add Python 3.12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
             toxenv: py310-5.0.X
           - python: "3.11"
             toxenv: py311-5.0.X
+          - python: "3.12"
+            toxenv: py312-5.0.X
 
     runs-on: ubuntu-latest
     steps:

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -7,7 +7,7 @@ csscompressor==0.9.5
 django-sekizai==4.0.0
 flake8==6.0.0
 html5lib==1.1
-lxml==4.9.2
+lxml==4.9.3
 rcssmin==1.1.1
 rjsmin==1.2.1
 slimit==0.8.1

--- a/setup.py
+++ b/setup.py
@@ -160,6 +160,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Internet :: WWW/HTTP",
     ],
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,14 @@ envlist =
     {py38,py39,py310}-4.0.X
     {py38,py39,py310,py311}-4.1.X
     {py38,py39,py310,py311}-4.2.X
-    {py310,py311}-5.0.X
+    {py310,py311,py312}-5.0.X
 [testenv]
 basepython =
     py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11
+    py312: python3.12
 usedevelop = true
 setenv =
     CPPFLAGS=-O0


### PR DESCRIPTION
* Add Python 3.12 to test matrix in ci.yml and tox.ini

* Add Python 3.12 classifier to setup.py

* Update lxml dependency from 4.9.2 to 4.9.3

Notes:

- Python 3.12 fails to install `lxml` 4.9.2, so I updated the dependency.
- Django 4.2 does not officially support Python 3.12 until version 4.2.8, so it will need to be added to the test matrix at a later date.