### PR TITLE
Include package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -143,6 +143,7 @@ setup(
     maintainer="Mathieu Pillard",
     packages=find_packages(),
     package_data=find_package_data(),
+    include_package_data=True,
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: Django",


### PR DESCRIPTION
By having `package_data` is not enough to include not `*.py` files and the final package ends up without `templates`, this change adds `include_package_data` parameter to fix it.

Reported in Guix issue tracker: https://issues.guix.gnu.org/76211

References:
- https://setuptools.pypa.io/en/latest/userguide/datafiles.html