### PR TITLE
Fixed remote storage fallback.

### DIFF
--- a/compressor/storage.py
+++ b/compressor/storage.py
@@ -10,10 +10,10 @@ from django.utils.functional import LazyObject, SimpleLazyObject
 from compressor.conf import settings
 
 
-def get_storage(
-    alias=settings.COMPRESS_STORAGE_ALIAS,
-    storage_class=settings.COMPRESS_STORAGE
-):
+def get_storage(alias=None, storage_class=None):
+    alias = alias or settings.COMPRESS_STORAGE_ALIAS
+    storage_class = storage_class or settings.COMPRESS_STORAGE
+
     try:
         return storages[alias]
     except InvalidStorageError:
@@ -61,7 +61,9 @@ class CompressorFileStorage(FileSystemStorage):
 
 
 compressor_file_storage = SimpleLazyObject(
-    lambda: get_storage()
+    lambda: storages.create_storage(
+        {"BACKEND": "compressor.storage.CompressorFileStorage"}
+    )
 )
 
 

--- a/compressor/tests/test_storages.py
+++ b/compressor/tests/test_storages.py
@@ -120,9 +120,16 @@ class CompressorFileNameTestCase(TestCase):
         instance of CompressorFileStorage. This must not be dependent on
         project settings.
         """
+        old_default_storage = storage.default_storage
+        storage.default_storage = storage.DefaultStorage()
+
         css = (
             '<link rel="stylesheet" href="/static/css/one.css" type="text/css" />'
         )
         compressor = CssCompressor("css", css)
-        # Remote storage would raise NotImplementedError is fallback is unsuccessful.
-        compressor.get_filename("css/one.css")
+        try:
+            # Remote storage would raise NotImplementedError if fallback is
+            # unsuccessful.
+            compressor.get_filename("css/one.css")
+        finally:
+            storage.default_storage = old_default_storage

--- a/compressor/tests/test_storages.py
+++ b/compressor/tests/test_storages.py
@@ -3,12 +3,14 @@ import brotli
 
 from django.core.files.base import ContentFile
 from django.core.files.storage import storages
+from django.core.files.storage.base import Storage
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils.functional import LazyObject
 
 from compressor import storage
 from compressor.conf import settings
+from compressor.css import CssCompressor
 from compressor.tests.test_base import css_tag
 from compressor.tests.test_templatetags import render
 
@@ -25,6 +27,18 @@ class BrotliStorage(LazyObject):
         self._wrapped = storages.create_storage({
             "BACKEND": "compressor.storage.BrotliCompressorFileStorage"
         })
+
+
+class DummyPathNotImplementedStorage(Storage):
+    """
+     A dummy storage backend that mimics a remote storage that does not implement
+     `.path()` e.g. `storages.backends.s3.S3Storage`.
+    """
+    def exists(self, name):
+        return True
+
+    def path(self, name):
+        raise NotImplementedError
 
 
 @override_settings(COMPRESS_ENABLED=True)
@@ -87,5 +101,28 @@ class StorageTestCase(TestCase):
         self.assertTrue(
             os.path.exists(os.path.join(settings.COMPRESS_ROOT, "CACHE", "test.txt"))
         )
-        # Check that the file is stored at the same default location as before the new manifest storage.
+        # Check that the file is stored at the same default location as before
+        # the new manifest storage.
         self.assertTrue(self.default_storage.exists(os.path.join("CACHE", "test.txt")))
+
+
+class CompressorFileNameTestCase(TestCase):
+    @override_settings(
+        COMPRESS_ENABLED=True,
+        DEBUG=False,
+        COMPRESS_STORAGE=(
+            "compressor.tests.test_storages.DummyPathNotImplementedStorage"
+        ),
+    )
+    def test_storage_without_path_fallback(self):
+        """
+        Remote storages not implementing path need a fallback to a private
+        instance of CompressorFileStorage. This must not be dependent on
+        project settings.
+        """
+        css = (
+            '<link rel="stylesheet" href="/static/css/one.css" type="text/css" />'
+        )
+        compressor = CssCompressor("css", css)
+        # Remote storage would raise NotImplementedError is fallback is unsuccessful.
+        compressor.get_filename("css/one.css")

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+v4.5.1 (2024-07-06)
+-------------------
+
+- Fixed an error in v4.5 when using remote storages not defining a ``path()`` method.
+
 v4.5 (2024-05-17)
 -----------------
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,5 +20,5 @@ commands =
 deps =
     4.2.X: Django>=4.2,<5.0
     5.0.X: Django>=5.0,<5.1
-    5.1.X: Django>=5.1a1,<5.2
+    5.1.X: Django>=5.1b1,<5.2
     -r{toxinidir}/requirements/tests.txt


### PR DESCRIPTION
Remote storages not implementing path need a fallback to a private instance of CompressorFileStorage. This must not be dependent on project settings.

Regression in v4.5. Closes #1253