### PR TITLE
Update test matrix for Django 6.1.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,20 +14,6 @@ jobs:
       matrix:
         versions:
           - python: "3.10"
-            toxenv: py310-4.2.X
-          - python: "3.11"
-            toxenv: py311-4.2.X
-
-          - python: "3.10"
-            toxenv: py310-5.1.X
-          - python: "3.11"
-            toxenv: py311-5.1.X
-          - python: "3.12"
-            toxenv: py312-5.1.X
-          - python: "3.13"
-            toxenv: py313-5.1.X
-
-          - python: "3.10"
             toxenv: py310-5.2.X
           - python: "3.11"
             toxenv: py311-5.2.X

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,13 @@ jobs:
           - python: "3.14"
             toxenv: py314-6.0.X
 
+          - python: "3.12"
+            toxenv: py312-6.1.X
+          - python: "3.13"
+            toxenv: py313-6.1.X
+          - python: "3.14"
+            toxenv: py314-6.1.X
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- Drop support for Django versions before 5.2.
+
 v4.6 (2025-11-10)
 -----------------
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -4,6 +4,7 @@ Changelog
 Unreleased
 ----------
 
+- Add support for Django 6.1.
 - Drop support for Django versions before 5.2.
 
 v4.6 (2025-11-10)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
   "Framework :: Django",
   "Framework :: Django :: 5.2",
   "Framework :: Django :: 6.0",
+  "Framework :: Django :: 6.1",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
   "Programming Language :: Python",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,6 @@ requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Framework :: Django",
-  "Framework :: Django :: 4.2",
-  "Framework :: Django :: 5.1",
   "Framework :: Django :: 5.2",
   "Framework :: Django :: 6.0",
   "Intended Audience :: Developers",
@@ -31,7 +29,7 @@ classifiers = [
 ]
 dynamic = [ "version" ]
 dependencies = [
-  "django>=4.2",
+  "django>=5.2",
   "django-appconf>=1.0.3",
   "rcssmin>=1.2.1",
   "rjsmin>=1.2.4",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,5 @@
 [tox]
 envlist =
-    {py310,py311}-4.2.X
-    {py310,py311,py312,py313}-5.1.X
     {py310,py311,py312,py313,py314}-5.2.X
     {py312,py313,py314}-6.0.X
 [testenv]
@@ -19,9 +17,6 @@ commands =
     django-admin --version
     make test
 deps =
-    4.2.X: Django>=4.2,<5.0
-    5.0.X: Django>=5.0,<5.1
-    5.1.X: Django>=5.1,<5.2
     5.2.X: Django>=5.2,<6.0
     6.0.X: Django>=6.0b1,<6.1
     -r{toxinidir}/requirements/tests.txt

--- a/tox.ini
+++ b/tox.ini
@@ -18,5 +18,5 @@ commands =
     make test
 deps =
     5.2.X: Django>=5.2,<6.0
-    6.0.X: Django>=6.0b1,<6.1
+    6.0.X: Django>=6.0,<6.1
     -r{toxinidir}/requirements/tests.txt

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     {py310,py311,py312,py313,py314}-5.2.X
     {py312,py313,py314}-6.0.X
+    {py312,py313,py314}-6.1.X
 [testenv]
 basepython =
     py310: python3.10
@@ -19,4 +20,5 @@ commands =
 deps =
     5.2.X: Django>=5.2,<6.0
     6.0.X: Django>=6.0,<6.1
+    6.1.X: Django>=6.1b1,<6.2
     -r{toxinidir}/requirements/tests.txt


### PR DESCRIPTION
Adds support for Django 6.1 and drop Django's prior to 5.2 (as [recommended](https://docs.djangoproject.com/en/6.0/releases/6.0/#third-party-library-support-for-older-versions-of-django) on release of 6.0 final).