### PR TITLE
Update dependencies for rcssmin and rjsmin for python 3.13 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -165,7 +165,7 @@ setup(
     install_requires=[
         "Django >= 4.2",
         "django-appconf >= 1.0.3",
-        "rcssmin == 1.1.3",
-        "rjsmin == 1.2.3",
+        "rcssmin == 1.2.1",
+        "rjsmin == 1.2.4",
     ],
 )


### PR DESCRIPTION
tests seemed to be running ok
OK (skipped=36)

I had to skip the installation for slimit==0.8.1
since that package has a dependency on the old 2to3 tool
