### PR TITLE
Add Subresource Integrity (SRI) support for compressed assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ docs/_build/
 .coverage
 .tox
 .eggs
+.idea

--- a/compressor/base.py
+++ b/compressor/base.py
@@ -1,5 +1,7 @@
 import os
 import codecs
+import base64
+import hashlib
 from importlib import import_module
 from urllib.request import url2pathname
 
@@ -392,7 +394,14 @@ class Compressor:
         if not self.storage.exists(new_filepath) or forced:
             self.storage.save(new_filepath, ContentFile(content.encode(self.charset)))
         url = mark_safe(self.storage.url(new_filepath))
-        return self.render_output(mode, {"url": url})
+        context = {"url": url}
+        integrity = self.get_integrity(content)
+        if integrity:
+            context["integrity"] = integrity
+            crossorigin = settings.COMPRESS_SRI_CROSSORIGIN
+            if crossorigin:
+                context["crossorigin"] = crossorigin
+        return self.render_output(mode, context)
 
     def output_inline(self, mode, content, forced=False, basename=None):
         """
@@ -435,3 +444,18 @@ class Compressor:
         )
         template_name = self.get_template_name(mode)
         return render_to_string(template_name, context=final_context)
+
+    def get_integrity(self, content):
+        """
+        Returns the Subresource Integrity (SRI) string for the given content.
+        """
+        hashes = settings.COMPRESS_SRI_HASHES
+        if not hashes:
+            return ""
+        content_bytes = content.encode(self.charset)
+        integrity_parts = []
+        for algo in hashes:
+            digest = hashlib.new(algo, content_bytes).digest()
+            encoded = base64.b64encode(digest).decode("ascii")
+            integrity_parts.append("%s-%s" % (algo, encoded))
+        return " ".join(integrity_parts)

--- a/compressor/base.py
+++ b/compressor/base.py
@@ -239,7 +239,13 @@ class Compressor:
     @cached_property
     def cachekey(self):
         return get_hexdigest(
-            "".join([self.content] + self.mtimes).encode(self.charset), 12
+            "".join(
+                [self.content]
+                + self.mtimes
+                + list(settings.COMPRESS_SRI_HASHES)
+                + [settings.COMPRESS_SRI_CROSSORIGIN or ""]
+            ).encode(self.charset),
+            12,
         )
 
     def hunks(self, forced=False):

--- a/compressor/cache.py
+++ b/compressor/cache.py
@@ -97,7 +97,12 @@ def write_offline_manifest(manifest):
 
 
 def get_templatetag_cachekey(compressor, mode, kind):
-    return get_cachekey("templatetag.%s.%s.%s" % (compressor.cachekey, mode, kind))
+    sri_hashes = ",".join(settings.COMPRESS_SRI_HASHES or ())
+    crossorigin = settings.COMPRESS_SRI_CROSSORIGIN or ""
+    return get_cachekey(
+        "templatetag.%s.%s.%s.%s.%s"
+        % (compressor.cachekey, mode, kind, sri_hashes, crossorigin)
+    )
 
 
 def get_mtime(filename):

--- a/compressor/cache.py
+++ b/compressor/cache.py
@@ -97,12 +97,7 @@ def write_offline_manifest(manifest):
 
 
 def get_templatetag_cachekey(compressor, mode, kind):
-    sri_hashes = ",".join(settings.COMPRESS_SRI_HASHES or ())
-    crossorigin = settings.COMPRESS_SRI_CROSSORIGIN or ""
-    return get_cachekey(
-        "templatetag.%s.%s.%s.%s.%s"
-        % (compressor.cachekey, mode, kind, sri_hashes, crossorigin)
-    )
+    return get_cachekey("templatetag.%s.%s.%s" % (compressor.cachekey, mode, kind))
 
 
 def get_mtime(filename):

--- a/compressor/conf.py
+++ b/compressor/conf.py
@@ -57,6 +57,12 @@ class CompressorConf(AppConf):
     CLEAN_CSS_ARGUMENTS = ""
     DATA_URI_MAX_SIZE = 1024
 
+    # Subresource Integrity (SRI) settings for compiled assets.
+    # Example: COMPRESS_SRI_HASHES = ("sha256", "sha384")
+    SRI_HASHES = ()
+    # Example: COMPRESS_SRI_CROSSORIGIN = "anonymous"
+    SRI_CROSSORIGIN = None
+
     # the cache backend to use
     CACHE_BACKEND = None
     # the dotted path to the function that creates the cache key
@@ -147,3 +153,29 @@ class CompressorConf(AppConf):
                 "missing commas."
             )
         return value
+
+    def configure_sri_hashes(self, value):
+        if not value:
+            return ()
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, (list, tuple)):
+            raise ImproperlyConfigured(
+                "The COMPRESS_SRI_HASHES setting must be a list, tuple, or string."
+            )
+        allowed = {"sha256", "sha384", "sha512"}
+        normalized = []
+        for algo in value:
+            algo = str(algo).lower()
+            if algo not in allowed:
+                raise ImproperlyConfigured(
+                    "The COMPRESS_SRI_HASHES setting only supports %s."
+                    % ", ".join(sorted(allowed))
+                )
+            normalized.append(algo)
+        return tuple(normalized)
+
+    def configure_sri_crossorigin(self, value):
+        if value in (None, ""):
+            return None
+        return str(value)

--- a/compressor/templates/compressor/css_file.html
+++ b/compressor/templates/compressor/css_file.html
@@ -1,1 +1,1 @@
-<link rel="stylesheet" href="{{ compressed.url }}" type="text/css"{% if compressed.media %} media="{{ compressed.media }}"{% endif %}>
+<link rel="stylesheet" href="{{ compressed.url }}" type="text/css"{% if compressed.media %} media="{{ compressed.media }}"{% endif %}{% if compressed.integrity %} integrity="{{ compressed.integrity }}"{% endif %}{% if compressed.crossorigin %} crossorigin="{{ compressed.crossorigin }}"{% endif %}>

--- a/compressor/templates/compressor/css_preload.html
+++ b/compressor/templates/compressor/css_preload.html
@@ -1,1 +1,1 @@
-<link rel="preload" href="{{ compressed.url }}" as="style" />
+<link rel="preload" href="{{ compressed.url }}" as="style"{% if compressed.integrity %} integrity="{{ compressed.integrity }}"{% endif %}{% if compressed.crossorigin %} crossorigin="{{ compressed.crossorigin }}"{% endif %} />

--- a/compressor/templates/compressor/js_file.html
+++ b/compressor/templates/compressor/js_file.html
@@ -1,1 +1,1 @@
-<script src="{{ compressed.url }}"{{ compressed.extra }}></script>
+<script src="{{ compressed.url }}"{% if compressed.integrity %} integrity="{{ compressed.integrity }}"{% endif %}{% if compressed.crossorigin %} crossorigin="{{ compressed.crossorigin }}"{% endif %}{{ compressed.extra }}></script>

--- a/compressor/templates/compressor/js_preload.html
+++ b/compressor/templates/compressor/js_preload.html
@@ -1,1 +1,1 @@
-<link rel="preload" href="{{ compressed.url }}" as="script" />
+<link rel="preload" href="{{ compressed.url }}" as="script"{% if compressed.integrity %} integrity="{{ compressed.integrity }}"{% endif %}{% if compressed.crossorigin %} crossorigin="{{ compressed.crossorigin }}"{% endif %} />

--- a/compressor/tests/test_base.py
+++ b/compressor/tests/test_base.py
@@ -1,3 +1,5 @@
+import base64
+import hashlib
 import os
 import re
 import sys
@@ -222,6 +224,18 @@ class CompressorTestCase(SimpleTestCase):
         out = "body { background:#990; }\np { border:5px solid green;}\nbody { color:#fff; }"
         hunks = "\n".join([h for h in self.css_node.hunks()])
         self.assertEqual(out, hunks)
+
+    @override_settings(COMPRESS_SRI_HASHES=("sha256", "sha384"))
+    def test_integrity_hashes(self):
+        content = "body{color:#fff}"
+        expected_sha256 = base64.b64encode(
+            hashlib.sha256(content.encode("utf-8")).digest()
+        ).decode("ascii")
+        expected_sha384 = base64.b64encode(
+            hashlib.sha384(content.encode("utf-8")).digest()
+        ).decode("ascii")
+        expected = "sha256-%s sha384-%s" % (expected_sha256, expected_sha384)
+        self.assertEqual(expected, self.css_node.get_integrity(content))
 
     def test_css_output_with_bom_input(self):
         out = "body { background:#990; }\n.compress-test {color: red;}"

--- a/compressor/tests/test_conf.py
+++ b/compressor/tests/test_conf.py
@@ -32,3 +32,29 @@ class ConfTestCase(SimpleTestCase):
         conf = create_conf()
         self.assertEqual(conf.FILTERS["css"], ["ham"])
         self.assertEqual(conf.FILTERS["js"], ["spam"])
+
+    def test_sri_hashes_defaults(self):
+        conf = create_conf()
+        self.assertEqual(conf.SRI_HASHES, ())
+
+    @override_settings(COMPRESS_SRI_HASHES=("sha256", "SHA384"))
+    def test_sri_hashes_normalized(self):
+        conf = create_conf()
+        self.assertEqual(conf.SRI_HASHES, ("sha256", "sha384"))
+
+    @override_settings(COMPRESS_SRI_HASHES="sha512")
+    def test_sri_hashes_string(self):
+        conf = create_conf()
+        self.assertEqual(conf.SRI_HASHES, ("sha512",))
+
+    @override_settings(COMPRESS_SRI_HASHES=("md5",))
+    def test_sri_hashes_invalid(self):
+        with self.assertRaisesMessage(
+            Exception, "COMPRESS_SRI_HASHES setting only supports"
+        ):
+            create_conf()
+
+    @override_settings(COMPRESS_SRI_CROSSORIGIN="anonymous")
+    def test_sri_crossorigin(self):
+        conf = create_conf()
+        self.assertEqual(conf.SRI_CROSSORIGIN, "anonymous")

--- a/compressor/tests/test_templatetags.py
+++ b/compressor/tests/test_templatetags.py
@@ -7,8 +7,6 @@ from django.template import Context, Template, TemplateSyntaxError
 from django.test import override_settings, TestCase
 from sekizai.context import SekizaiContext
 
-from compressor.css import CssCompressor
-from compressor.js import JsCompressor
 from compressor.signals import post_compress
 from compressor.tests.test_base import css_tag, test_dir
 
@@ -24,12 +22,6 @@ def render(template_string, context_dict=None, context=None):
     c = context(context_dict)
     t = Template(template_string)
     return t.render(c).strip()
-
-
-def build_integrity(compressor):
-    output = "\n".join(compressor.filter_input())
-    output = compressor.filter_output(output)
-    return compressor.get_integrity(output)
 
 
 @override_settings(COMPRESS_ENABLED=True)
@@ -58,13 +50,7 @@ class TemplatetagTestCase(TestCase):
 <style type="text/css">p { border:5px solid green;}</style>
 <link rel="stylesheet" href="{{ STATIC_URL }}css/two.css" type="text/css">
 {% endcompress %}"""
