### PR TITLE
Pass ES modules and importmaps unmodified

### DIFF
--- a/compressor/js.py
+++ b/compressor/js.py
@@ -10,8 +10,21 @@ class JsCompressor(Compressor):
         if self.split_content:
             return self.split_content
         self.extra_nodes = []
+        self.module_nodes = []  # Store original module nodes separately
+
         for elem in self.parser.js_elems():
             attribs = self.parser.elem_attribs(elem)
+            script_type = attribs.get("type")
+            is_module = script_type == "module"
+            is_importmap = script_type == "importmap"
+
+            # For module and importmap scripts, we'll skip compression and keep them as-is
+            if is_module or is_importmap:
+                # Store the original element string to emit it as-is later
+                self.module_nodes.append(self.parser.elem_str(elem))
+                continue
+
+            # For non-module scripts, proceed with normal compression
             if "src" in attribs:
                 basename = self.get_basename(attribs["src"])
                 filename = self.get_filename(basename)
@@ -42,12 +55,23 @@ class JsCompressor(Compressor):
             or kwargs.get("forced", False)
         ):
             self.split_contents()
-            if hasattr(self, "extra_nodes"):
-                ret = []
+            ret = []
+
+            # Add module scripts as-is without compression
+            if hasattr(self, "module_nodes") and self.module_nodes:
+                ret.extend(self.module_nodes)
+
+            # If we have non-module scripts, compress them
+            if hasattr(self, "extra_nodes") and self.extra_nodes:
                 for extra, subnode in self.extra_nodes:
                     subnode.extra_context.update({"extra": extra})
                     ret.append(subnode.output(*args, **kwargs))
-                return "\n".join(ret)
+
+            # If no content to return, use the standard output method
+            if not ret:
+                return super().output(*args, **kwargs)
+
+            return "\n".join(ret)
         return super().output(*args, **kwargs)
 
     def filter_input(self, forced=False):

--- a/compressor/tests/test_templatetags.py
+++ b/compressor/tests/test_templatetags.py
@@ -114,6 +114,63 @@ class TemplatetagTestCase(TestCase):
         out = '<script src="/static/CACHE/js/output.06a98ccfd380.js"></script>'
         self.assertEqual(out, render(template, self.context))
 
+    def test_js_module_and_importmap_tag(self):
+        template = """{% load compress %}{% compress js %}
+        <script type="importmap">
+        {
+            "imports": {
+                "example": "./module.js"
+            }
+        }
+        </script>
+        <script type="module">
+            import { example } from './module.js';
+            console.log(example);
+        </script>
+        <script type="text/javascript">
+            // Regular JavaScript
+            function regularFunction() {
+                return "Hello from regular JS";
+            }
+        </script>
+        <script type="module" src="{{ STATIC_URL }}js/one.js"></script>
+        {% endcompress %}
+        """
+        # With our implementation, we expect:
+        # 1. Import map and module scripts to be kept as-is without compression
+        # 2. Regular scripts to be compressed
+        rendered = render(template, self.context)
+
+        # Verify import map is preserved exactly as-is
+        self.assertTrue('<script type="importmap">' in rendered)
+        self.assertTrue('"imports"' in rendered)
+        self.assertTrue('"example": "./module.js"' in rendered)
+
+        # Verify module scripts are preserved exactly as-is
+        self.assertTrue('<script type="module">' in rendered)
+        self.assertTrue('import { example } from \'./module.js\';' in rendered)
+        self.assertTrue('console.log(example);' in rendered)
+        self.assertTrue('<script type="module" src="/static/js/one.js">' in rendered)
+
+        # Verify regular scripts are compressed
+        self.assertTrue('<script src="/static/CACHE/js/' in rendered)
+
+        # Verify we have exactly 4 script tags:
+        # - 1 importmap script
+        # - 2 uncompressed module scripts
+        # - 1 compressed regular script
+        self.assertEqual(rendered.count('</script>'), 4)
+
+        # Verify correct order (first importmap, then inline module, then src module, then compressed regular)
+        script_positions = [
+            rendered.find('<script type="importmap">'),
+            rendered.find('<script type="module">'),
+            rendered.find('<script type="module" src='),
+            rendered.find('<script src="/static/CACHE/js/')
+        ]
+        self.assertTrue(all(pos >= 0 for pos in script_positions), "All scripts should be present")
+        self.assertEqual(sorted(script_positions), script_positions, "Scripts should be in the correct order")
+
     def test_compress_tag_with_illegal_arguments(self):
         template = """{% load compress %}{% compress pony %}
         <script type="pony/application">unicorn</script>

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -6,6 +6,8 @@ UNRELEASED
 
 - Drop support for EOL Python 3.8.
 - Officially support Django 5.2
+- Added support for ES modules and importmaps by passing them through
+  unmodified.
 
 v4.5.1 (2024-07-22)
 -------------------


### PR DESCRIPTION
Heads up: I used AI for this change but I have proofread and edited it. I haven't tested the change in a real-world project because I haven't been using django-compressor for years. My hope is that this change will help people use more modern JS when they need or want it. 

I think this may be a partial solution to the problem alluded to here:
https://406.ch/writing/django-javascript-modules-and-importmaps/#using-django-compressor-or-similar-packages

When using something like `{% compress js %}{{ form.media.js }}{% endcompress %}` you have no control over the types of assets in there; I am not really happy with the denylist-based approach of passing through known types though. I think it would be better to use an allowlist for the compressor and only compress known types. As I mentioned above I probably wouldn't want to do this work because I have been a happy user of frontend bundlers for years.