### PR TITLE
Avoid use of deprecated ast.Constant.s

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ class VersionFinder(ast.NodeVisitor):
 
     def visit_Assign(self, node):
         if node.targets[0].id == "__version__":
-            self.version = node.value.s
+            self.version = node.value.value
 
 
 def read(*parts):


### PR DESCRIPTION
This is deprecated since Python 3.8 and removed in Python 3.14:

https://docs.python.org/dev/whatsnew/3.14.html#id3

Per upstream Python recommendation, use `ast.Constant.value` instead.

Tested building with this patch in Fedora against its Python 3.14 COPR:

https://copr.fedorainfracloud.org/coprs/g/python/python3.14/

Fixes: #1270