### PR TITLE
Add Python 3.13 to CI and declare support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
             toxenv: py311-5.1.X
           - python: "3.12"
             toxenv: py312-5.1.X
+          - python: "3.13"
+            toxenv: py313-5.1.X
 
           - python: "3.10"
             toxenv: py310-5.2.X
@@ -40,6 +42,8 @@ jobs:
             toxenv: py311-5.2.X
           - python: "3.12"
             toxenv: py312-5.2.X
+          - python: "3.13"
+            toxenv: py313-5.2.X
 
     runs-on: ubuntu-latest
     steps:

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -10,4 +10,3 @@ html5lib==1.1
 lxml==5.4.0
 rcssmin==1.1.3
 rjsmin==1.2.4
-slimit==0.8.1

--- a/setup.py
+++ b/setup.py
@@ -158,6 +158,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Internet :: WWW/HTTP",
     ],
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -2,14 +2,15 @@
 envlist =
     {py39,py310,py311}-4.2.X
     {py310,py311,py312}-5.0.X
-    {py310,py311,py312}-5.1.X
-    {py310,py311,py312}-5.2.X
+    {py310,py311,py312,py313}-5.1.X
+    {py310,py311,py312,py313}-5.2.X
 [testenv]
 basepython =
     py39: python3.9
     py310: python3.10
     py311: python3.11
     py312: python3.12
+    py313: python3.13
 usedevelop = true
 setenv =
     CPPFLAGS=-O0


### PR DESCRIPTION
- Add tox targets and CI jobs following https://docs.djangoproject.com/en/5.2/faq/install/#what-python-version-can-i-use-with-django
- Add trove classifiers