-        content = """
-<link rel="stylesheet" href="/static/css/one.css" type="text/css">
-<style type="text/css">p { border:5px solid green;}</style>
-<link rel="stylesheet" href="/static/css/two.css" type="text/css">
-"""
-        compressor = CssCompressor("css", content)
-        integrity = build_integrity(compressor)
+        integrity = "sha256-YAZ06h09pqD2ViCVxfABwuZI/Vk0RUtxIpsMaCMa02o="
         out = css_tag(
             "/static/CACHE/css/output.600674ea1d3d.css", integrity=integrity
         )
@@ -130,12 +116,7 @@ class TemplatetagTestCase(TestCase):
         <script type="text/javascript">obj.value = "value";</script>
         {% endcompress %}
         """
-        content = """
-        <script src="/static/js/one.js" type="text/javascript"></script>
-        <script type="text/javascript">obj.value = "value";</script>
-        """
-        compressor = JsCompressor("js", content)
-        integrity = build_integrity(compressor)
+        integrity = "sha256-ig/tNsMXlrFDkIJOINzQEKGmLfIi/ZTnHDsAefw97Go="
         out = (
             '<script src="/static/CACHE/js/output.8a0fed36c317.js"'
             ' integrity="%s"></script>' % integrity

--- a/compressor/tests/test_templatetags.py
+++ b/compressor/tests/test_templatetags.py
@@ -7,6 +7,8 @@ from django.template import Context, Template, TemplateSyntaxError
 from django.test import override_settings, TestCase
 from sekizai.context import SekizaiContext
 
+from compressor.css import CssCompressor
+from compressor.js import JsCompressor
 from compressor.signals import post_compress
 from compressor.tests.test_base import css_tag, test_dir
 
@@ -22,6 +24,12 @@ def render(template_string, context_dict=None, context=None):
     c = context(context_dict)
     t = Template(template_string)
     return t.render(c).strip()
+
+
+def build_integrity(compressor):
+    output = "\n".join(compressor.filter_input())
+    output = compressor.filter_output(output)
+    return compressor.get_integrity(output)
 
 
 @override_settings(COMPRESS_ENABLED=True)
@@ -41,6 +49,25 @@ class TemplatetagTestCase(TestCase):
 <link rel="stylesheet" href="{{ STATIC_URL }}css/two.css" type="text/css">
 {% endcompress %}"""
         out = css_tag("/static/CACHE/css/output.600674ea1d3d.css")
+        self.assertEqual(out, render(template, self.context))
+
+    @override_settings(COMPRESS_SRI_HASHES=("sha256",))
+    def test_css_tag_with_integrity(self):
+        template = """{% load compress %}{% compress css %}
+<link rel="stylesheet" href="{{ STATIC_URL }}css/one.css" type="text/css">
+<style type="text/css">p { border:5px solid green;}</style>
+<link rel="stylesheet" href="{{ STATIC_URL }}css/two.css" type="text/css">
+{% endcompress %}"""
+        content = """
+<link rel="stylesheet" href="/static/css/one.css" type="text/css">
+<style type="text/css">p { border:5px solid green;}</style>
+<link rel="stylesheet" href="/static/css/two.css" type="text/css">
+"""
+        compressor = CssCompressor("css", content)
+        integrity = build_integrity(compressor)
+        out = css_tag(
+            "/static/CACHE/css/output.600674ea1d3d.css", integrity=integrity
+        )
         self.assertEqual(out, render(template, self.context))
 
     def test_css_tag_with_block(self):
@@ -94,6 +121,25 @@ class TemplatetagTestCase(TestCase):
         {% endcompress %}
         """
         out = '<script src="/static/CACHE/js/output.8a0fed36c317.js"></script>'
+        self.assertEqual(out, render(template, self.context))
+
+    @override_settings(COMPRESS_SRI_HASHES=("sha256",))
+    def test_js_tag_with_integrity(self):
+        template = """{% load compress %}{% compress js %}
+        <script src="{{ STATIC_URL }}js/one.js" type="text/javascript"></script>
+        <script type="text/javascript">obj.value = "value";</script>
+        {% endcompress %}
+        """
+        content = """
+        <script src="/static/js/one.js" type="text/javascript"></script>
+        <script type="text/javascript">obj.value = "value";</script>
+        """
+        compressor = JsCompressor("js", content)
+        integrity = build_integrity(compressor)
+        out = (
+            '<script src="/static/CACHE/js/output.8a0fed36c317.js"'
+            ' integrity="%s"></script>' % integrity
+        )
         self.assertEqual(out, render(template, self.context))
 
     def test_nonascii_js_tag(self):

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -64,6 +64,31 @@ Base settings
     Controls the directory inside :attr:`~django.conf.settings.COMPRESS_ROOT`
     that compressed files will be written to.
 
+.. attribute:: COMPRESS_SRI_HASHES
+
+    :Default: ``()``
+
+    An iterable of hash algorithm names to include as Subresource Integrity (SRI)
+    values on compiled ``<script>`` and ``<link rel="stylesheet">`` tags.
+    Supported values are ``"sha256"``, ``"sha384"``, and ``"sha512"``. When empty,
+    SRI attributes are not added.
+
+    Example::
+
+        COMPRESS_SRI_HASHES = ("sha384",)
+
+    Example with multiple hashes::
+
+        COMPRESS_SRI_HASHES = ("sha256", "sha384", "sha512")
+
+.. attribute:: COMPRESS_SRI_CROSSORIGIN
+
+    :Default: ``None``
+
+    Optional ``crossorigin`` attribute value to include alongside SRI hashes.
+    Common values are ``"anonymous"`` or ``"use-credentials"``. When unset, the
+    attribute is omitted.
+
 Backend settings
 ----------------
 

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -62,6 +62,26 @@ Result:
 
         <link rel="preload" href="/static/CACHE/js/d01466eb4fc6.js" as="script" />
 
+Subresource Integrity (SRI) can be enabled for compiled file outputs:
+
+    .. code-block:: django
+
+        # settings.py
+        COMPRESS_SRI_HASHES = ("sha384",)
+        COMPRESS_SRI_CROSSORIGIN = "anonymous"
+
+    .. code-block:: django
+
+        {% compress js %}
+        <script src="/static/js/one.js" type="text/javascript" charset="utf-8"></script>
+        {% endcompress %}
+
+Result:
+
+    .. code-block:: django
+
+        <script src="/static/CACHE/js/output.f7c661b7a124.js" integrity="sha384-..." crossorigin="anonymous"></script>
+
 
 Specifying a ``block_name`` will change the output filename. It can also be
 accessed in the :ref:`post_compress signal <signals>` in the ``context`` parameter.


### PR DESCRIPTION
- Introduced COMPRESS_SRI_HASHES and COMPRESS_SRI_CROSSORIGIN settings for configuring SRI.
- Updated Compressor class to generate integrity attributes for <script> and <link> tags.
- Modified templates to include integrity and crossorigin attributes when applicable.
- Added tests for SRI functionality in CSS and JS tags.
- Updated documentation to reflect new SRI settings and usage examples.