### PR TITLE
Added USE_TZ test setting.

### DIFF
--- a/compressor/test_settings.py
+++ b/compressor/test_settings.py
@@ -62,3 +62,5 @@ SECRET_KEY = "iufoj=mibkpdz*%bob952x(%49rqgv8gg45k36kjcg76&-y5=!"
 PASSWORD_HASHERS = ("django.contrib.auth.hashers.UnsaltedMD5PasswordHasher",)
 
 MIDDLEWARE_CLASSES = []
+
+USE_TZ = True


### PR DESCRIPTION
Default for this changes in Django 5.0 to True, so given that it's been missing for ages, we could just leave it off, but it raises a deprecation warning in earlier versions so leads to difficulties when running with the `-W error` flag, to debug other issues.