### PR TITLE
Fix stylesheet detection in CssCompressor with bs4 4.13

### DIFF
--- a/compressor/css.py
+++ b/compressor/css.py
@@ -17,7 +17,7 @@ class CssCompressor(Compressor):
             if (
                 elem_name == "link"
                 and "rel" in elem_attribs
-                and elem_attribs["rel"].lower() == "stylesheet"
+                and "stylesheet" in [rel.lower() for rel in elem_attribs["rel"]]
             ):
                 basename = self.get_basename(elem_attribs["href"])
                 filename = self.get_filename(basename)

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,5 +1,5 @@
 Jinja2==3.1.5
-beautifulsoup4==4.12.3
+beautifulsoup4==4.13.3
 brotli==1.1.0
 calmjs==3.4.4
 coverage==7.6.12


### PR DESCRIPTION
This change should deal with the fact that with beautifulsoup 4.13.0 the values of a tag attribute are now represented by a list.

I'm keeping the lowercasing strategy intact, since it allows matching of non-lowercase stylesheet representations.

This change is likely incomplete and requires further thought.

Closes: #1279 