### PR TITLE
Replace get_storage_class with new storages API for Django >= 4.2

### DIFF
--- a/compressor/storage.py
+++ b/compressor/storage.py
@@ -58,7 +58,7 @@ class CompressorFileStorage(FileSystemStorage):
 
 
 compressor_file_storage = SimpleLazyObject(
-    lambda: _get_storage_class("compressor.storage.CompressorFileStorage")()
+    lambda: _get_storage_class("compressor.storage.CompressorFileStorage")
 )
 
 
@@ -122,7 +122,7 @@ class BrotliCompressorFileStorage(CompressorFileStorage):
 
 class DefaultStorage(LazyObject):
     def _setup(self):
-        self._wrapped = _get_storage_class(settings.COMPRESS_STORAGE)()
+        self._wrapped = _get_storage_class(settings.COMPRESS_STORAGE)
 
 
 default_storage = DefaultStorage()
@@ -141,7 +141,7 @@ class OfflineManifestFileStorage(CompressorFileStorage):
 
 class DefaultOfflineManifestStorage(LazyObject):
     def _setup(self):
-        self._wrapped = _get_storage_class(settings.COMPRESS_OFFLINE_MANIFEST_STORAGE)()
+        self._wrapped = _get_storage_class(settings.COMPRESS_OFFLINE_MANIFEST_STORAGE)
 
 
 default_offline_manifest_storage = DefaultOfflineManifestStorage()

--- a/compressor/tests/test_storages.py
+++ b/compressor/tests/test_storages.py
@@ -2,27 +2,25 @@ import os
 import brotli
 
 from django.core.files.base import ContentFile
-from django.core.files.storage import get_storage_class
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils.functional import LazyObject
 
 from compressor import storage
 from compressor.conf import settings
+from compressor.storage import _get_storage_class
 from compressor.tests.test_base import css_tag
 from compressor.tests.test_templatetags import render
 
 
 class GzipStorage(LazyObject):
     def _setup(self):
-        self._wrapped = get_storage_class(
-            "compressor.storage.GzipCompressorFileStorage"
-        )()
+        self._wrapped = _get_storage_class("compressor.storage.GzipCompressorFileStorage")
 
 
 class BrotliStorage(LazyObject):
     def _setup(self):
-        self._wrapped = get_storage_class(
+        self._wrapped = _get_storage_class(
             "compressor.storage.BrotliCompressorFileStorage"
         )()
 

--- a/compressor/tests/test_storages.py
+++ b/compressor/tests/test_storages.py
@@ -22,7 +22,7 @@ class BrotliStorage(LazyObject):
     def _setup(self):
         self._wrapped = _get_storage_class(
             "compressor.storage.BrotliCompressorFileStorage"
-        )()
+        )
 
 
 @override_settings(COMPRESS_ENABLED=True)

--- a/docs/remote-storages.txt
+++ b/docs/remote-storages.txt
@@ -53,7 +53,8 @@ apps can be integrated.
    to use; below is an example of the boto3 S3 storage backend from
    django-storages_::
 
-    from django.core.files.storage import get_storage_class
+    from django.core.files.storage import get_storage_class  # Django <= 4.1
+    from django.core.files.storage import storages  # Django >= 4.2
     from storages.backends.s3boto3 import S3Boto3Storage
 
     class CachedS3Boto3Storage(S3Boto3Storage):
@@ -62,8 +63,12 @@ apps can be integrated.
         """
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
+            # Django <= 4.1
             self.local_storage = get_storage_class(
                 "compressor.storage.CompressorFileStorage")()
+            # Django >= 4.2
+            self.local_storage = storages.create_storage(
+                {"BACKEND": "compressor.storage.CompressorFileStorage"})
 
         def save(self, name, content):
             self.local_storage.save(name, content)


### PR DESCRIPTION
In response to issue #1187 I've created a helper function `_get_storage_class` which detects whether to use the old or new API depending on the current Django version.

I've updated the code, and tests, to use this for now. Then when Django 4.1 support is dropped, it can be removed in favour of directly using `storages.create_storage`.

I also updated the docs about custom remote storages, so people know to use the new API if they are using Django >= 4.2