### PR TITLE
Correct test requirement onto calmjs.parse

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,7 +1,7 @@
 Jinja2==3.1.6
 beautifulsoup4>=4.13
 brotli==1.2.0
-calmjs==3.4.4
+calmjs.parse==1.3.4
 coverage==7.11.1
 csscompressor==0.9.5
 django-sekizai==4.1.0


### PR DESCRIPTION
To help reduce unnecessary effort by OS distribution maintainers, please use the actual dependency required by the feature introduced via #957 into the correct package which is `calmjs.parse` and not `calmjs`. This way they don't have to put in the effort to package (and install) a development tool for the integration of npm and PyPI that won't see usage when all users may want is a JavaScript parser/minifier.  This way maybe the maintainers can just package `calmjs.parse` and leave the rest alone as future releases of `setuptools` may render `calmjs` unusable. Just to be clear `calmjs.parse` shouldn't be affected.