### PR TITLE
Schedule dependabot PyPI updates to be weekly, not daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,10 @@ version: 2
 updates:
 - package-ecosystem: pip
   directory: "/requirements"
+  groups:
+       PyPI:
+          patterns:
+            - "*"  # Group all PyPI updates into a single larger pull request
   schedule:
     interval: weekly
   open-pull-requests-limit: 99

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,5 @@ updates:
 - package-ecosystem: pip
   directory: "/requirements"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 99


### PR DESCRIPTION
Batch up these updates to make them less chatty and more manageable as discussed at https://github.com/django-compressor/django-compressor/pull/1226#pullrequestreview-1827708876

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval