### PR TITLE
Fix typo in OFFLINE_MANIFEST_STORAGE_ALIAS documentation and code

### DIFF
--- a/compressor/conf.py
+++ b/compressor/conf.py
@@ -82,7 +82,7 @@ class CompressorConf(AppConf):
     OFFLINE_CONTEXT = {}
     # The name of the manifest file (e.g. filename.ext)
     OFFLINE_MANIFEST = "manifest.json"
-    OFFLINE_MANIFEST_STORAGE_ALIAS = "compressor-offine"
+    OFFLINE_MANIFEST_STORAGE_ALIAS = "compressor-offline"
     OFFLINE_MANIFEST_STORAGE = "compressor.storage.OfflineManifestFileStorage"
     # The Context to be used when TemplateFilter is used
     TEMPLATE_FILTER_CONTEXT = {}

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -608,7 +608,7 @@ Offline settings
 
 .. attribute:: COMPRESS_OFFLINE_MANIFEST_STORAGE_ALIAS
 
-    :Default: ``'compressor-offine'``
+    :Default: ``'compressor-offline'``
 
     The alias into Django's ``STORAGES`` setting that will be used to save
     compressed files.


### PR DESCRIPTION
Correct a typo in `OFFLINE_MANIFEST_STORAGE_ALIAS` within both the documentation and the code.

This typo was causing some projects to not copy the manifest to the correct storage.