### PR TITLE
Update code to use newer Django storages object. 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,13 @@ jobs:
           - python: "3.12"
             toxenv: py312-5.0.X
 
+          - python: "3.10"
+            toxenv: py310-5.1.X
+          - python: "3.11"
+            toxenv: py311-5.1.X
+          - python: "3.12"
+            toxenv: py312-5.1.X
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/compressor/conf.py
+++ b/compressor/conf.py
@@ -16,6 +16,7 @@ class CompressorConf(AppConf):
     # the backend to use when parsing the JavaScript or Stylesheet files
     PARSER = "compressor.parser.AutoSelectParser"
     OUTPUT_DIR = "CACHE"
+    STORAGE_ALIAS = "compressor"
     STORAGE = "compressor.storage.CompressorFileStorage"
 
     COMPRESSORS = dict(
@@ -75,6 +76,7 @@ class CompressorConf(AppConf):
     OFFLINE_CONTEXT = {}
     # The name of the manifest file (e.g. filename.ext)
     OFFLINE_MANIFEST = "manifest.json"
+    OFFLINE_MANIFEST_STORAGE_ALIAS = "compressor-offine"
     OFFLINE_MANIFEST_STORAGE = "compressor.storage.OfflineManifestFileStorage"
     # The Context to be used when TemplateFilter is used
     TEMPLATE_FILTER_CONTEXT = {}

--- a/compressor/tests/test_storages.py
+++ b/compressor/tests/test_storages.py
@@ -2,7 +2,7 @@ import os
 import brotli
 
 from django.core.files.base import ContentFile
-from django.core.files.storage import get_storage_class
+from django.core.files.storage import storages
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils.functional import LazyObject
@@ -15,16 +15,16 @@ from compressor.tests.test_templatetags import render
 
 class GzipStorage(LazyObject):
     def _setup(self):
-        self._wrapped = get_storage_class(
-            "compressor.storage.GzipCompressorFileStorage"
-        )()
+        self._wrapped = storages.create_storage({
+            "BACKEND": "compressor.storage.GzipCompressorFileStorage"
+        })
 
 
 class BrotliStorage(LazyObject):
     def _setup(self):
-        self._wrapped = get_storage_class(
-            "compressor.storage.BrotliCompressorFileStorage"
-        )()
+        self._wrapped = storages.create_storage({
+            "BACKEND": "compressor.storage.BrotliCompressorFileStorage"
+        })
 
 
 @override_settings(COMPRESS_ENABLED=True)

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,10 +1,17 @@
 Changelog
 =========
 
-To be released
--------------------
+v4.5 (To be released)
+---------------------
+
 - Officially support Python 3.12 (requires lxml 4.9.3 or higher)
 - Drop support for Django versions before 4.2.
+- Added support for Django 5.1
+- Added new ``COMPRESS_STORAGE_ALIAS`` and ``COMPRESS_OFFLINE_MANIFEST_STORAGE_ALIAS``
+  settings. These point to keys in Django's ``storages`` handler. If set by the
+  user, Compressor will use these storages, or otherwise will set a default
+  storage, given by ``COMPRESS_STORAGE`` and
+  ``COMPRESS_OFFLINE_MANIFEST_STORAGE`` respectively on first access.
 
 v4.4 (2023-06-28)
 -------------------

--- a/docs/remote-storages.txt
+++ b/docs/remote-storages.txt
@@ -53,8 +53,7 @@ apps can be integrated.
    to use; below is an example of the boto3 S3 storage backend from
    django-storages_::
 
-    # TODO: Update this example.
-    from django.core.files.storage import get_storage_class
+    from django.core.files.storage import storages
     from storages.backends.s3boto3 import S3Boto3Storage
 
     class CachedS3Boto3Storage(S3Boto3Storage):
@@ -63,8 +62,9 @@ apps can be integrated.
         """
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
-            self.local_storage = get_storage_class(
-                "compressor.storage.CompressorFileStorage")()
+            self.local_storage = storages.create_storage({
+                "BACKEND": "compressor.storage.CompressorFileStorage"
+            })
 
         def save(self, name, content):
             self.local_storage.save(name, content)

--- a/docs/remote-storages.txt
+++ b/docs/remote-storages.txt
@@ -53,6 +53,7 @@ apps can be integrated.
    to use; below is an example of the boto3 S3 storage backend from
    django-storages_::
 
+    # TODO: Update this example.
     from django.core.files.storage import get_storage_class
     from storages.backends.s3boto3 import S3Boto3Storage
 
@@ -71,7 +72,7 @@ apps can be integrated.
             return name
 
 #. Set your :attr:`~django.conf.settings.COMPRESS_STORAGE`, STATICFILES_STORAGE_
-   and :attr:`~django.conf.settings.COMPRESS_OFFLINE_MANIFEST_STORAGE` settings 
+   and :attr:`~django.conf.settings.COMPRESS_OFFLINE_MANIFEST_STORAGE` settings
    to the dotted path of your custom cached storage backend, e.g.
    ``'mysite.storage.CachedS3Boto3Storage'``.
 

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -370,6 +370,17 @@ Backend settings
       create ``*.br`` files of each of the compressed files. It is using
       the maximum level of compression (11) so compression speed will be low.
 
+.. attribute:: COMPRESS_STORAGE_ALIAS
+
+    :Default: ``'compressor'``
+
+    The alias into Django's ``STORAGES`` setting that will be used to save
+    compressed files.
+
+    If directly set by the user in ``STORAGES``, Compressor will use this
+    storage, otherwise it otherwise will set a default storage, given by
+    ``COMPRESS_STORAGE``.
+
 .. attribute:: COMPRESS_PARSER
 
     :Default: ``'compressor.parser.AutoSelectParser'``
@@ -569,3 +580,14 @@ Offline settings
         class PrivateOfflineManifestFileStorage(OfflineManifestFileStorage):
             def __init__(self, *args, **kwargs):
                 super().__init__(settings.BASE_DIR, None, *args, **kwargs)
+
+.. attribute:: COMPRESS_OFFLINE_MANIFEST_STORAGE_ALIAS
+
+    :Default: ``'compressor-offine'``
+
+    The alias into Django's ``STORAGES`` setting that will be used to save
+    compressed files.
+
+    If directly set by the user in ``STORAGES``, Compressor will use this
+    storage, otherwise it otherwise will set a default storage, given by
+    ``COMPRESS_OFFLINE_MANIFEST_STORAGE``.

--- a/setup.py
+++ b/setup.py
@@ -148,6 +148,7 @@ setup(
         "Framework :: Django",
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.0",
+        "Framework :: Django :: 5.1",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     {py38,py39,py310,py311}-4.2.X
     {py310,py311,py312}-5.0.X
+    {py310,py311,py312}-5.1.X
 [testenv]
 basepython =
     py38: python3.8
@@ -19,4 +20,5 @@ commands =
 deps =
     4.2.X: Django>=4.2,<5.0
     5.0.X: Django>=5.0,<5.1
+    5.1.X: Django>=5.1a1,<5.2
     -r{toxinidir}/requirements/tests.txt


### PR DESCRIPTION
Fixes #1187
Compare #1216 and #1202. 

Adds a new helper to call into Django's `storages` handler to look for the appropriate aliases, and populate those keys if not manually set. This allows users to opt-in to Django's new setting, but not require that they do anything for the default case. 

@diox can I ask you to take a glance, and let me know what you think. 

I need to do docs and change notes. **Update**: Done ✅

Q: From the release of 5.0, Django's official advice is to drop Django<4.2. Doing so would allow us to proceed more or less with how this is now. Keeping compat with older versions would require branching on availability as you see in #1202 particularly. I'm not sure that's worth it now: Anyone on an older Django can just use an older compressor, but I'm happy to follow your guidance there. (CI is passing for Django 4.2+)

