### PR TITLE
Add Python 3.12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           python-version: ${{ matrix.versions.python }}
       - run: |
-          pip install tox
+          pip install tox setuptools
           python setup.py install_egg_info
       - run: tox -e ${{ matrix.versions.toxenv }}
       - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
             toxenv: py310-5.0.X
           - python: "3.11"
             toxenv: py311-5.0.X
+          - python: "3.12"
+            toxenv: py312-5.0.X
 
     runs-on: ubuntu-latest
     steps:

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+To be released
+-------------------
+- Officially support Python 3.12 (requires lxml 4.9.3 or higher)
+
 v4.4 (2023-06-28)
 -------------------
 

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -7,7 +7,7 @@ csscompressor==0.9.5
 django-sekizai==4.0.0
 flake8==6.0.0
 html5lib==1.1
-lxml==4.9.2
+lxml==4.9.3
 rcssmin==1.1.1
 rjsmin==1.2.1
 slimit==0.8.1

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ import ast
 import codecs
 import os
 import sys
-from distutils.util import convert_path
 from fnmatch import fnmatchcase
+from pathlib import Path
 
 from setuptools import find_packages, setup
 
@@ -84,7 +84,7 @@ def find_package_data(
     """
 
     out = {}
-    stack = [(convert_path(where), "", package, only_in_packages)]
+    stack = [(str(Path(where)), "", package, only_in_packages)]
     while stack:
         where, prefix, package, only_in_packages = stack.pop(0)
         for name in os.listdir(where):

--- a/setup.py
+++ b/setup.py
@@ -160,6 +160,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Internet :: WWW/HTTP",
     ],
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,14 @@ envlist =
     {py38,py39,py310}-4.0.X
     {py38,py39,py310,py311}-4.1.X
     {py38,py39,py310,py311}-4.2.X
-    {py310,py311}-5.0.X
+    {py310,py311,py312}-5.0.X
 [testenv]
 basepython =
     py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11
+    py312: python3.12
 usedevelop = true
 setenv =
     CPPFLAGS=-O0


### PR DESCRIPTION
This (hopefully) fixes the issues encountered in #1213, cherry-picks commits from #1208, and adds support for python 3.12. As previously mentioned, only for Django 5.0 at the moment as 4.2.7 does not officially support 3.12.