### PR TITLE
Drop support for EOL Python 3.8.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         versions:
-          - python: 3.8
-            toxenv: py38-4.2.X
           - python: 3.9
             toxenv: py39-4.2.X
           - python: "3.10"

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+UNRELEASED
+----------
+
+- Drop support for EOL Python 3.8.
+
+
 v4.5.1 (2024-07-22)
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -160,7 +160,7 @@ setup(
         "Topic :: Internet :: WWW/HTTP",
     ],
     zip_safe=False,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=[
         "Django >= 4.2",
         "django-appconf >= 1.0.3",

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
 envlist =
-    {py38,py39,py310,py311}-4.2.X
+    {py39,py310,py311}-4.2.X
     {py310,py311,py312}-5.0.X
     {py310,py311,py312}-5.1.X
 [testenv]
 basepython =
-    py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11


### PR DESCRIPTION
As well as being EOL now, Python 3.8 is blocking the `coverage` update (which already dropped support).