### PR TITLE
Disable bs4's multi valued attributes

### DIFF
--- a/compressor/parser/beautifulsoup.py
+++ b/compressor/parser/beautifulsoup.py
@@ -12,7 +12,7 @@ class BeautifulSoupParser(ParserBase):
 
             # Disable multi_valued_attributes
             # http://www.crummy.com/software/BeautifulSoup/bs4/doc/#multi-valued-attributes
-            self.soup = BeautifulSoup(self.content, "html.parser", multi_valued_attributes={})
+            self.soup = BeautifulSoup(self.content, "html.parser", multi_valued_attributes=None)
         except ImportError as err:
             raise ImproperlyConfigured("Error while importing BeautifulSoup: %s" % err)
 

--- a/compressor/parser/beautifulsoup.py
+++ b/compressor/parser/beautifulsoup.py
@@ -10,7 +10,9 @@ class BeautifulSoupParser(ParserBase):
         try:
             from bs4 import BeautifulSoup
 
-            self.soup = BeautifulSoup(self.content, "html.parser")
+            # Disable multi_valued_attributes
+            # http://www.crummy.com/software/BeautifulSoup/bs4/doc/#multi-valued-attributes
+            self.soup = BeautifulSoup(self.content, "html.parser", multi_valued_attributes={})
         except ImportError as err:
             raise ImproperlyConfigured("Error while importing BeautifulSoup: %s" % err)
 
@@ -21,13 +23,7 @@ class BeautifulSoupParser(ParserBase):
         return self.soup.find_all("script")
 
     def elem_attribs(self, elem):
-        attrs = dict(elem.attrs)
-        # hack around changed behaviour in bs4, it returns lists now instead of one string, see
-        # http://www.crummy.com/software/BeautifulSoup/bs4/doc/#multi-valued-attributes
-        for key, value in attrs.items():
-            if type(value) is list:
-                attrs[key] = " ".join(value)
-        return attrs
+        return elem.attrs
 
     def elem_content(self, elem):
         return elem.string

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,5 +1,5 @@
 Jinja2==3.1.6
-beautifulsoup4==4.12.3
+beautifulsoup4>=4.13
 brotli==1.1.0
 calmjs==3.4.4
 coverage==7.7.0


### PR DESCRIPTION
I don't know why `rel` would have a list type instead of a string when `elem_attrib` does the transformation. This change seems to work locally and fixes some Python 3.13 issues, so let's run it through the full CI.